### PR TITLE
Add support for List/Map/Set/Tuple

### DIFF
--- a/src/main/scala/lms/collection/ListOps.scala
+++ b/src/main/scala/lms/collection/ListOps.scala
@@ -1,0 +1,186 @@
+package lms.collection.immutable
+
+import lms.core._
+import lms.util._
+import lms.core.stub._
+import lms.core.Backend._
+import lms.core.virtualize
+import lms.core.utils.time
+import lms.macros.SourceContext
+
+trait ListOps { b: Base =>
+  object List {
+    def apply[A: Manifest](xs: Rep[A]*)(implicit pos: SourceContext) = {
+      val mA = Backend.Const(manifest[A])
+      val unwrapped_xs = Seq(mA) ++ xs.map(Unwrap)
+      Wrap[List[A]](Adapter.g.reflect("list-new", unwrapped_xs:_*))
+    }
+  }
+
+  implicit def __liftConstList[A: Manifest](xs: List[A]): ListOps[A] = new ListOps(unit(xs))
+  implicit def __liftVarList[A: Manifest](xs: Var[List[A]]): ListOps[A] = new ListOps(readVar(xs))
+
+  implicit class ListOps[A: Manifest](xs: Rep[List[A]]) {
+    def apply(i: Rep[Int]): Rep[A] = Wrap[A](Adapter.g.reflect("list-apply", Unwrap(xs), Unwrap(i)))
+    def head: Rep[A] = Wrap[A](Adapter.g.reflect("list-head", Unwrap(xs)))
+    def tail: Rep[List[A]] = Wrap[List[A]](Adapter.g.reflect("list-tail", Unwrap(xs)))
+    def size: Rep[Int] = Wrap[Int](Adapter.g.reflect("list-size", Unwrap(xs)))
+    def isEmpty: Rep[Boolean] = Wrap[Boolean](Adapter.g.reflect("list-isEmpty", Unwrap(xs)))
+    def take(i: Rep[Int]) = Wrap[List[A]](Adapter.g.reflect("list-take", Unwrap(xs), Unwrap(i)))
+    def ::(x: Rep[A]): Rep[List[A]] =
+      Wrap[List[A]](Adapter.g.reflect("list-prepend", Unwrap(xs), Unwrap(x)))
+    def ++(ys: Rep[List[A]]): Rep[List[A]] =
+      Wrap[List[A]](Adapter.g.reflect("list-concat", Unwrap(xs), Unwrap(ys)))
+    def mkString: Rep[String] = mkString(unit(""))
+    def mkString(sep: Rep[String]): Rep[String] =
+      Wrap[String](Adapter.g.reflect("list-mkString", Unwrap(xs), Unwrap(sep)))
+    def toArray: Rep[Array[A]] = Wrap[Array[A]](Adapter.g.reflect("list-toArray", Unwrap(xs)))
+    def toSeq: Rep[Seq[A]] = Wrap[Seq[A]](Adapter.g.reflect("list-toSeq", Unwrap(xs)))
+    def map[B: Manifest](f: Rep[A] => Rep[B]): Rep[List[B]] = {
+      val block = Adapter.g.reify(x => Unwrap(f(Wrap[A](x))))
+      Wrap[List[B]](Adapter.g.reflect("list-map", Unwrap(xs), block))
+    }
+    def flatMap[B: Manifest](f: Rep[A] => Rep[List[B]]): Rep[List[B]] = {
+      val block = Adapter.g.reify(x => Unwrap(f(Wrap[A](x))))
+      val mA = Backend.Const(manifest[A])
+      Wrap[List[B]](Adapter.g.reflect("list-flatMap", Unwrap(xs), block, mA))
+    }
+    def foldLeft[B: Manifest](z: Rep[B])(f: (Rep[B], Rep[A]) => Rep[B]): Rep[B] = {
+      val block = Adapter.g.reify((x, y) => Unwrap(f(Wrap[B](x), Wrap[A](y))))
+      Wrap[B](Adapter.g.reflect("list-foldLeft", Unwrap(xs), Unwrap(z), block))
+    }
+    def zip[B: Manifest](ys: Rep[List[B]]): Rep[List[(A, B)]] =
+      Wrap[List[(A, B)]](Adapter.g.reflect("list-zip", Unwrap(xs), Unwrap(ys)))
+    def filter(f: Rep[A] => Rep[Boolean]): Rep[List[A]] = {
+      val block = Adapter.g.reify(x => Unwrap(f(Wrap[A](x))))
+      Wrap[List[A]](Adapter.g.reflect("list-filter", Unwrap(xs), block))
+    }
+    def withFilter(f: Rep[A] => Rep[Boolean]): Rep[List[A]] = filter(f)
+    def sortBy[B: Manifest : Ordering](f: Rep[A] => Rep[B]): Rep[List[A]] = {
+      val block = Adapter.g.reify(x => Unwrap(f(Wrap[A](x))))
+      Wrap[List[A]](Adapter.g.reflect("list-sortBy", Unwrap(xs), block))
+    }
+    def containsSlice[B <: A : Manifest](ys: Rep[List[B]]): Rep[Boolean] =
+      Wrap[Boolean](Adapter.g.reflect("list-containsSlice", Unwrap(xs), Unwrap(ys)))
+    def intersect[B >: A : Manifest](ys: Rep[List[B]]): Rep[List[A]] =
+      Wrap[List[A]](Adapter.g.reflect("list-intersect", Unwrap(xs), Unwrap(ys)))
+  }
+}
+
+trait ListOpsOpt extends ListOps { b: Base =>
+  implicit override def __liftConstList[A: Manifest](xs: List[A]): ListOps[A] = new ListOpsOpt(unit(xs))
+  implicit override def __liftVarList[A: Manifest](xs: Var[List[A]]): ListOps[A] = new ListOpsOpt(readVar(xs))
+
+  implicit class ListOpsOpt[A: Manifest](xs: Rep[List[A]]) extends ListOps[A](xs) {
+    override def ++(ys: Rep[List[A]]): Rep[List[A]] = (Unwrap(xs), Unwrap(ys)) match {
+      case (Adapter.g.Def("list-new", mA::(xs: List[Backend.Exp])),
+            Adapter.g.Def("list-new",  _::(ys: List[Backend.Exp]))) =>
+        val unwrapped_xsys = Seq(mA) ++ xs ++ ys
+        Wrap[List[A]](Adapter.g.reflect("list-new", unwrapped_xsys:_*))
+      case (Adapter.g.Def("list-new", mA::(xs: List[Backend.Exp])), _) if xs.isEmpty =>
+        ys
+      case (_, Adapter.g.Def("list-new", mA::(ys: List[Backend.Exp]))) if ys.isEmpty =>
+        xs
+      case _ => super.++(ys)
+    }
+    override def foldLeft[B: Manifest](z: Rep[B])(f: (Rep[B], Rep[A]) => Rep[B]): Rep[B] =
+      Unwrap(xs) match {
+        case Adapter.g.Def("list-new", mA::(xs: List[Backend.Exp])) =>
+          xs.map(Wrap[A](_)).foldLeft(z)(f)
+        case _ => super.foldLeft(z)(f)
+      }
+  }
+}
+
+trait ScalaCodeGen_List extends ExtendedScalaCodeGen {
+  override def remap(m: Manifest[_]): String = {
+    if (m.runtimeClass.getName == "scala.collection.immutable.List") {
+      val kty = m.typeArguments(0)
+      s"List[${remap(kty)}]"
+    } else { super.remap(m) }
+  }
+
+  override def mayInline(n: Node): Boolean = n match {
+    case Node(_, "list-new", _, _) => false
+    case Node(_, "list-map", _, _) => false
+    case Node(_, "list-flatMap", _, _) => false
+    case Node(_, "list-foldLeft", _, _) => false
+    case Node(_, "list-take", _, _) => false
+    case Node(_, "list-prepend", _, _) => false
+    case Node(_, "list-concat", _, _) => false
+    case Node(_, "list-zip", _, _) => false
+    case Node(_, "list-sortBy", _, _) => false
+    case _ => super.mayInline(n)
+  }
+
+  override def quote(s: Def): String = s match {
+    case Const(xs: List[_]) =>
+      "List(" + xs.map(x => quote(Const(x))).mkString(", ") + ")"
+    case _ => super.quote(s)
+  }
+
+  override def shallow(n: Node): Unit = n match {
+    case Node(s, "list-new", Const(mA: Manifest[_])::xs, _) =>
+      val ty = remap(mA)
+      emit("List[")
+      emit(ty)
+      emit("](")
+      xs.zipWithIndex.map { case (x, i) =>
+        shallow(x)
+        if (i != xs.length-1) emit(", ")
+      }
+      emit(")")
+    case Node(s, "list-apply", List(xs, i), _) =>
+      shallow(xs); emit("("); shallow(i); emit(")")
+    case Node(s, "list-head", List(xs), _) =>
+      shallow(xs); emit(".head")
+    case Node(s, "list-tail", List(xs), _) =>
+      shallow(xs); emit(".tail")
+    case Node(s, "list-size", List(xs), _) =>
+      shallow(xs); emit(".size")
+    case Node(s, "list-isEmpty", List(xs), _) =>
+      shallow(xs); emit(".isEmpty")
+    case Node(s, "list-take", List(xs, i), _) =>
+      shallow(xs); emit(".take("); shallow(i); emit(")")
+    case Node(s, "list-prepend", List(xs, x), _) =>
+      shallow(x); emit(" :: "); shallow(xs)
+    case Node(s, "list-concat", List(xs, ys), _) =>
+      shallow(xs); emit(" ++ "); shallow(ys)
+    case Node(s, "list-mkString", List(xs, Const("")), _) =>
+      shallow(xs); emit(".mkString")
+    case Node(s, "list-mkString", List(xs, sep), _) =>
+      shallow(xs); emit(".mkString("); shallow(sep); emit(")")
+    case Node(s, "list-toArray", List(xs), _) =>
+      shallow(xs); emit(".toArray")
+    case Node(s, "list-toSeq", List(xs), _) =>
+      shallow(xs); emit(".toSeq")
+    case Node(s, "list-map", List(xs, b), _) =>
+      shallow(xs); emit(".map("); shallow(b); emit(")")
+    case Node(s, "list-flatMap", xs::(b: Block)::rest, _) =>
+      shallow(xs); emit(".flatMap("); shallow(b); emit(")")
+    case Node(s, "list-foldLeft", List(xs, z, b), _) =>
+      shallow(xs); emit(".foldLeft("); shallow(z); emit(")("); shallow(b, false); emit(")")
+    case Node(s, "list-zip", List(xs, ys), _) =>
+      shallow(xs); emit(".zip("); shallow(ys); emit(")")
+    case Node(s, "list-filter", List(xs, b), _) =>
+      shallow(xs); emit(".filter("); shallow(b); emit(")")
+    case Node(s, "list-sortBy", List(xs, b), _) =>
+      shallow(xs); emit(".sortBy("); shallow(b); emit(")")
+    case Node(s, "list-containsSlice", List(xs, ys), _) =>
+      shallow(xs); emit(".containsSlice("); shallow(ys); emit(")")
+    case Node(s, "list-intersect", List(xs, ys), _) =>
+      shallow(xs); emit(".intersect("); shallow(ys); emit(")")
+    case _ => super.shallow(n)
+  }
+
+  //TODO: what should be added here?
+  override def traverse(n: Node): Unit = n match {
+    case _ => super.traverse(n)
+  }
+
+  //TODO: what should be added here?
+  override def symsFreq(n: Node): Set[(Def, Double)] = n match {
+    case _ => super.symsFreq(n)
+  }
+}
+

--- a/src/main/scala/lms/collection/MapOps.scala
+++ b/src/main/scala/lms/collection/MapOps.scala
@@ -1,0 +1,178 @@
+package lms.collection.immutable
+
+import lms.core._
+import lms.util._
+import lms.core.stub._
+import lms.core.Backend._
+import lms.core.virtualize
+import lms.core.utils.time
+import lms.macros.SourceContext
+
+trait MapOps { b: Base =>
+  object Map {
+    def apply[K: Manifest, V: Manifest](kvs: Rep[(K, V)]*)(implicit pos: SourceContext) = {
+      val mK = Backend.Const(manifest[K])
+      val mV = Backend.Const(manifest[V])
+      val unwrapped_kvs: Seq[Backend.Exp] = Seq(mK, mV) ++ kvs.map(Unwrap).toSeq
+      Wrap[Map[K, V]](Adapter.g.reflect("map-new", unwrapped_kvs:_*))
+    }
+    def empty[K: Manifest, V: Manifest](implicit pos: SourceContext) = {
+      val mK = Backend.Const(manifest[K])
+      val mV = Backend.Const(manifest[V])
+      val unwrapped_kvs: Seq[Backend.Exp] = Seq[Backend.Exp](mK, mV)
+      Wrap[Map[K, V]](Adapter.g.reflect("map-new", unwrapped_kvs:_*))
+    }
+  }
+
+  implicit def __liftConstMap[K: Manifest, V: Manifest](m: Map[K, V]): MapOps[K, V] = new MapOps(m)
+  implicit def __liftVarMap[K: Manifest, V: Manifest](m: Var[Map[K, V]]): MapOps[K, V] = new MapOps(readVar(m))
+
+  implicit class MapOps[K: Manifest, V: Manifest](m: Rep[Map[K, V]]) {
+    def apply(k: Rep[K]): Rep[V] = Wrap[V](Adapter.g.reflect("map-apply", Unwrap(m), Unwrap(k)))
+    def contains(k: Rep[K]): Rep[Boolean] = Wrap[Boolean](Adapter.g.reflect("map-contains", Unwrap(m), Unwrap(k)))
+    def get(k: Rep[K]): Rep[Option[V]] = Wrap[Option[V]](Adapter.g.reflect("map-get", Unwrap(m), Unwrap(k)))
+    def getOrElse(k: Rep[K], default: Rep[V]): Rep[V] =
+      Wrap[V](Adapter.g.reflect("map-getOrElse", Unwrap(m), Unwrap(k), Unwrap(default)))
+    def size: Rep[Int] = Wrap[Int](Adapter.g.reflect("map-size", Unwrap(m)))
+    def +(kv: Rep[(K, V)]): Rep[Map[K, V]] = {
+      Wrap[Map[K, V]](Adapter.g.reflect("map-+", Unwrap(m), Unwrap(kv)))
+    }
+    def ++(m1: Rep[Map[K, V]]): Rep[Map[K, V]] =
+      Wrap[Map[K, V]](Adapter.g.reflect("map-++", Unwrap(m), Unwrap(m1)))
+    def ===(m1: Rep[Map[K, V]]): Rep[Boolean] =
+      Wrap[Boolean](Adapter.g.reflect("map-===", Unwrap(m), Unwrap(m1)))
+    def keySet: Rep[Set[K]] = Wrap[Set[K]](Adapter.g.reflect("map-keySet", Unwrap(m)))
+    def isEmpty: Rep[Boolean] = Wrap[Boolean](Adapter.g.reflect("map-isEmpty", Unwrap(m)))
+    def foldLeft[B: Manifest](z: Rep[B])(f: (Rep[B], (Rep[K], Rep[V])) => Rep[B]) = {
+      def block2 = Adapter.g.reify(2, { syms =>
+        val k = Wrap[K](Adapter.g.reflect("tuple2-1", syms(1)))
+        val v = Wrap[V](Adapter.g.reflect("tuple2-2", syms(1)))
+        Unwrap(f(Wrap[B](syms(0)), (k, v)))
+      })
+      val block3 = Adapter.g.reify(3, syms =>
+        Unwrap(f(Wrap[B](syms(0)), (Wrap[K](syms(1)), Wrap[V](syms(2))))))
+      Wrap[B](Adapter.g.reflect("map-foldLeft", Unwrap(m), Unwrap(z), block3, block2))
+    }
+    def foreach(f: ((Rep[K], Rep[V])) => Rep[Unit]): Rep[Unit] = {
+      val block = Adapter.g.reify(2, syms => Unwrap(f(Wrap[K](syms(0)), Wrap[V](syms(1)))))
+      Wrap[Unit](Adapter.g.reflect("map-foreach", Unwrap(m), block))
+    }
+    def filter(f: ((Rep[K], Rep[V])) => Rep[Boolean]): Rep[Map[K, V]] = {
+      val block = Adapter.g.reify(2, syms => Unwrap(f(Wrap[K](syms(0)), Wrap[V](syms(1)))))
+      Wrap[Map[K, V]](Adapter.g.reflect("map-filter", Unwrap(m), block))
+    }
+    def map[A: Manifest](f: ((Rep[K], Rep[V])) => Rep[A]): Rep[List[A]] = {
+      val block = Adapter.g.reify(2, syms => Unwrap(f(Wrap[K](syms(0)), Wrap[V](syms(1)))))
+      Wrap[List[A]](Adapter.g.reflect("map-map", Unwrap(m), block))
+    }
+    def map[K1: Manifest, V1: Manifest](f: ((Rep[K], Rep[V])) => Rep[(K1, V1)]): Rep[Map[K1,V1]] = {
+      val block = Adapter.g.reify(2, syms => Unwrap(f(Wrap[K](syms(0)), Wrap[V](syms(1)))))
+      Wrap[Map[K1, V1]](Adapter.g.reflect("map-mapmap", Unwrap(m), block))
+    }
+  }
+}
+
+trait MapOpsOpt extends MapOps { b: Base with TupleOps =>
+  implicit override def __liftConstMap[K: Manifest, V: Manifest](m: Map[K, V]): MapOps[K, V] = 
+    new MapOpsOpt(m)
+  implicit override def __liftVarMap[K: Manifest, V: Manifest](m: Var[Map[K, V]]): MapOps[K, V] = 
+    new MapOpsOpt(readVar(m))
+
+  implicit class MapOpsOpt[K: Manifest, V: Manifest](m: Rep[Map[K, V]]) extends MapOps[K, V](m) {
+    override def foldLeft[B: Manifest](z: Rep[B])(f: (Rep[B], (Rep[K], Rep[V])) => Rep[B]) = 
+      Unwrap(m) match {
+        case Adapter.g.Def("map-new", mK::mV::(kvs: List[Backend.Exp])) =>
+          val kv_tps = kvs.map {
+            case Adapter.g.Def("tuple2-new", List(k: Backend.Exp, v: Backend.Exp)) =>
+              (Wrap[K](k), Wrap[V](v))
+            case s@Backend.Sym(n) =>
+              val t = Wrap[(K, V)](s)
+              (t._1, t._2)
+          }
+          kv_tps.foldLeft(z)(f)
+        case _ => super.foldLeft(z)(f)
+      }
+  }
+}
+
+trait ScalaCodeGen_Map extends ExtendedScalaCodeGen {
+  override def remap(m: Manifest[_]): String = {
+    if (m.runtimeClass.getName == "scala.collection.immutable.Map") {
+      val kty = m.typeArguments(0)
+      val vty = m.typeArguments(1)
+      s"Map[${remap(kty)}, ${remap(vty)}]"
+    } else { super.remap(m) }
+  }
+
+  override def mayInline(n: Node): Boolean = n match {
+    case Node(_, "map-new", _, _) => false
+    case Node(_, "map-+", _, _) => false
+    case Node(_, "map-++", _, _) => false
+    case Node(_, "map-getOrElse", _, _) => false
+    case Node(_, "map-foldLeft", _, _) => false
+    case Node(_, "map-foreach", _, _) => false
+    case Node(_, "map-filter", _, _) => false
+    case Node(_, "map-map", _, _) => false
+    case Node(_, "map-mapmap", _, _) => false
+    case _ => super.mayInline(n)
+  }
+
+  override def quote(s: Def): String = s match {
+    case Const(m: Map[_, _]) =>
+      val kvs = m.map {
+        case (k, v) => "(" + quote(Const(k)) + ", " + quote(Const(v)) + ")"
+      }
+      "Map(" + kvs.mkString(", ") + ")"
+    case _ => super.quote(s)
+  }
+
+  override def shallow(n: Node): Unit = n match {
+    case Node(s, "map-new", Const(mK: Manifest[_])::Const(mV: Manifest[_])::kvs, _) =>
+      val kty = remap(mK)
+      val vty = remap(mV)
+      emit("Map[")
+      emit(kty); emit(", "); emit(vty)
+      emit("](")
+      kvs.zipWithIndex.map { case (kv, i) =>
+        shallow(kv)
+        if (i != kvs.length-1) emit(", ")
+      }
+      emit(")")
+    case Node(s, "map-apply", List(m, k), _) =>
+      shallow(m); emit("("); shallow(k); emit(")")
+    case Node(s, "map-contains", List(m, k), _) =>
+      shallow(m); emit(".contains("); shallow(k); emit(")")
+    case Node(s, "map-get", List(m, k), _) =>
+      shallow(m); emit(".get("); shallow(k); emit(")")
+    case Node(s, "map-getOrElse", List(m, k, d), _) =>
+      shallow(m); emit(".getOrElse("); shallow(k); emit(", "); shallow(d); emit(")")
+    case Node(s, "map-size", List(m), _) =>
+      shallow(m); emit(".size");
+    case Node(s, "map-+", List(m, kv), _) =>
+      shallow(m); emit(" + ("); shallow(kv); emit(")")
+    case Node(s, "map-++", List(m1, m2), _) =>
+      shallow(m1); emit(" ++ "); shallow(m2)
+    case Node(s, "map-keySet", List(m), _) =>
+      shallow(m); emit(".keySet");
+    case Node(s, "map-isEmpty", List(m), _) =>
+      shallow(m); emit(".isEmpty");
+    case Node(s, "map-foldLeft", List(m, z, b: Block, _), _) =>
+      val p = PTuple(List(PVar(b.in(0)), PTuple(List(PVar(b.in(1)), PVar(b.in(2))))))
+      shallow(m); emit(".foldLeft(")
+      shallow(z); emit(") ")
+      quoteCaseBlock(b, p) //Note: quoteBlock will emit `{` and `}`
+    case Node(s, "map-foreach", List(m, b: Block), _) =>
+      val p = PTuple(b.in.map(PVar(_)))
+      shallow(m); emit(".foreach "); quoteCaseBlock(b, p)
+    case Node(s, "map-filter", List(m, b: Block), _) =>
+      val p = PTuple(b.in.map(PVar(_)))
+      shallow(m); emit(".filter "); quoteCaseBlock(b, p)
+    case Node(s, "map-map", List(m, b: Block), _) =>
+      val p = PTuple(b.in.map(PVar(_)))
+      shallow(m); emit(".map "); quoteCaseBlock(b, p)
+    case Node(s, "map-mapmap", List(m, b: Block), _) =>
+      val p = PTuple(b.in.map(PVar(_)))
+      shallow(m); emit(".map "); quoteCaseBlock(b, p)
+    case _ => super.shallow(n)
+  }
+}

--- a/src/main/scala/lms/collection/SetOps.scala
+++ b/src/main/scala/lms/collection/SetOps.scala
@@ -1,0 +1,133 @@
+package lms.collection.immutable
+
+import lms.core._
+import lms.util._
+import lms.core.stub._
+import lms.core.Backend._
+import lms.core.virtualize
+import lms.core.utils.time
+import lms.macros.SourceContext
+
+trait SetOps { b: Base =>
+  object Set {
+    def apply[A: Manifest](xs: Rep[A]*)(implicit pos: SourceContext) = {
+      val mA = Backend.Const(manifest[A])
+      val unwrapped_xs = Seq(mA) ++ xs.map(Unwrap)
+      Wrap[Set[A]](Adapter.g.reflect("set-new", unwrapped_xs:_*))
+    }
+  }
+
+  implicit def __liftConstSet[A: Manifest](xs: Set[A]): SetOps[A] = new SetOps(xs)
+  implicit def __liftVarSet[A: Manifest](xs: Var[Set[A]]): SetOps[A] = new SetOps(readVar(xs))
+
+  implicit class SetOps[A: Manifest](s: Rep[Set[A]]) {
+    def apply(a: Rep[A]): Rep[Boolean] = Wrap[Boolean](Adapter.g.reflect("set-apply", Unwrap(s), Unwrap(a)))
+    def size: Rep[Int] = Wrap[Int](Adapter.g.reflect("set-size", Unwrap(s)))
+    def isEmpty: Rep[Boolean] = Wrap[Boolean](Adapter.g.reflect("set-isEmpty", Unwrap(s)))
+    def head: Rep[A] = Wrap[A](Adapter.g.reflect("set-head", Unwrap(s)))
+    def tail: Rep[Set[A]] = Wrap[Set[A]](Adapter.g.reflect("set-tail", Unwrap(s)))
+    def toList: Rep[List[A]] = Wrap[List[A]](Adapter.g.reflect("set-toList", Unwrap(s)))
+    def ++(s1: Rep[Set[A]]): Rep[Set[A]] = Wrap[Set[A]](Adapter.g.reflect("set-++", Unwrap(s), Unwrap(s1)))
+    def intersect(s1: Rep[Set[A]]): Rep[Set[A]] =
+      Wrap[Set[A]](Adapter.g.reflect("set-intersect", Unwrap(s), Unwrap(s1)))
+    def union(s1: Rep[Set[A]]): Rep[Set[A]] =
+      Wrap[Set[A]](Adapter.g.reflect("set-union", Unwrap(s), Unwrap(s1)))
+    def subsetOf(s1: Rep[Set[A]]): Rep[Boolean] =
+      Wrap[Boolean](Adapter.g.reflect("set-subsetOf", Unwrap(s), Unwrap(s1)))
+    def map[B: Manifest](f: Rep[A] => Rep[B]): Rep[Set[B]] = {
+      val block = Adapter.g.reify(x => Unwrap(f(Wrap[A](x))))
+      Wrap[Set[B]](Adapter.g.reflect("set-map", Unwrap(s), block))
+    }
+    def foldLeft[B: Manifest](z: Rep[B])(f: (Rep[B], Rep[A]) => Rep[B]): Rep[B] = {
+      val block = Adapter.g.reify((x, y) => Unwrap(f(Wrap[B](x), Wrap[A](y))))
+      Wrap[B](Adapter.g.reflect("set-foldLeft", Unwrap(s), Unwrap(z), block))
+    }
+    def filter(f: Rep[A] => Rep[Boolean]) = {
+      val block = Adapter.g.reify(x => Unwrap(f(Wrap[A](x))))
+      Wrap[Set[A]](Adapter.g.reflect("set-filter", Unwrap(s), block))
+    }
+  }
+}
+
+trait SetOpsOpt extends SetOps { b: Base =>
+  implicit override def __liftConstSet[A: Manifest](xs: Set[A]): SetOps[A] = new SetOpsOpt(unit(xs))
+  implicit override def __liftVarSet[A: Manifest](xs: Var[Set[A]]): SetOps[A] = new SetOpsOpt(readVar(xs))
+
+  implicit class SetOpsOpt[A: Manifest](xs: Rep[Set[A]]) extends SetOps[A](xs) {
+    override def ++(ys: Rep[Set[A]]): Rep[Set[A]] = (Unwrap(xs), Unwrap(ys)) match {
+      case (Adapter.g.Def("set-new", mA::(xs: List[Backend.Exp])),
+            Adapter.g.Def("set-new",  _::(ys: List[Backend.Exp]))) =>
+        val unwrapped_xsys = Seq(mA) ++ xs ++ ys
+        Wrap[Set[A]](Adapter.g.reflect("set-new", unwrapped_xsys:_*))
+      case (Adapter.g.Def("set-new", mA::(xs: List[Backend.Exp])), _) if xs.isEmpty =>
+        ys
+      case (_, Adapter.g.Def("set-new", mA::(ys: List[Backend.Exp]))) if ys.isEmpty =>
+        xs
+      case _ => super.++(ys)
+    }
+    override def foldLeft[B: Manifest](z: Rep[B])(f: (Rep[B], Rep[A]) => Rep[B]): Rep[B] =
+      Unwrap(xs) match {
+        case Adapter.g.Def("set-new", mA::(xs: List[Backend.Exp])) => 
+          xs.map(Wrap[A](_)).foldLeft(z)(f)
+        case _ => super.foldLeft(z)(f)
+      }
+  }
+}
+
+trait ScalaCodeGen_Set extends ExtendedScalaCodeGen {
+  override def remap(m: Manifest[_]): String = {
+    if (m.runtimeClass.getName == "scala.collection.immutable.Set") {
+      val kty = m.typeArguments(0)
+      s"Set[${remap(kty)}]"
+    } else { super.remap(m) }
+  }
+
+  override def mayInline(n: Node): Boolean = n match {
+    case Node(_, "set-++", _, _) => false
+    case Node(_, "set-intersect", _, _) => false
+    case Node(_, "set-union", _, _) => false
+    case Node(_, "set-subsetOf", _, _) => false
+    case Node(_, "set-map", _, _) => false
+    case Node(_, "set-foldLeft", _, _) => false
+    case Node(_, "set-filter", _, _) => false
+    case _ => super.mayInline(n)
+  }
+
+  override def shallow(n: Node): Unit = n match {
+    case Node(s, "set-new", Const(mA: Manifest[_])::xs, _) =>
+      val ty = remap(mA)
+      emit("Set["); emit(ty); emit("](")
+      xs.zipWithIndex.map { case (x, i) =>
+        shallow(x)
+        if (i != xs.length-1) emit(", ")
+      }
+      emit(")")
+    case Node(_, "set-apply", List(s, x), _) =>
+      shallow(s); emit("("); shallow(x); emit(")")
+    case Node(_, "set-size", List(s), _) =>
+      shallow(s); emit(".size")
+    case Node(_, "set-isEmpty", List(s), _) =>
+      shallow(s); emit(".isEmpty")
+    case Node(_, "set-head", List(s), _) =>
+      shallow(s); emit(".head")
+    case Node(_, "set-tail", List(s), _) =>
+      shallow(s); emit(".tail")
+    case Node(_, "set-toList", List(s), _) =>
+      shallow(s); emit(".toList")
+    case Node(_, "set-++", List(s1, s2), _) =>
+      shallow(s1); emit(" ++ "); shallow(s2)
+    case Node(_, "set-intersect", List(s1, s2), _) =>
+      shallow(s1); emit(".intersect("); shallow(s2); emit(")")
+    case Node(_, "set-union", List(s1, s2), _) =>
+      shallow(s1); emit(".union("); shallow(s2); emit(")")
+    case Node(_, "set-subsetOf", List(s1, s2), _) =>
+      shallow(s1); emit(".subsetOf("); shallow(s2); emit(")")
+    case Node(_, "set-map", List(s, b), _) =>
+      shallow(s); emit(".map("); shallow(b); emit(")")
+    case Node(_, "set-foldLeft", List(s, z, b), _) =>
+      shallow(s); emit(".foldLeft("); shallow(z); emit(")("); shallow(b); emit(")")
+    case Node(_, "set-filter", List(s, b), _) =>
+      shallow(s); emit(".filter("); shallow(b); emit(")")
+    case _ => super.shallow(n)
+  }
+}

--- a/src/main/scala/lms/collection/TupleOps.scala
+++ b/src/main/scala/lms/collection/TupleOps.scala
@@ -1,0 +1,151 @@
+package lms.collection.immutable
+
+import lms.core._
+import lms.util._
+import lms.core.stub._
+import lms.core.Backend._
+import lms.core.virtualize
+import lms.core.utils.time
+import lms.macros.SourceContext
+
+trait TupleOps { b: Base =>
+  // Tuple2
+
+  object Tuple2 {
+    def apply[A: Manifest, B: Manifest](a: Rep[A], b: Rep[B]) = {
+      Wrap[Tuple2[A, B]](Adapter.g.reflect("tuple2-new", Unwrap(a), Unwrap(b)))
+    }
+  }
+
+  implicit def __liftTuple2Rep[A: Manifest, B: Manifest](t: (Rep[A], Rep[B])) =
+    Tuple2[A, B](t._1, t._2)
+  implicit def __liftTuple2RepLhs[A: Manifest, B: Manifest](t: (A, Rep[B])) =
+    Tuple2[A, B](unit[A](t._1), t._2)
+  implicit def __liftTuple2RepRhs[A: Manifest, B: Manifest](t: (Rep[A], B)) =
+    Tuple2[A, B](t._1, unit[B](t._2))
+  implicit def __liftTuple2[A: Manifest, B: Manifest](t: (A, B)) =
+    Tuple2[A, B](unit[A](t._1), unit[B](t._2))
+
+  implicit class Tuple2Ops[A: Manifest, B: Manifest](t: Rep[(A, B)]) {
+    def _1: Rep[A] = Wrap[A](Adapter.g.reflect("tuple2-1", Unwrap(t)))
+    def _2: Rep[B] = Wrap[B](Adapter.g.reflect("tuple2-2", Unwrap(t)))
+    def swap: Rep[(B, A)] = Wrap[(B, A)](Adapter.g.reflect("tuple2-swap", Unwrap(t)))
+    def unlift: (Rep[A], Rep[B]) = (this._1, this._2)
+  }
+
+  // Tuple3
+
+  object Tuple3 {
+    def apply[A: Manifest, B: Manifest, C: Manifest](a: Rep[A], b: Rep[B], c: Rep[C]) =
+      Wrap[Tuple3[A, B, C]](Adapter.g.reflect("tuple3-new", Unwrap(a), Unwrap(b), Unwrap(c)))
+  }
+
+  implicit def __liftTuple3RepAll[A: Manifest, B: Manifest, C: Manifest](t: (Rep[A], Rep[B], Rep[C])) =
+    Tuple3[A, B, C](t._1, t._2, t._3)
+  implicit def __liftTuple3RepFst[A: Manifest, B: Manifest, C: Manifest](t: (A, Rep[B], Rep[C])) =
+    Tuple3[A, B, C](unit(t._1), t._2, t._3)
+  implicit def __liftTuple3RepSnd[A: Manifest, B: Manifest, C: Manifest](t: (Rep[A], B, Rep[C])) =
+    Tuple3[A, B, C](t._1, unit(t._2), t._3)
+  implicit def __liftTuple3RepTrd[A: Manifest, B: Manifest, C: Manifest](t: (Rep[A], Rep[B], C)) =
+    Tuple3[A, B, C](t._1, t._2, unit(t._3))
+  implicit def __liftTuple3RepFstSnd[A: Manifest, B: Manifest, C: Manifest](t: (A, B, Rep[C])) =
+    Tuple3[A, B, C](unit(t._1), unit(t._2), t._3)
+  implicit def __liftTuple3RepFstTrd[A: Manifest, B: Manifest, C: Manifest](t: (A, Rep[B], C)) =
+    Tuple3[A, B, C](unit(t._1), t._2, unit(t._3))
+  implicit def __liftTuple3RepSndTrd[A: Manifest, B: Manifest, C: Manifest](t: (Rep[A], B, C)) =
+    Tuple3[A, B, C](t._1, unit(t._2), unit(t._3))
+  implicit def __liftTuple3[A: Manifest, B: Manifest, C: Manifest](t: (A, B, C)) =
+    Tuple3[A, B, C](unit(t._1), unit(t._2), unit(t._3))
+
+  implicit class Tuple3Ops[A: Manifest, B: Manifest, C: Manifest](t: Rep[(A, B, C)]) {
+    def _1: Rep[A] = Wrap[A](Adapter.g.reflect("tuple3-1", Unwrap(t)))
+    def _2: Rep[B] = Wrap[B](Adapter.g.reflect("tuple3-2", Unwrap(t)))
+    def _3: Rep[C] = Wrap[C](Adapter.g.reflect("tuple3-3", Unwrap(t)))
+    def unliftLeft: ((Rep[A], Rep[B]), Rep[C]) =
+      ((this._1, this._2), this._3)
+    def unliftRight: (Rep[A], (Rep[B], Rep[C])) =
+      (this._1, (this._2, this._3))
+  }
+}
+
+trait TupleOpsOpt extends TupleOps { b: Base =>
+  implicit class Tuple2OpsOpt[A: Manifest, B: Manifest](t: Rep[(A, B)]) extends Tuple2Ops[A, B](t) {
+    override def _1: Rep[A] = Unwrap(t) match {
+      case Adapter.g.Def("tuple2-new", List(t1: Backend.Exp, t2: Backend.Exp)) => Wrap[A](t1)
+      case _ => super._1
+    }
+    override def _2: Rep[B] = Unwrap(t) match {
+      case Adapter.g.Def("tuple2-new", List(t1: Backend.Exp, t2: Backend.Exp)) => Wrap[B](t2)
+      case _ => super._2
+    }
+  }
+
+  implicit class Tuple3OpsOpt[A: Manifest, B: Manifest, C: Manifest](t: Rep[(A, B, C)]) extends Tuple3Ops[A, B, C](t) {
+    override def _1: Rep[A] = Unwrap(t) match {
+      case Adapter.g.Def("tuple3-new", List(t1: Backend.Exp, t2: Backend.Exp, t3: Backend.Exp)) =>
+        Wrap[A](t1)
+      case _ => Wrap[A](Adapter.g.reflect("tuple3-1", Unwrap(t)))
+    }
+    override def _2: Rep[B] = Unwrap(t) match {
+      case Adapter.g.Def("tuple3-new", List(t1: Backend.Exp, t2: Backend.Exp, t3: Backend.Exp)) =>
+        Wrap[B](t2)
+      case _ => Wrap[B](Adapter.g.reflect("tuple3-2", Unwrap(t)))
+    }
+    override def _3: Rep[C] = Unwrap(t) match {
+      case Adapter.g.Def("tuple3-new", List(t1: Backend.Exp, t2: Backend.Exp, t3: Backend.Exp)) =>
+        Wrap[C](t3)
+      case _ => Wrap[C](Adapter.g.reflect("tuple3-3", Unwrap(t)))
+    }
+  }
+}
+
+trait ScalaCodeGen_Tuple extends ExtendedScalaCodeGen {
+  override def remap(m: Manifest[_]): String = {
+    val typeStr = m.runtimeClass.getName
+    if (typeStr == "scala.Tuple2") {
+      val fst = m.typeArguments(0)
+      val snd = m.typeArguments(1)
+      s"Tuple2[${remap(fst)}, ${remap(snd)}]"
+    } else if (typeStr == "scala.Tuple3") {
+      val fst = m.typeArguments(0)
+      val snd = m.typeArguments(1)
+      val thd = m.typeArguments(2)
+      s"Tuple3[${remap(fst)}, ${remap(snd)}, ${remap(thd)}]"
+    } else {
+      super.remap(m)
+    }
+  }
+
+  override def quote(s: Def): String = s match {
+    case Const(t: Tuple2[_, _]) =>
+      "(" + quote(Const(t._1)) + ", " + quote(Const(t._2)) + ")"
+    case Const(t: Tuple3[_, _, _]) =>
+      "(" + quote(Const(t._1)) + ", " + quote(Const(t._2)) + ", " + quote(Const(t._3)) + ")"
+    case _ => super.quote(s)
+  }
+
+  override def shallow(n: Node): Unit = n match {
+    // Tuple2
+    case Node(s, "tuple2-new", List(fst, snd), _) =>
+      emit("("); shallow(fst); emit(", "); shallow(snd); emit(")")
+    case Node(s, "tuple2-1", List(t), _) =>
+      shallow(t); emit("._1")
+    case Node(s, "tuple2-2", List(t), _) =>
+      shallow(t); emit("._2")
+    case Node(s, "tuple2-swap", List(t), _) =>
+      shallow(t); emit(".swap")
+    // Tuple3
+    case Node(s, "tuple3-new", List(fst, snd, trd), _) =>
+      emit("(")
+      shallow(fst); emit(", ")
+      shallow(snd); emit(", ")
+      shallow(trd); emit(")")
+    case Node(s, "tuple3-1", List(t), _) =>
+      shallow(t); emit("._1")
+    case Node(s, "tuple3-2", List(t), _) =>
+      shallow(t); emit("._2")
+    case Node(s, "tuple3-3", List(t), _) =>
+      shallow(t); emit("._3")
+    case _ => super.shallow(n)
+  }
+}

--- a/src/main/scala/lms/core/codegen/scala_codegen.scala
+++ b/src/main/scala/lms/core/codegen/scala_codegen.scala
@@ -367,7 +367,23 @@ class ExtendedScalaCodeGen extends CompactScalaCodeGen with ExtendedCodeGen {
   def record(man: RefinedManifest[_]): String = ""
   def function(sig: List[Manifest[_]]): String = ""
   def remapUnsigned(m: Manifest[_]) = ???
-  override def remap(m: Manifest[_]): String = m.toString
+  override def remap(m: Manifest[_]): String = {
+    m.runtimeClass.getName match {
+      case "scala.Function0" =>
+        val ret = m.typeArguments(0)
+        s"Function0[${remap(ret)}]"
+      case "scala.Function1" =>
+        val fst = m.typeArguments(0)
+        val ret = m.typeArguments(1)
+        s"Function2[${remap(fst)}, ${remap(ret)}]"
+      case "scale.Function2" =>
+        val fst = m.typeArguments(0)
+        val snd = m.typeArguments(1)
+        val ret = m.typeArguments(2)
+        s"Function2[${remap(fst)}, ${remap(snd)}, ${remap(ret)}]"
+      case _ => m.toString
+    }
+  }
 
   val nameMap: Map[String, String] = Map( // FIXME: tutorial-specific
     "ScannerNew"     -> "new scala.lms.tutorial.Scanner",

--- a/src/main/scala/lms/core/codegen/scala_codegen.scala
+++ b/src/main/scala/lms/core/codegen/scala_codegen.scala
@@ -375,7 +375,7 @@ class ExtendedScalaCodeGen extends CompactScalaCodeGen with ExtendedCodeGen {
       case "scala.Function1" =>
         val fst = m.typeArguments(0)
         val ret = m.typeArguments(1)
-        s"Function2[${remap(fst)}, ${remap(ret)}]"
+        s"Function1[${remap(fst)}, ${remap(ret)}]"
       case "scale.Function2" =>
         val fst = m.typeArguments(0)
         val snd = m.typeArguments(1)

--- a/src/out/backend/recursion_1.check.scala
+++ b/src/out/backend/recursion_1.check.scala
@@ -3,7 +3,7 @@ Emitting Generated Code
 *******************************************/
 class Snippet() extends (Int => Int) {
   def apply(x0: Int): Int = {
-    var x1: scala.Function1[Int, Int] = null.asInstanceOf[scala.Function1[Int, Int]]
+    var x1: Function1[Int, Int] = null.asInstanceOf[Function1[Int, Int]]
     x1 = x2
     def x2(x3:Int): Int = if (x3 > 0) x3 * x1(x3 - 1) else 1
     x2(3)

--- a/src/out/backend/recursion_2.check.scala
+++ b/src/out/backend/recursion_2.check.scala
@@ -4,7 +4,7 @@ Emitting Generated Code
 class Snippet() extends (Int => Unit) {
   def apply(x0: Int): Unit = {
     var x1: Int = null.asInstanceOf[Int]
-    var x2: scala.Function1[Int, Int] = null.asInstanceOf[scala.Function1[Int, Int]]
+    var x2: Function1[Int, Int] = null.asInstanceOf[Function1[Int, Int]]
     x1 = 0
     x2 = x3
     def x3(x4:Int): Int = if (x4 > 0) x4 * x2(x4 - x0) else 1

--- a/src/out/backend/recursion_3.check.scala
+++ b/src/out/backend/recursion_3.check.scala
@@ -4,7 +4,7 @@ Emitting Generated Code
 class Snippet() extends (Int => Unit) {
   def apply(x0: Int): Unit = {
     var x1: Int = null.asInstanceOf[Int]
-    var x2: scala.Function1[Int, Int] = null.asInstanceOf[scala.Function1[Int, Int]]
+    var x2: Function1[Int, Int] = null.asInstanceOf[Function1[Int, Int]]
     x1 = 0
     x2 = x3
     def x3(x4:Int): Int = if (x4 > 0) x1 * x2(x4 - x0) else 1


### PR DESCRIPTION
- This PR adds support for immutable data structures, `List`/`Map`/`Set`/`Tuple`, as well as Scala codegen of them.
- Take `List` as an example, `ListOps` provides basic operations, which should be (at least) mixed with `Base` when used. `ListOpsOpt` is similar to `ListOps`, but additionally provides some optimizations based on partially-static data (not complete though). 
- In my own use, I also have C++ codegen, which uses the `immer` library. But I think it is probably not everyone would need, so they are not included in this PR.
- @feiwang3311 For mutable collections (eg Array), I think we can also refactor and reorganize in this modular way.