### PR TITLE
[CodeGen] fix code gen logic for all unit tests in lms_clean

### DIFF
--- a/src/main/scala/lms/core/backend.scala
+++ b/src/main/scala/lms/core/backend.scala
@@ -78,7 +78,7 @@ object Backend {
   // arguments, as well as an effect summary.
 
   case class Node(n: Sym, op: String, rhs: List[Def], eff: EffectSummary) {
-    override def toString = s"$n = ($op ${rhs.mkString(" ")}) $eff"
+    override def toString = s"$n = ($op ${rhs.mkString(" ")})  $eff"
   }
 
   /* YYY TODO

--- a/src/main/scala/lms/core/codegen/C_codegen.scala
+++ b/src/main/scala/lms/core/codegen/C_codegen.scala
@@ -131,7 +131,7 @@ class ExtendedCCodeGen extends CompactScalaCodeGen with ExtendedCodeGen {
     val res = body.res
     val args = body.in
     val ret = s"${remap(typeBlockRes(res))} "
-    val params = "(" + args.map(s => s"${remap(typeMap.getOrElse(s, manifest[Unknown]))} ${quote(s)}").mkString(", ") + ")"
+    val params = "(" + args.map(s => s"${remap(typeMap.getOrElse(s, manifest[Unknown]))} ${quote(s)}").mkString(", ") + ") "
     val sig = ret + name + params
     emit(sig)
     quoteBlockPReturn(traverse(body))
@@ -233,7 +233,7 @@ class ExtendedCCodeGen extends CompactScalaCodeGen with ExtendedCodeGen {
     quoteBlockPReturn(traverse(b))
   }
 
-  override def quoteBlock(b: Block): Unit = quoteTypedBlock(b, true, false)
+  def quoteBlock(b: Block): Unit = quoteTypedBlock(b, true, false)
 
   override def shallow(n: Def): Unit = n match {
     case InlineSym(t: Node) => shallow(t)


### PR DESCRIPTION
The unit tests were broken for a while because our test use strict string comparison, which is sometimes overly strong. However, it might be good to keep the string output (codegen) as is.

This PR `reverts` some of the earlier changes in the code base so that all tests pass now. I am sure about some of them (which are just one more or one less space) but not sure about others. Please review to see if your intended features are unfortunately reverted. 