### PR TITLE
[Backend] fun: partially fix lambda forward effect

### DIFF
--- a/src/main/scala/lms/core/backend.scala
+++ b/src/main/scala/lms/core/backend.scala
@@ -369,8 +369,8 @@ class GraphBuilder {
   def getFunctionLatentEffect(f: Exp): ((Set[Exp], Set[Exp]),(Set[Int], Set[Int]), Option[Exp]) = findDefinition(f) match {
       case Some(Node(_, "λ", (b:Block)::_, _)) =>
         getEffKeysWithParam(b)
-      case Some(Node(_, "λforward", _, _)) => // what about doubly recursive?
-        ((Set[Exp](), Set[Exp](Const("CTRL"))), (Set[Int](), Set[Int]()), None)
+      case Some(Node(_, "λforward", xf::Const(arity:Int)::Nil, _)) => // what about doubly recursive?
+        ((Set[Exp](), Set[Exp](Const("CTRL"))), (0.until(arity).toSet, 0.until(arity).toSet), None)
       case None => // FIXME: function argument? fac-01 test used for recursive function...
         ((Set[Exp](), Set[Exp](Const("CTRL"))), (Set[Int](), Set[Int]()), None)
       case Some(Node(_, "@", (f: Sym)+:args, _)) =>

--- a/src/main/scala/lms/core/backend.scala
+++ b/src/main/scala/lms/core/backend.scala
@@ -369,7 +369,13 @@ class GraphBuilder {
   def getFunctionLatentEffect(f: Exp): ((Set[Exp], Set[Exp]),(Set[Int], Set[Int]), Option[Exp]) = findDefinition(f) match {
       case Some(Node(_, "λ", (b:Block)::_, _)) =>
         getEffKeysWithParam(b)
-      case Some(Node(_, "λforward", xf::Const(arity:Int)::Nil, _)) => // what about doubly recursive?
+      case Some(Node(_, "λforward", xf::Const(arity:Int)::Nil, _)) =>
+        // for lambdaforward, there are several options:
+        // 1. take the effect of `xf`. However, this is very tricky since `xf` node is not yet constructed at this moment
+        //    (maybe block of the `xf` function is not yet reified), and the application of lambda-forward might just be part of that block
+        // 2. stop the world effect, which is safe. FIXME(feiw): how to implement it?
+        // 3. temp solution: add read write effects to all arguments.
+        // what about doubly recursive?
         ((Set[Exp](), Set[Exp](Const("CTRL"))), (0.until(arity).toSet, 0.until(arity).toSet), None)
       case None => // FIXME: function argument? fac-01 test used for recursive function...
         ((Set[Exp](), Set[Exp](Const("CTRL"))), (Set[Int](), Set[Int]()), None)

--- a/src/main/scala/lms/core/codegen/C_codegen.scala
+++ b/src/main/scala/lms/core/codegen/C_codegen.scala
@@ -400,7 +400,7 @@ class ExtendedCCodeGen extends CompactCodeGen with ExtendedCodeGen {
       shallow(x) // FIXME(feiw): this is currently wrong: should have array copy
     case n @ Node(s,op,args,_) if nameMap contains op =>
       shallow(n.copy(op = nameMap(n.op)))
-    case n @ Node(f, "λforward",List(y),_) => ??? // this case is short cut at traverse function!
+    case n @ Node(f, "λforward", _, _) => ??? // this case is short cut at traverse function!
     case n @ Node(s,op,args,_) if op.startsWith("unchecked") => // unchecked
       var next = 9 // skip unchecked
       for (a <- args) {
@@ -519,7 +519,7 @@ class ExtendedCCodeGen extends CompactCodeGen with ExtendedCodeGen {
         traverse(b)
       }
       emitln(";\n//# " + str)
-    case n @ Node(s, "λforward", List(y), _) =>
+    case n @ Node(s, "λforward", List(y, arity), _) =>
       emitln("//# lambda forward is here!")
       // for this case, adding (f, y) in forwardMap is all we need
       // XXX: this is most likely not enough in the general case

--- a/src/main/scala/lms/core/codegen/cps_codegen.scala
+++ b/src/main/scala/lms/core/codegen/cps_codegen.scala
@@ -66,7 +66,7 @@ class CPSScalaCodeGen extends CPSTraverser {
       k
 
     // "λforward" is the used for recursive functions (as a function name declaration)
-    case n @ Node(s,"λforward",List(x), _) =>
+    case n @ Node(s,"λforward",List(x, arity), _) =>
       emitln(s"lazy val $s = ${quote(x)} _"); k
 
     // application needs to be split into 2 cases: function appliation and continuation application

--- a/src/main/scala/lms/core/codegen/scala_codegen.scala
+++ b/src/main/scala/lms/core/codegen/scala_codegen.scala
@@ -91,7 +91,7 @@ class ScalaCodeGen extends Traverser {
       emit(s"val $s = ${quote(x)} >= ${quote(y)}")
     case n @ Node(s,"<=",List(x,y), _) =>
       emit(s"val $s = ${quote(x)} <= ${quote(y)}")
-    case n @ Node(s,"λforward",List(x), _) =>
+    case n @ Node(s,"λforward",List(x, arity), _) =>
       emit(s"lazy val $s = ${quote(x)} _")
     case n @ Node(s, "define_exit", _, _) =>
       emit(s"def exit(res: Int): Int = res")
@@ -352,7 +352,7 @@ class ExtendedScalaCodeGen extends CompactScalaCodeGen with ExtendedCodeGen {
   // (either inline or as part of val def)
   // XXX TODO: precedence of nested expressions!!
   override def shallow(n: Node): Unit = n match {
-    case n @ Node(f,"λforward",List(y),_) => emit(quote(y))
+    case n @ Node(f,"λforward",List(y, arity),_) => emit(quote(y))
     case n @ Node(f, "λ", (y:Block)::_, _) =>
       // XXX what should we do for functions?
       // proper inlining will likely work better

--- a/src/main/scala/lms/core/stub.scala
+++ b/src/main/scala/lms/core/stub.scala
@@ -361,7 +361,7 @@ trait Base extends EmbeddedControls with OverloadHack with lms.util.ClosureCompa
         // Step 1. set up "λforward" node with 2 new fresh Syms
         val fn = Backend.Sym(Adapter.g.fresh)
         val fn1 = Backend.Sym(Adapter.g.fresh)
-        Adapter.g.reflect(fn, "λforward", fn1)()
+        Adapter.g.reflect(fn, "λforward", fn1, Backend.Const(arity))()
 
         // Step 2. register (fn, can) in funTable, so that recursive calls
         //    will find fn as the function Sym. Reify the block.

--- a/src/main/scala/lms/core/traversal.scala
+++ b/src/main/scala/lms/core/traversal.scala
@@ -629,12 +629,12 @@ abstract class CPSTransformer extends Transformer {
       val cont = reflectHelper(es, "λ", g.reify{e => subst(s) = e; k})
       withSubst(s)(reflectHelper(es, "@", transform(x), cont, transform(y)))
 
-    case Node(s,"λforward",List(y:Sym), _) =>
+    case Node(s,"λforward",List(y:Sym, arity), _) =>
       assert(!(subst contains y), "should not have handled lambda yet")
       val sFrom = Sym(g.fresh); val sTo = Sym(g.fresh)
       subst(s) = sFrom; subst(y) = sTo
       forwardMap(sTo) = sFrom
-      g.reflect(sFrom, "λforward", sTo)()
+      g.reflect(sFrom, "λforward", sTo, arity)()
       k
 
     case Node(s,op,rs,es) =>
@@ -670,7 +670,7 @@ abstract class SelectiveCPSTransformer extends CPSTransformer {
 
     case Node(s,"shift1",List(y:Block),_) => super.traverse(n)(k)
     case Node(s,"reset1",List(y:Block),_) => super.traverse(n)(k)
-    case Node(s,"λforward",List(y:Sym), _) => super.traverse(n)(k)
+    case Node(s,"λforward", _, _) => super.traverse(n)(k)
     case Node(f,"?",c::(a:Block)::(b:Block)::_,es) if (es.keys contains Adapter.CPS) => super.traverse(n)(k)
     case Node(f,"W",(c:Block)::(b:Block)::e, es) if (es.keys contains Adapter.CPS) => super.traverse(n)(k)
     // the es.keys of "@" node may have Adapter.CPS, if and only if the lambda has Adapter.CPS

--- a/src/out/backend/recursion_lambda_forward_effect.check.scala
+++ b/src/out/backend/recursion_lambda_forward_effect.check.scala
@@ -1,0 +1,30 @@
+/*****************************************
+Emitting Generated Code
+*******************************************/
+class Snippet() extends (Int => Unit) {
+  def apply(x0: Int): Unit = {
+    var x1: Array[Int] = null.asInstanceOf[Array[Int]]
+    var x2: scala.Function2[Int, Array[Int], Unit] = null.asInstanceOf[scala.Function2[Int, Array[Int], Unit]]
+    x1 = Array(1, 1, 1, 1, 1)
+    x2 = x3
+    def x3(x4: Int, x5: Array[Int]): Unit = {
+      printf("%d\n", x5(x4))
+      if (x4 > 0) {
+        val x6 = Array(x4, x4, x4, x4, x4)
+        val x7 = x4 - 1
+        x6(x7) = 100
+        x2(x7,x6)
+      }
+    }
+    x3(3,x1)
+  }
+}
+/*****************************************
+End of Generated Code
+*******************************************/
+// output:
+compilation: ok
+1
+100
+100
+100

--- a/src/test/scala/lms/core/test_lambda.scala
+++ b/src/test/scala/lms/core/test_lambda.scala
@@ -409,6 +409,29 @@ class LambdaTest extends TutorialFunSuite {
     })
   }
 
+  test("recursion_lambda_forward_effect") {
+    val driver = new DslDriver[Int,Unit] {
+      @virtualize
+      def snippet(a: Rep[Int]) = {
+        lazy val f: Rep[(Int, Array[Int]) => Unit] = fun { (c: Rep[Int], x: Rep[Array[Int]]) =>
+          printf("%d\n", x(c))
+          if (c > 0) {
+            val na = Array(c,c,c,c,c)
+            na(c-1) = 100 // this line of code is removed :(
+            f(c-1, na)
+          }
+        }
+        val arr = Array(1,1,1,1,1)
+        f(3, arr)
+      }
+    }
+    checkOut("recursion_lambda_forward_effect", "scala", {
+      println(driver.code)
+      println("// output:")
+      driver.eval(7)
+    })
+  }
+
   test("mutual_recursion") {
     val driver = new DslDriver[Int,Unit] {
       @virtualize

--- a/src/test/scala/lms/core/test_lambda.scala
+++ b/src/test/scala/lms/core/test_lambda.scala
@@ -417,7 +417,7 @@ class LambdaTest extends TutorialFunSuite {
           printf("%d\n", x(c))
           if (c > 0) {
             val na = Array(c,c,c,c,c)
-            na(c-1) = 100 // this line of code is removed :(
+            na(c-1) = 100 // this line of code should not be removed!
             f(c-1, na)
           }
         }


### PR DESCRIPTION
Previously `lambda forward` just has `CTRL` latent effect, which might intend to be `stop-the-world-effect` but is not really. I wrote a test (added in this PR) to probe the wrong behavior.

I am not sure what the right way to fix it is:
1. accurate computation of lambda forward latent effect seems overly complex
2. a real stop-of-the-world effect is needed, but how to implement it?
3. temp solution in this PR is to enforce read/write effects to all arguments. I am composing it as a partial step toward a `stop-of-the-world` effect, and also proves that it fixes my test (and probably some Lantern tests as well).
4. should be able to be precise or conservative or optimistic (be able to choose).