### PR TITLE
[Traverser && CodeGen] comments and code refactoring

### DIFF
--- a/src/main/scala/lms/core/backend.scala
+++ b/src/main/scala/lms/core/backend.scala
@@ -121,15 +121,6 @@ object Backend {
       case _ => Nil
     }
 
-  // TODO: remove filter syms
-  def filterSym(x: List[Exp]): Set[Sym] = x collect { case s: Sym => s } toSet
-  def symsAndEffectSyms(x: Node): (Set[Sym], Set[Sym]) = ((Set[Sym](), x.eff.hdeps.toSet) /: x.rhs) {
-    case ((syms, symsEffect), s: Sym) => (syms + s, symsEffect)
-    case ((syms, symsEffect), Block(_, res: Sym, _, eff)) => (syms + res, symsEffect ++ eff.hdeps)
-    case ((syms, symsEffect), Block(_, _, _, eff)) => (syms, symsEffect ++ eff.hdeps)
-    case (agg, _) => agg
-  }
-
   def syms(x: Node): List[Sym] = {
     x.rhs.flatMap {
       case s: Sym => List(s)
@@ -354,6 +345,7 @@ class GraphBuilder {
     case _ =>
       (Set[Exp](), Set[Exp]())
   }
+
   // getLaternEffect(xs: Def*) wrappers getLatentEffect(x: Def) and accumulate effects of multiple Defs
   def getLatentEffect(xs: Def*): (Set[Exp], Set[Exp]) =
     xs.foldLeft((Set[Exp](), Set[Exp]())) { case ((r, w), x) =>

--- a/src/main/scala/lms/core/backend.scala
+++ b/src/main/scala/lms/core/backend.scala
@@ -538,6 +538,113 @@ class DeadCodeElim extends Phase {
   }
 }
 
+/*
+ * Resolve may dependencies
+ */
+class DeadCodeElimCG {
+
+  final val fixDeps = true // remove deps on removed nodes
+  // it is interesting to discuss the difference between `live` and `reach`.
+  // `reach` is the set of nodes (or Syms of nodes) that are reachable via hard-dependencies.
+  // the reachable set can include values that are needed (data dependencies) and side-effects
+  // (printing, mutation, et. al.)
+  // `live` is the set of ndoes (or Syms of nodes) whose values are needed (only data dependencies).
+  // For instance, a conditional can have side-effects and return values. If the side-effects
+  // are relevant, then the conditional is reachable. If the values are relevant, the conditional
+  // is live. The property of `live` and `reach` can be independent.
+  var live: collection.Set[Sym] = _
+  var reach: collection.Set[Sym] = _
+
+  def valueSyms(n: Node): List[Sym] =
+    directSyms(n) ++ blocks(n).flatMap {
+      case Block(ins, res:Sym, ein, _) => res::ein::ins
+      case Block(ins, _, ein, _) => ein::ins
+    }
+
+  // staticData -- not really a DCE task, but hey
+  var statics: collection.Set[Node] = _
+
+  def apply(g: Graph): Graph = utils.time("DeadCodeElimCG") {
+
+    live = new mutable.HashSet[Sym]
+    reach = new mutable.HashSet[Sym]
+    statics = new mutable.HashSet[Node]
+    var newNodes: List[Node] = Nil
+    val used = new mutable.HashSet[Exp]
+    var size = 0
+
+    // First pass liveness and reachability
+    // Only a single pass that reduce input size and first step of the next loop
+    utils.time("A_First_Path") {
+      reach ++= g.block.used
+      if (g.block.res.isInstanceOf[Sym]) {
+        live += g.block.res.asInstanceOf[Sym]
+        used += g.block.res.asInstanceOf[Sym]
+      }
+      used ++= g.block.bound
+      for (d <- g.nodes.reverseIterator) {
+        if (reach(d.n)) {
+          val nn = d match {
+            case n @ Node(s, "?", c::(a:Block)::(b:Block)::t, eff) if !live(s) =>
+              n.copy(rhs = c::a.copy(res = Const(()))::b.copy(res = Const(()))::t) // remove result deps if dead
+            case _ => d
+          }
+          live ++= valueSyms(nn)
+          reach ++= hardSyms(nn)
+
+          // if (!used(nn.n)) {
+          //   if (nn.eff.hasSimpleEffect || nn.eff.wkeys.exists(used)) {
+          //     used += nn.n
+          //     used ++= valueSyms(nn)
+          //   }
+          // } else {
+          //   used ++= valueSyms(nn)
+          // }
+          newNodes = nn::newNodes
+        }
+      }
+    }
+
+    // Second pass remove unused variables
+    var idx: Int = 1
+    while (size != used.size) {
+      utils.time(s"Extra_Path_$idx") {
+        size = used.size
+        for (d <- newNodes.reverseIterator) {
+          if (used(d.n)) {
+            used ++= valueSyms(d)
+          } else if (d.eff.hasSimpleEffect || d.eff.wkeys.exists(used)) {
+            used += d.n
+            used ++= valueSyms(d)
+          }
+        }
+      }
+      idx += 1
+    }
+
+    utils.time(s"Recreate_the_graph") {
+      var newGlobalDefsCache = Map[Sym,Node]()
+      newNodes = for (d <- newNodes if used(d.n)) yield {
+        newGlobalDefsCache += d.n -> d
+        if (d.op == "staticData") statics += d
+        if (fixDeps)
+          d.copy(rhs = d.rhs.map {
+            case b: Block => b.copy(eff = b.eff.filter(used))
+            case o => o
+          }, eff = d.eff.filter(used))
+        else
+          d
+      }
+      val newBlock = if (fixDeps)
+        g.block.copy(eff = g.block.eff.filter(used))
+      else
+        g.block
+
+      Graph(newNodes, newBlock, newGlobalDefsCache)
+    }
+  }
+}
+
 // Compute frequency information (i.e., how
 // many times a node's result is going to
 // be used, in expectation)

--- a/src/main/scala/lms/core/codegen.scala
+++ b/src/main/scala/lms/core/codegen.scala
@@ -10,6 +10,10 @@ import Backend._
 
 class Unknown // HACK: Sentinel for typeMap
 
+/**
+ * This class demonstrates a minimal code generator from Traverser.
+ * It is not used in production.
+ */
 class GenericCodeGen extends Traverser {
 
   def emit(s: String) = println(s)
@@ -35,124 +39,10 @@ class GenericCodeGen extends Traverser {
   }
 }
 
-/*
- * Resolve may dependencies
- */
-class DeadCodeElimCG {
-
-  final val fixDeps = true // remove deps on removed nodes
-  var live: collection.Set[Sym] = _
-  var reach: collection.Set[Sym] = _
-
-  def valueSyms(n: Node): List[Sym] =
-    directSyms(n) ++ blocks(n).flatMap {
-      case Block(ins, res:Sym, ein, _) => res::ein::ins
-      case Block(ins, _, ein, _) => ein::ins
-    }
-
-  // staticData -- not really a DCE task, but hey
-  var statics: collection.Set[Node] = _
-
-  def apply(g: Graph): Graph = utils.time("DeadCodeElimCG") {
-
-    live = new mutable.HashSet[Sym]
-    reach = new mutable.HashSet[Sym]
-    statics = new mutable.HashSet[Node]
-    var newNodes: List[Node] = Nil
-    val used = new mutable.HashSet[Exp]
-    var size = 0
-
-    // First pass liveness and reachability
-    // Only a single pass that reduce input size and first step of the next loop
-    utils.time("A_First_Path") {
-      reach ++= g.block.used
-      if (g.block.res.isInstanceOf[Sym]) {
-        live += g.block.res.asInstanceOf[Sym]
-        used += g.block.res.asInstanceOf[Sym]
-      }
-      used ++= g.block.bound
-      for (d <- g.nodes.reverseIterator) {
-        if (reach(d.n)) {
-          val nn = d match {
-            case n @ Node(s, "?", c::(a:Block)::(b:Block)::t, eff) if !live(s) =>
-              n.copy(rhs = c::a.copy(res = Const(()))::b.copy(res = Const(()))::t) // remove result deps if dead
-            case _ => d
-          }
-          live ++= valueSyms(nn)
-          reach ++= hardSyms(nn)
-
-          // if (!used(nn.n)) {
-          //   if (nn.eff.hasSimpleEffect || nn.eff.wkeys.exists(used)) {
-          //     used += nn.n
-          //     used ++= valueSyms(nn)
-          //   }
-          // } else {
-          //   used ++= valueSyms(nn)
-          // }
-          newNodes = nn::newNodes
-        }
-      }
-    }
-
-    // Second pass remove unused variables
-    var idx: Int = 1
-    while (size != used.size) {
-      utils.time(s"Extra_Path_$idx") {
-        size = used.size
-        for (d <- newNodes.reverseIterator) {
-          if (!used(d.n)) {
-            if (d.eff.hasSimpleEffect || d.eff.wkeys.exists(used)) {
-              used += d.n
-              used ++= valueSyms(d)
-            }
-          } else {
-            used ++= valueSyms(d)
-          }
-        }
-      }
-      idx += 1
-    }
-
-    utils.time(s"Recreate_the_graph") {
-      var newGlobalDefsCache = Map[Sym,Node]()
-      newNodes = for (d <- newNodes if used(d.n)) yield {
-        newGlobalDefsCache += d.n -> d
-        if (d.op == "staticData") statics += d
-        if (fixDeps)
-          d.copy(rhs = d.rhs.map {
-            case b: Block => b.copy(eff = b.eff.filter(used))
-            case o => o
-          }, eff = d.eff.filter(used))
-        else
-          d
-      }
-      val newBlock = if (fixDeps)
-        g.block.copy(eff = g.block.eff.filter(used))
-      else
-        g.block
-
-      Graph(newNodes, newBlock, newGlobalDefsCache)
-    }
-  }
-}
 
 trait ExtendedCodeGen {
 
-  var typeMap: collection.Map[lms.core.Backend.Exp, Manifest[_]] = _
-  def typeBlockRes(x: lms.core.Backend.Exp) = x match {
-    case Const(()) => manifest[Unit]
-    case Const(x: Int) => manifest[Int]
-    case Const(x: Long) => manifest[Long]
-    case Const(x: Float) => manifest[Float]
-    case Const(x: Double) => manifest[Double]
-    case Const(x: Char) => manifest[Char]
-    case Const(x: String) => manifest[String]
-    case Const(_) => ???
-    case _ => typeMap.getOrElse(x, manifest[Unknown])
-  }
-
-  val dce = new DeadCodeElimCG
-
+  // Method Group 1: stream and emit (for codegen string handling)
   var stream: java.io.PrintStream = _
   def withStream(out: PrintStream)(f: => Unit) = {
     val save = stream
@@ -169,7 +59,22 @@ trait ExtendedCodeGen {
 
   def emit(buf: ByteArrayOutputStream): Unit = buf.writeTo(stream)
 
-  def quote(s: Def): String
+  // Method Group 2: typeMap (from core Exp to type Manifest, the information
+  //                 of which is collection in the frontend)
+  var typeMap: collection.Map[lms.core.Backend.Exp, Manifest[_]] = _
+  def typeBlockRes(x: lms.core.Backend.Exp) = x match {
+    case Const(()) => manifest[Unit]
+    case Const(x: Int) => manifest[Int]
+    case Const(x: Long) => manifest[Long]
+    case Const(x: Float) => manifest[Float]
+    case Const(x: Double) => manifest[Double]
+    case Const(x: Char) => manifest[Char]
+    case Const(x: String) => manifest[String]
+    case Const(_) => ???
+    case _ => typeMap.getOrElse(x, manifest[Unknown])
+  }
+
+  // Method Group 3: remap (from type Manifest to string representation of type)
   def array(innerType: String): String
   def primitive(rawType: String): String
   def record(man: RefinedManifest[_]): String
@@ -184,21 +89,17 @@ trait ExtendedCodeGen {
     case sig => function(sig)
   }
 
+  // Method Group 4: dead code elimination
+  val dce = new DeadCodeElimCG
   def init(g: Graph): Graph = dce(g)
 
+  // Method Group 5: quote (for generating string of a unit of code generation:
+  //                 variable, const, or block)
+  def quote(s: Def): String
   def quoteStatic(n: Node) = n match {
     case Node(s, "staticData", List(Const(a)), _) =>
       val arg = "p"+quote(s)
-      val tpe = a match { // FIXME: hardcoded ...
-        case a: Array[Array[Int]] => "Array[Array[Int]]"
-        case a: Array[Int] => "Array[Int]"
-        case a: Array[Array[Double]] => "Array[Array[Double]]"
-        case a: Array[Double] => "Array[Double]"
-        case a: Array[Array[Float]] => "Array[Array[Float]]"
-        case a: Array[Float] => "Array[Float]"
-        case a: Array[Array[Long]] => "Array[Array[Long]]"
-        case a: Array[Long] => "Array[Long]"
-      }
+      val tpe = remap(typeMap.getOrElse(s, manifest[Unknown]))
       s"$arg: $tpe"
   }
 
@@ -209,7 +110,9 @@ trait ExtendedCodeGen {
 
   def extractAllStatics() = dce.statics.toList.map(extractStatic)
 
-  def emitAll(g: Graph, name: String)(m1:Manifest[_],m2:Manifest[_]): Unit
-
+  // Method Group 6: nameMap (from Node Op string to Target Language Method string)
   def nameMap: Map[String, String]
+
+  // Head Function: emitAll take a graph and generate the code.
+  def emitAll(g: Graph, name: String)(m1:Manifest[_],m2:Manifest[_]): Unit
 }

--- a/src/main/scala/lms/core/codegen/cps_codegen.scala
+++ b/src/main/scala/lms/core/codegen/cps_codegen.scala
@@ -8,34 +8,56 @@ import java.io.{ByteArrayOutputStream, PrintStream}
 
 import Backend._
 
+/**
+ * On top of the CPSTraverser, we can build code generators that run in CPS.
+ * Here we show a CPSScalaCodeGen. However, the CPSScalaCodeGen isn't just generating
+ * normal code with CPS traverser. It is generated code that can manipulate continuations:
+ * i.e., support `shift1` and `reset1` in the LMS IR.
+ *
+ * However, note that this code gen is quite rudimentary (no inlining, types are simple).
+ * This is just a show case of CPS code gen, not the one actually used in production.
+ */
 class CPSScalaCodeGen extends CPSTraverser {
 
   var trace = 0
   def fresh = try { trace } finally { trace += 1 }
   def emit(s: String) = print(s)
   def emitln(s: String) = println(s)
+
+  // Although the paramete `s` is of type `Def`
+  // this function is only handling `Exp`
   def quote(s: Def): String = s match {
     case Sym(n) => s"x$n"
     case Const(x: String) => "\""+x+"\""
     case Const(x: Char) => "'"+x+"'"
     case Const(x) => x.toString
+    case _ => System.out.println("Block not supported"); ???
   }
 
+  // this function tracks the set of continuations, because
+  // application of continutations do not generate another continuation
   val contSet = mutable.Set.empty[Exp]
 
+  // In this simple case, the main difference between a codegen pass and
+  // a generic traverser is that each node has to generate some code.
   override def traverse(n: Node)(k: => Unit): Unit = n match {
 
+    // `shift` captures the current continutation (generate a def)
+    // and then generates the `shift` body.
     case n @ Node(s,"shift1",List(y:Block),_) =>
       contSet += y.in.head
       emitln(s"def ${quote(y.in.head)}($s: Int) = {"); k; emitln("\n}")
       traverse(y)(v => emitln(quote(v)))
 
+    // `reset` needs to deliminate the continuation, thus the continuation `k` is
+    // not supplied to the traverse of the reset block.
     case n @ Node(s,"reset1",List(y:Block),_) =>
       emitln(s"val ${quote(s)} = {")
       traverse(y){ v => emit(quote(v)) }
       emitln("\n}")
       k
 
+    // In CPS code, all functions should have additional parameter, the continuation
     case n @ Node(f,"λ",List(y:Block),_) =>
       val x = y.in.head
       emitln(s"def ${quote(f)}(c: Int => Int, ${quote(x)}: Int): Int = {")
@@ -43,6 +65,31 @@ class CPSScalaCodeGen extends CPSTraverser {
       emitln("\n}")
       k
 
+    // "λforward" is the used for recursive functions (as a function name declaration)
+    case n @ Node(s,"λforward",List(x), _) =>
+      emitln(s"lazy val $s = ${quote(x)} _"); k
+
+    // application needs to be split into 2 cases: function appliation and continuation application
+    // Continuation Application (the true case) is simple (just apply and continue)
+    // Function Application (the false case) should capture the continuation
+    //    and use it as the first argument of the generated function.
+    case n @ Node(s,"@",x::y::_,_) =>
+      if (x.isInstanceOf[Sym] && contSet.contains(x.asInstanceOf[Sym])) {
+        emitln(s"val ${quote(s)} = ${quote(x)}(${quote(y)})"); k
+      } else {
+        val index = fresh
+        emitln(s"def cApp$index($s: Int) = {"); k; emitln("\n}")
+        emitln(s"${quote(x)}(cApp$index, ${quote(y)})")
+      }
+
+    // In CPS conditional, there should be a continuation `cIf`, and then
+    // each branch should call the continuation at the end.
+    // Note that the 2 traverse(block) cannot be code in tandem
+    // like `traverse(a){ v => emit ... ; traverse(b) { v => emit ...}}`
+    // because we are doing code generation (the generated code are static, and
+    // both branches are generated). For instance, if the true branch has a
+    // `shift1`, the code for the false branch should not be captured as part of
+    // the shift continuation!
     case n @ Node(f,"?",c::(a:Block)::(b:Block)::_,_) =>
       val index = fresh
       emitln(s"def cIf$index($f: Int) = {"); k; emitln("\n}")
@@ -52,6 +99,9 @@ class CPSScalaCodeGen extends CPSTraverser {
       traverse(b){ v => emit(s"cIf$index("); emit(quote(v)); emit(")") }
       emitln("\n}")
 
+    // CPS loop is generated as recursive function `def loop`
+    // In the recursive function, the true branch recurses on `loop`, while
+    // the false branch runs the code after the loop (the continuation).
     case n @ Node(f,"W", List(c:Block, b:Block),_) =>
       val index = fresh
       emitln(s"def loop$index(): Int = {")
@@ -63,6 +113,7 @@ class CPSScalaCodeGen extends CPSTraverser {
       emitln("\n}\n}")
       emit(s"loop$index()")
 
+    // Simple computations are generated in direct style.
     case n @ Node(s,"+",List(x,y),_) =>
       emitln(s"val $s = ${quote(x)} + ${quote(y)}"); k
     case n @ Node(s,"-",List(x,y),_) =>
@@ -77,6 +128,14 @@ class CPSScalaCodeGen extends CPSTraverser {
       emitln(s"val $s = ${quote(x)} == ${quote(y)}"); k
     case n @ Node(s,"!=",List(x,y),_) =>
       emitln(s"val $s = ${quote(x)} != ${quote(y)}"); k
+    case n @ Node(s,">",List(x,y), _) =>
+      emitln(s"val $s = ${quote(x)} > ${quote(y)}"); k
+    case n @ Node(s,"<",List(x,y), _) =>
+      emitln(s"val $s = ${quote(x)} < ${quote(y)}"); k
+    case n @ Node(s,">=",List(x,y), _) =>
+      emitln(s"val $s = ${quote(x)} >= ${quote(y)}"); k
+    case n @ Node(s,"<=",List(x,y), _) =>
+      emitln(s"val $s = ${quote(x)} <= ${quote(y)}"); k
     case n @ Node(s,"var_new",List(x),_) =>
       emitln(s"var $s = ${quote(x)}"); k
     case n @ Node(s,"var_get",List(x),_) =>
@@ -89,29 +148,8 @@ class CPSScalaCodeGen extends CPSTraverser {
       emitln(s"val $s = ${quote(x)}(${quote(i)})"); k
     case n @ Node(s,"array_set",List(x,i,y),_) =>
       emitln(s"${quote(x)}(${quote(i)}) = ${quote(y)}"); k
-
-    case n @ Node(s,"@",x::y::_,_) =>
-      if (x.isInstanceOf[Sym] && contSet.contains(x.asInstanceOf[Sym])) {
-        emitln(s"val ${quote(s)} = ${quote(x)}(${quote(y)})"); k
-      }
-      else {
-        val index = fresh
-        emitln(s"def cApp$index($s: Int) = {"); k; emitln("\n}")
-        emitln(s"${quote(x)}(cApp$index, ${quote(y)})")
-      }
-
     case n @ Node(s,"P",List(x),_) =>
       emitln(s"val $s = println(${quote(x)})"); k
-    case n @ Node(s,">",List(x,y), _) =>
-      emitln(s"val $s = ${quote(x)} > ${quote(y)}"); k
-    case n @ Node(s,"<",List(x,y), _) =>
-      emitln(s"val $s = ${quote(x)} < ${quote(y)}"); k
-    case n @ Node(s,">=",List(x,y), _) =>
-      emitln(s"val $s = ${quote(x)} >= ${quote(y)}"); k
-    case n @ Node(s,"<=",List(x,y), _) =>
-      emitln(s"val $s = ${quote(x)} <= ${quote(y)}"); k
-    case n @ Node(s,"λforward",List(x), _) =>
-      emitln(s"lazy val $s = ${quote(x)} _"); k
     case n @ Node(_,_,_,_) =>
       emitln(s"??? " + n.toString); k
   }

--- a/src/main/scala/lms/core/codegen/scala_codegen.scala
+++ b/src/main/scala/lms/core/codegen/scala_codegen.scala
@@ -121,65 +121,23 @@ class ScalaCodeGen extends Traverser {
   }
 }
 
-class CompactScalaCodeGen extends CompactTraverser {
-
+/**
+ * The `CompactScalaCodeGen` is only used for some legacy tests in the repo that
+ * do not start from the stub.scala frontend. As a result, the IR generated do not have
+ * typeMap, thus cannot use the ExtendedCodeGen trait.
+ * FIXME(feiw) Maybe rewrite those legacy tests with the stub.scala frontend, and update
+ *   the tests to use ExtendedScalaCodeGen. Then this CompactScalaCodeGen can be merged
+ *   into ExtendedScalaCodeGen.
+ */
+class CompactScalaCodeGen extends CompactCodeGen {
   def emit(s: String): Unit = print(s)
   def emitln(s: String = ""): Unit = println(s)
 
-  /**
-   * `quote` family of methods are used to emit a codegen unit (a variable, constant, or block)
-   * We have `quote` for variable/const
-   *         `quoteEff` for effects
-   *         `quoteBlock` `quoteBlockP` `quoteElseBlock` for
-   *          block,    block with parenthesis, and else block
-   */
-  // with `rename` `doRename` and the usage of them in `quote`, we may
-  // rename variables (say from x6 to x4).
-  val rename = new mutable.HashMap[Sym,String]
-  var doRename = true
-  def quote(s: Def): String = s match {
-    case s @ Sym(n) if doRename => rename.getOrElseUpdate(s, s"x${rename.size}")
-    case Sym(n) => s.toString
-    case Const(s: String) => "\""+s.replace("\"", "\\\"").replace("\n","\\n").replace("\t","\\t")+"\"" // TODO: more escapes?
-    case Const(x: Char) if x == '\n' => "'\\n'"
-    case Const(x: Char) if x == '\t' => "'\\t'"
-    case Const(x: Char) if x == 0    => "'\\0'"
-    case Const(x: Char) => "'"+x+"'"
-    case Const(x: Long) => x.toString + "L"
+  override def quote(s: Def) = s match {
     case Const(null) => "null"
-    case Const(x) => x.toString
+    case _ => super.quote(s)
   }
 
-  // with `doPrintEffects` and `quoteEff`, we can optionally print the effect information
-  var doPrintEffects = false
-  def quoteEff(x: Def): String =
-    if (!doPrintEffects) ""
-    else " /* " + quote(x) + " */"
-
-  def quoteEff(x: Set[Sym]): String =
-    if (!doPrintEffects) ""
-    else " /* " + x.toSeq.sorted.map(quote).mkString(" ") + " */"
-
-  def quoteEff(x: EffectSummary): String = quoteEff(x.deps)
-
-  def quoteEff(n: Node): String = if (!doPrintEffects) "" else {
-    if (n.eff.isEmpty) "" else {
-      s"/* val ${quote(n.n)} = ${n.eff.repr(quote)} */"
-    }
-  }
-
-  type WrapFun = (Int, Option[Node], Block) => (=> Unit) =>Unit
-  def withWraper(w: WrapFun)(f: => Unit) = {
-    val save = wraper
-    wraper = w
-    f
-    wraper = save // needed?
-  }
-
-  def nowraper(numStms: Int, l: Option[Node], y: Block)(f: => Unit) = f
-  var wraper: WrapFun = nowraper _
-
-  def quoteBlock(f: => Unit): Unit = quoteBlock("")(f)
   def quoteBlock(header: String)(f: => Unit): Unit = {
     def wraper(numStms: Int, l: Option[Node], y: Block)(f: => Unit) = {
       // XXX(GW): for performance, can we omit those checks and just emit { } anyway?
@@ -202,42 +160,7 @@ class CompactScalaCodeGen extends CompactTraverser {
                   else args.mkString("(", ", ", s")$eff => ")
     quoteBlock(argsStr)(traverse(b))
   }
-  def quoteBlockP(f: => Unit): Unit = quoteBlockP(0)(f)
-  def quoteBlockP(prec: Int)(f: => Unit) = {
-    def wraper(numStms: Int, l: Option[Node], y: Block)(f: => Unit) = {
-      val paren = numStms == 0 && l.map(n => precedence(n) < prec).getOrElse(false)
-      if (paren) emit("(") else if (numStms > 0) emitln("{")
-      f
-      if (y.res != Const(())) { shallow(y.res); emit(quoteEff(y.eff)) } else emit(quoteEff(y.eff))
-      if (paren) emit(")") else if (numStms > 0) emit("\n}")
-    }
-    withWraper(wraper _)(f)
-  }
-  def noquoteBlock(f: => Unit) = withWraper(nowraper _)(f)
-  def quoteElseBlock(f: => Unit) = {
-    def wraper(numStms: Int, l: Option[Node], y: Block)(f: => Unit) = {
-      if (numStms > 0) {
-        emitln(" else {")
-        f
-        if (y.res != Const(())) shallow(y.res)
-        emitln(quoteEff(y.eff))
-        emit("}")
-      } else {
-        if (y.res != Const(())) { emit(" else "); shallow(y.res) }
-        emit(quoteEff(y.eff))
-      }
-    }
-    withWraper(wraper _)(f)
-  }
 
-  def precedence(n: Node): Int = n match {
-    case Node(s,"?",List(c,a,b:Block),_) if b.isPure && b.res == Const(false) => precedence("&&")
-    case Node(s,"?",List(c,a:Block,b),_) if a.isPure && a.res == Const(true) => precedence("||")
-    case Node(s,op,List(x),_) if unaryop(op) => unaryPrecedence(op)
-    case _ => precedence(n.op)
-  }
-
-  final def unaryPrecedence(op: String): Int = 12
   def precedence(op: String): Int = op match {
     case "?" => 1
     case "||" => 2
@@ -256,31 +179,7 @@ class CompactScalaCodeGen extends CompactTraverser {
     case _ => 20
   }
 
-  // process and print block results
-  override def traverseCompact(ns: Seq[Node], y: Block): Unit = {
-    wraper(numStms, lastNode, y) {
-      super.traverseCompact(ns, y)
-    }
-  }
-
-  def shallow(n: Def): Unit = n match {
-    case InlineSym(n) => shallow(n)
-    case b:Block => quoteBlock(b)
-    case _ => emit(quote(n))
-  }
-
-  def shallow1(n: Def, prec: Int = 20): Unit = n match {
-    case InlineSym(n) if precedence(n) < prec => emit("("); shallow(n); emit(")")
-    case _ => shallow(n)
-  }
-
-  // generate string for node's right-hand-size
-  // (either inline or as part of val def)
-  // XXX TODO: precedence of nested expressions!!
-  val unaryop = Set("-","!","&")
-  val binop = Set("+","-","*","/","%","==","!=","<",">",">=","<=","&","|","<<",">>", ">>>", "&&", "||", "^")
-  val math = Set("sin", "cos", "tanh", "exp", "sqrt")
-  def shallow(n: Node): Unit = { n match {
+  override def shallow(n: Node): Unit = { n match {
     case n @ Node(f, "λ", (y:Block)::_, _) =>
       // XXX what should we do for functions?
       // proper inlining will likely work better
@@ -289,33 +188,15 @@ class CompactScalaCodeGen extends CompactTraverser {
       // Note: if argument types have to be emitted, ExtendedScalaCodeGen has overrided this case
       quoteBlock(y, true)
 
-    case n @ Node(f,"?",c::(a:Block)::(b:Block)::_,_) =>
-      emit("if ("); shallow(c); emit(") ")
-      quoteBlockP(traverse(a))
-      emit(" else ")
-      quoteBlockP(traverse(b))
-
-    case n @ Node(f,"W",List(c:Block,b:Block),_) =>
-      emit("while ("); quoteBlockP(traverse(c)); emit(") ")
-      quoteBlock(traverse(b))
-
-    case n @ Node(s, op,List(x,y),_) if binop(op) => // associativity??
-      shallow1(x, precedence(op)); emit(" "); emit(op); emit(" "); shallow1(y, precedence(op)+1)
-
-    case n @ Node(s, op,List(x),_) if unaryop(op) => // associativity??
-      emit(op); shallow1(x, unaryPrecedence(op))
-
     case n @ Node(s,op,List(x),_) if math(op) =>
-      emit(s"scala.math.$op("); shallow1(x); emit(")")
+      emit(s"scala.math.$op("); shallowP(x); emit(")")
 
-    case n @ Node(s,"var_get",List(x),_) =>
-      shallow(x)
     case n @ Node(s,"array_get",List(x,i),_) =>
       shallow(x); emit("("); shallow(i); emit(")")
-    case n @ Node(s,"@",x::y,_) =>
-      shallow1(x); emit("("); y.headOption.foreach(h => { shallow1(h, 0); y.tail.foreach(a => { emit(", "); shallow1(a, 0) }) }); emit(")")
+
     case n @ Node(s,"P",List(x),_) =>
       emit("println("); shallow(x); emit(")")
+
     case n @ Node(s,"comment",Const(str: String)::Const(verbose: Boolean)::(b:Block)::_,_) =>
       quoteBlock {
         emitln("//#" + str)
@@ -328,8 +209,8 @@ class CompactScalaCodeGen extends CompactTraverser {
         emitln("//#" + str)
       }
 
-    case n @ Node(_,op,args,_) =>
-      emit(op); emit("("); args.headOption.foreach(h => { shallow1(h, 0); args.tail.foreach(a => { emit(", "); shallow1(a, 0) }) }); emit(")")
+    case _ => super.shallow(n)
+
   }; emit(quoteEff(n)) }
 
   override def traverse(n: Node): Unit = n match {
@@ -349,9 +230,7 @@ class CompactScalaCodeGen extends CompactTraverser {
       emit(s"val ${quote(s)} = new Array[Int]("); shallow(x); emitln(")")
     case n @ Node(s,"array_set",List(x,i,y),_) =>
       shallow(x); emit("("); shallow(i); emit(") = "); shallow(y); emitln("")
-    case _ =>
-      // emit(s"val ${quote(s)} = " + shallow(n))
-      emitValDef(n)
+    case _ => emitValDef(n)
   }
 
   def emitValDef(n: Node): Unit = {
@@ -363,6 +242,7 @@ class CompactScalaCodeGen extends CompactTraverser {
     emitln()
   }
 }
+
 
 trait Pattern
 case class PVar(x: Sym) extends Pattern
@@ -469,9 +349,9 @@ class ExtendedScalaCodeGen extends CompactScalaCodeGen with ExtendedCodeGen {
       */
       quoteBlock(y, true)
     case n @ Node(s,"?",List(c, a: Block, b: Block),_) if b.isPure && b.res == Const(false) =>
-      shallow1(c, precedence("&&")); emit(" && "); quoteBlockP(precedence("&&") + 1)(traverse(a))
+      shallowP(c, precedence("&&")); emit(" && "); quoteBlockP(precedence("&&") + 1)(traverse(a))
     case n @ Node(s,"?",List(c, a: Block, b: Block),_) if a.isPure && a.res == Const(true) =>
-      shallow1(c, precedence("||")); emit(" || "); quoteBlockP(precedence("||") + 1)(traverse(b))
+      shallowP(c, precedence("||")); emit(" || "); quoteBlockP(precedence("||") + 1)(traverse(b))
     case n @ Node(f,"?",c::(a:Block)::(b:Block)::_,_) =>
       emit(s"if ("); shallow(c); emit(") ")
       quoteBlockP(traverse(a))
@@ -484,7 +364,7 @@ class ExtendedScalaCodeGen extends CompactScalaCodeGen with ExtendedCodeGen {
     case n @ Node(s,"var_get",List(x),_) =>
       shallow(x)
     case n @ Node(s,"array_get",List(x,i),_) =>
-      shallow1(x); emit("("); shallow(i); emit(")")
+      shallowP(x); emit("("); shallow(i); emit(")")
     case n @ Node(s,"array_length",List(x), _) =>
       shallow(x); emit(".length")
     case n @ Node(s,"array_free", List(arr), _) => ()
@@ -496,7 +376,7 @@ class ExtendedScalaCodeGen extends CompactScalaCodeGen with ExtendedCodeGen {
         case t::Nil => shallow(t)
         case t::ys  => shallow(t); emit(","); emitArgs(ys)
       }
-      shallow1(x); emit("("); emitArgs(y); emit(")")
+      shallowP(x); emit("("); emitArgs(y); emit(")")
     }
     case n @ Node(s,"P",List(x),_) =>
       emit("println"); emit("("); shallow(x); emit(")")
@@ -520,10 +400,10 @@ class ExtendedScalaCodeGen extends CompactScalaCodeGen with ExtendedCodeGen {
       shallow(n.copy(op = nameMap(n.op)))
 
     // case n @ Node(s,op,List(x),_) if numTypeConv(op) =>
-    //   shallow1(x); emit(s".$op")
+    //   shallowP(x); emit(s".$op")
     case n @ Node(s, "cast", a::_, _) =>
       val tpe = remap(typeMap.getOrElse(s, manifest[Unknown]))
-      shallow1(a); emit(s".to$tpe")
+      shallowP(a); emit(s".to$tpe")
 
     case n @ Node(s,op,args,_) if op.startsWith("unchecked") => // unchecked
       var next = 9 // skip unchecked
@@ -538,7 +418,7 @@ class ExtendedScalaCodeGen extends CompactScalaCodeGen with ExtendedCodeGen {
 
     case n @ Node(s,op,args,_) if op.contains('.') && !op.contains(' ') => // method call
       val (recv::args1) = args
-      shallow1(recv); emit("."); emit(op.drop(op.lastIndexOf('.')+1))
+      shallowP(recv); emit("."); emit(op.drop(op.lastIndexOf('.')+1))
       if (args1.nonEmpty) {
         emit("(")
         shallow(args1.head)
@@ -548,7 +428,7 @@ class ExtendedScalaCodeGen extends CompactScalaCodeGen with ExtendedCodeGen {
         emit(")")
       }
     case n @ Node(s, "timestamp", _, _) => emitln(s"System.nanoTime / 1000L")
-    case n @ Node(s, "array_sort_scala", List(arr, l), _) => shallow1(arr); emit(".slice(0, "); shallow1(l); emitln(").sorted")
+    case n @ Node(s, "array_sort_scala", List(arr, l), _) => shallowP(arr); emit(".slice(0, "); shallowP(l); emitln(").sorted")
 
     case _ => super.shallow(n)
   }
@@ -594,7 +474,7 @@ class ExtendedScalaCodeGen extends CompactScalaCodeGen with ExtendedCodeGen {
       }
       emitln("\n//# " + str)
     case n @ Node(_, "switch", guard::default::others, _) =>
-      shallow1(guard); emitln(" match {");
+      shallowP(guard); emitln(" match {");
       others.grouped(2).foreach {
         case List(Const(cases: Seq[Const]), block: Block) =>
           emit("case "); emit(quote(cases.head)); cases.tail.foreach(x => emit(s" | ${quote(x)}")); emitln(" =>")

--- a/src/main/scala/lms/core/traversal.scala
+++ b/src/main/scala/lms/core/traversal.scala
@@ -29,7 +29,7 @@ abstract class Traverser {
 
 
   // This `bound` is used to track the dependent bound variable of each node
-  // See the implementation in lms-clean/src/main/scala/lms/core/backend.scala `class Bound`
+  // See the implementation in src/main/scala/lms/core/backend.scala `class Bound`
   // It is initialized in the `apply()` function of this class
   val bound = new Bound
 

--- a/src/main/scala/lms/core/traversal.scala
+++ b/src/main/scala/lms/core/traversal.scala
@@ -74,7 +74,7 @@ abstract class Traverser {
   // This `withResetScope` function maintains the old `inner` when entering a new block
   // with new `inner` (as paramtere `ns`).
   // It is so far only used in test6_tensors.scala for ???
-  def withResetScope[T](p: List[Sym], ns: Seq[Node])(b: =>T): T = {
+  def withResetScope[T](p: List[Sym], ns: Seq[Node])(b: => T): T = {
     assert(path.takeRight(p.length) == p, s"$path -- $p")
     val inner0 = inner
     inner = ns

--- a/src/main/scala/lms/core/traversal.scala
+++ b/src/main/scala/lms/core/traversal.scala
@@ -138,7 +138,7 @@ abstract class Traverser {
           reach ++= hardSyms(d)
         }
       }
-      if (reachInner contains d.n) {
+      if (reachInner.contains(d.n)) {
         reachInner ++= hardSyms(d)
       }
     }

--- a/src/main/scala/lms/core/traversal.scala
+++ b/src/main/scala/lms/core/traversal.scala
@@ -45,7 +45,7 @@ abstract class Traverser {
   var inner: Seq[Node] = _
 
   // This `blockEffectPath` is currently unused.
-  val blockEffectPath = new mutable.HashMap[Block,Set[Exp]]
+  val blockEffectPath = new mutable.HashMap[Block, Set[Exp]]
 
   // This `withScope` function maintains the old `path` and `inner` when entering a new block
   // with new `path` (as parameter `p`) and new `inner` (as parameter `ns`).

--- a/src/main/scala/lms/core/traversal.scala
+++ b/src/main/scala/lms/core/traversal.scala
@@ -28,40 +28,84 @@ abstract class Traverser {
   }
 
 
+  // This `bound` is used to track the dependent bound variable of each node
+  // See the implementation in lms-clean/src/main/scala/lms/core/backend.scala `class Bound`
+  // It is initialized in the `apply()` function of this class
   val bound = new Bound
 
+  // This `path` is used to track the available bound variables at the current block
+  // New Syms are pushed when entering a new block, and popped when exiting a block
+  // Its content is maintained by the `withScope` family of functions.
   var path = List[Sym]()
+  // This `inner` is used to track the current unscheduled nodes for this block.
+  // For each block, the `inner` is split into 2 groups, the first one to be scheduled in this block,
+  //    and the second one to be scheduled later.
+  // This splitting is done via the `scheduleBlock_` function.
+  // Just as the `path`, the content of `inner` is maintained via the `withScope` family of functions.
   var inner: Seq[Node] = _
+
+  // This `blockEffectPath` is currently unused.
   val blockEffectPath = new mutable.HashMap[Block,Set[Exp]]
 
+  // This `withScope` function maintains the old `path` and `inner` when entering a new block
+  // with new `path` (as parameter `p`) and new `inner` (as parameter `ns`).
+  // The block function `b` takes no parameters
   def withScope[T](p: List[Sym], ns: Seq[Node])(b: =>T): T = {
     val (path0, inner0) = (path, inner)
     path = p; inner = ns;
     try b finally { path = path0; inner = inner0 }
   }
 
-  def withScope1[T](p: List[Sym], ns: Seq[Node])(b: (List[Sym], Seq[Node]) => T): T = {
+  // This `withScopeCPS` function maintains the old `path` and `inner` when entering a new block
+  // with new `path` (as parameter `p`) and new `inner` (as parameter `ns`).
+  // The block function `b` take a pair of `path` and `inner` as parameters,
+  // which are feed with the old `path` and `inner` values.
+  // This might seem to be a strange "scoping behavior". Indeed, it is used for CPSTraverser/Transformer.
+  // The reason is in continuation-passing style (CPS), the control flow never comes back to the old scope.
+  // Instead, it keeps calling the continuations. As the continuations need to use the "old" environment,
+  // we have to pass the "old" environment to the `b`.
+  // Checkout the `CPSTraverser` and `CPSTransformer` below for more details.
+  def withScopeCPS[T](p: List[Sym], ns: Seq[Node])(b: (List[Sym], Seq[Node]) => T): T = {
     val (path0, inner0) = (path, inner)
     path = p; inner = ns;
     try b(path0, inner0) finally { path = path0; inner = inner0 }
   }
 
+  // This `withResetScope` function maintains the old `inner` when entering a new block
+  // with new `inner` (as paramtere `ns`).
+  // It is so far only used in test6_tensors.scala for ???
   def withResetScope[T](p: List[Sym], ns: Seq[Node])(b: =>T): T = {
     assert(path.takeRight(p.length) == p, s"$path -- $p")
     val inner0 = inner
     inner = ns
     try b finally { inner = inner0 }
-
   }
 
-  def focus[T](y: Block, extra: Sym*)(f: (Seq[Node], Block) => T): T =
-    focus0(y, extra: _*) { (path1, inner1, outer1, y) =>
+  // This `scheduleBlock` function wraps on the `scheduleBlock_` function, while
+  // applying the logic of setting new path (`path1`) and new inner (`inner1`) environment,
+  // and traversing nodes for the current block: `traverse(outer1, y)`
+  def scheduleBlock[T](y: Block, extra: Sym*)(traverse: (Seq[Node], Block) => T): T =
+    scheduleBlock_(y, extra: _*) { (path1, inner1, outer1, y) =>
       withScope(path1, inner1) {
-        f(outer1, y)
+        traverse(outer1, y)
       }
     }
 
-  def focus0[T](y: Block, extra: Sym*)(f: (List[Sym], Seq[Node], Seq[Node], Block) => T): T = {
+  /**
+   * This `scheduleBlock_` is the core function in traversal. The main purpose of this function is to
+   * separate the currently unscheduled nodes into the `outer1` and `inner1`, where
+   * `outer1` is to be scheduled for the current block, and `inner1` is to be scheduled later.
+   * It should be noted that this is strongly tied to the fact that LMS IR uses `sea-of-node`
+   * representation, where the blocks do not explicitly scope the nodes. Instead, the nodes
+   * in each block are collected lazily from this scheduleBlock_ function, from the result and effects
+   * of the (to be scheduled) block.
+   * The function takes another function `f` as curried parameter, which is applied with
+   * the new path, new inner, new outer, and the block.
+   */
+  def scheduleBlock_[T](y: Block, extra: Sym*)(f: (List[Sym], Seq[Node], Seq[Node], Block) => T): T = {
+
+    // when entering a block, we get more bound variables (from the block and possibly supplimented
+    // via `extra)
     val path1 = y.bound ++ extra.toList ++ path
 
     // a node is available if all bound vars
@@ -73,27 +117,28 @@ abstract class Traverser {
     // warm path (not only via if/else branches)
     val g = new Graph(inner, y, null)
 
+    // Step 1: compute `reach` and `reachInner`
+    // These are nodes that are reachable from for the current block and for an inner block
+    // We start from `y.used`, where `y` is the current block as seeds, and back track all
+    // nodes that are hard-depended from the seeds.
+    // The `reachInner` is seeded by reachable Syms that have low frequency.
     val reach = new mutable.HashSet[Sym]
     val reachInner = new mutable.HashSet[Sym]
-
     reach ++= y.used
 
-    // for (d <- g.nodes) {
-    //   println("check "+d + " " + bound.hm(d.n) + " " + path1.toSet + " " + reach(d.n) + " " + available(d))
-    // }
-
     for (d <- g.nodes.reverseIterator) {
-      if ((reach contains d.n)) {
+      if (reach contains d.n) {
         if (available(d)) {
           // node will be sched here, don't follow if branches!
           // other statement will be scheduled in an inner block
           for ((e:Sym,f) <- symsFreq(d))
             if (f > 0.5) reach += e else reachInner += e
         } else {
+          // QUESTION(feiw): why we don't split via frequency here?
           reach ++= hardSyms(d)
         }
       }
-      if (reachInner(d.n)) {
+      if (reachInner contains d.n) {
         reachInner ++= hardSyms(d)
       }
     }
@@ -149,10 +194,18 @@ abstract class Traverser {
     def scheduleHere(d: Node) =
       available(d) && reach(d.n)
 
+    // Step 2: with the computed `reach` and `reachInner`, we can split the nodes
+    // to `outer1` (for current block) and `inner1` (for inner blocks)
+    // The logic is simply: `outer1` has nodes that are reachable and available.
     var outer1 = Seq[Node]()
     var inner1 = Seq[Node]()
 
     // Extra reachable statement from soft dependencies
+    // It is important to track softDeps too because if we don't, the soft-dependent
+    //   nodes might go to `inner1` and be scheduled after the node that soft-depends on it.
+    // If a node is only soft-depended by other nodes, we make sure that we can remove it
+    //   by DCE pass before traversal passes. (see DeadCodeElimCG class in codegen.scala)
+    // the test "extraThroughSoft_is_necessary" show cases the importance of `extraThroughSoft`.
     val extraThroughSoft = new mutable.HashSet[Sym]
     for (n <- inner.reverseIterator) {
       if (reach(n.n) || extraThroughSoft(n.n)) {
@@ -170,6 +223,7 @@ abstract class Traverser {
       }
     }
 
+    // These Prints Are Very Useful for Debugging!
     // System.out.println(s"================ $y ==============")
     // for (n <- inner)
     //   System.out.println(s"\t$n")
@@ -188,20 +242,15 @@ abstract class Traverser {
   }
 
   def traverse(b: Block, extra: Sym*): Unit = {
-    focus(b, extra:_*)(traverse)
+    scheduleBlock(b, extra:_*)(traverse)
   }
 
-  def getFreeVarBlock(y: Block, extra: Sym*): Set[Sym] = focus(y, extra:_*) { (ns: Seq[Node], res: Block) =>
+  def getFreeVarBlock(y: Block, extra: Sym*): Set[Sym] = scheduleBlock(y, extra:_*) { (ns: Seq[Node], res: Block) =>
     val used = new mutable.HashSet[Sym]
     val bound = new mutable.HashSet[Sym]
     used ++= y.used
     bound ++= path
-    for (n <- inner) {
-      used ++= syms(n)
-      bound += n.n
-      bound ++= boundSyms(n)
-    }
-    for (n <- ns) {
+    for (n <- ns ++ inner) {
       used ++= syms(n)
       bound += n.n
       bound ++= boundSyms(n)
@@ -232,8 +281,8 @@ abstract class Traverser {
 abstract class CPSTraverser extends Traverser {
 
   def traverse(y: Block, extra: Sym*)(k: Exp => Unit): Unit =
-    focus0(y, extra: _*) { (path1, inner1, outer1, y) =>
-      withScope1(path1, inner1) { (path0, inner0) =>
+    scheduleBlock_(y, extra: _*) { (path1, inner1, outer1, y) =>
+      withScopeCPS(path1, inner1) { (path0, inner0) =>
         traverse(outer1, y){ v => withScope(path0, inner0)(k(v)) }
       }
     }
@@ -249,8 +298,7 @@ abstract class CPSTraverser extends Traverser {
     case n @ Node(f, "λ", (y:Block)::_, _) =>
       traverse(y, f)(v => k)
     case n @ Node(f, op, es, _) =>
-      val blocks = es.filter{ case Block(_,_,_,_) => true; case _ => false}.map(_.asInstanceOf[Block])
-      traverse(blocks)(k)
+      traverse(blocks(n))(k)
   }
 
   def apply(g: Graph)(k: Int): Unit = {
@@ -500,8 +548,8 @@ abstract class CPSTransformer extends Transformer {
   }
 
   def traverse(y: Block, extra: Sym*)(k: Exp => Exp): Exp =
-    focus0(y, extra: _*) { (path1, inner1, outer1, y) =>
-      withScope1(path1, inner1) { (path0, inner0) =>
+    scheduleBlock_(y, extra: _*) { (path1, inner1, outer1, y) =>
+      withScopeCPS(path1, inner1) { (path0, inner0) =>
         traverse(outer1, y){ v => withScope(path0, inner0)(k(v)) }
       }
     }

--- a/src/main/scala/lms/core/traversal.scala
+++ b/src/main/scala/lms/core/traversal.scala
@@ -278,8 +278,18 @@ abstract class Traverser {
 
 }
 
+/**
+ * CPSTraverser is an adaptation of regular Traverser, where the traverse calls
+ * are carried out in Continuation-Passing Style (CPS). The CPS style is featured
+ * by the `k` parameter of each `traverse` function, which is the `continuation`
+ * after each `traverse` function. The main idea is that for each `traverse` call,
+ * what needs to happen after are captured in the `continuation`, such that when
+ * a `traverse` function returns, the traverse of all the nodes are done already.
+ */
 abstract class CPSTraverser extends Traverser {
 
+  // Note that the continuation of `traverse(block)` need to use the original
+  // `path0` and `inner0`, as shown in the `(v => withScope(path0, inner0)(k(v)))`
   def traverse(y: Block, extra: Sym*)(k: Exp => Unit): Unit =
     scheduleBlock_(y, extra: _*) { (path1, inner1, outer1, y) =>
       withScopeCPS(path1, inner1) { (path0, inner0) =>
@@ -287,6 +297,8 @@ abstract class CPSTraverser extends Traverser {
       }
     }
 
+  // Similarly, when traversing a list of nodes or blocks (the next function),
+  // the rest of the blocks are traversed in the continuation of the first node/block
   def traverse(ns: Seq[Node], y: Block)(k: Exp => Unit): Unit = {
     if (!ns.isEmpty) traverse(ns.head)(traverse(ns.tail, y)(k)) else k(y.res)
   }

--- a/src/main/scala/lms/core/traversal.scala
+++ b/src/main/scala/lms/core/traversal.scala
@@ -50,7 +50,7 @@ abstract class Traverser {
   // This `withScope` function maintains the old `path` and `inner` when entering a new block
   // with new `path` (as parameter `p`) and new `inner` (as parameter `ns`).
   // The block function `b` takes no parameters
-  def withScope[T](p: List[Sym], ns: Seq[Node])(b: =>T): T = {
+  def withScope[T](p: List[Sym], ns: Seq[Node])(b: => T): T = {
     val (path0, inner0) = (path, inner)
     path = p; inner = ns;
     try b finally { path = path0; inner = inner0 }

--- a/src/out/backend/extraThroughSoft_is_necessary.check.c
+++ b/src/out/backend/extraThroughSoft_is_necessary.check.c
@@ -1,0 +1,26 @@
+/*****************************************
+Emitting C Generated Code
+*******************************************/
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+/**************** Snippet ****************/
+void Snippet(int x0) {
+  int* x1 = (int*)malloc((x0 + 3) * sizeof(int));
+  int x2 = x1[x0];
+  x1[x0] = 5;
+  if (x0 == 0) printf("%d\n", x2);
+  printf("%d", x1[x0 + 2]);
+}
+/*****************************************
+End of C Generated Code
+*******************************************/
+int main(int argc, char *argv[]) {
+  if (argc != 2) {
+    printf("usage: %s <arg>\n", argv[0]);
+    return 0;
+  }
+  Snippet(atoi(argv[1]));
+  return 0;
+}

--- a/src/test/scala/lms/core/test_arrays.scala
+++ b/src/test/scala/lms/core/test_arrays.scala
@@ -212,4 +212,18 @@ class ArrayTest extends TutorialFunSuite {
     }
     check("array_opt_set_equal", driver.code, "c")
   }
+
+  test("extraThroughSoft_is_necessary") {
+    val driver = new DslDriverC[Int,Unit] {
+      @virtualize
+      def snippet(in: Rep[Int]) = {
+        val x = NewArray[Int](in + 3)
+        val y = x(in)
+        x(in) = 5
+        if (in == 0) printf("%d\n", y)
+        printf("%d", x(in + 2))
+      }
+    }
+    check("extraThroughSoft_is_necessary", driver.code, "c")
+  }
 }


### PR DESCRIPTION
the most important refactoring is that I split the CompactScalaCodeGen into 2 classes, where the non-scala-specific part is refactored into CompactCodeGen. Then the ExtendedCCodeGen just extend the CompactCodeGen :) 