### PR TITLE
Reformat using `scalafmt`

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,10 @@
+version = 2.6.4
+maxColumn = 120
+align.preset = none
+assumeStandardLibraryStripMargin = true
+align.stripMargin = true
+optIn.configStyleArguments = true
+runner.optimizer.forceConfigStyleOnOffset = 5
+runner.optimizer.forceConfigStyleMinArgCount = 10
+newlines.alwaysBeforeMultilineDef = false
+newlines.alwaysBeforeElseAfterCurlyIf = false

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0") // "2.4.0" is just sbt plugin version

--- a/src/main/scala/lms/collection/ArrayOps.scala
+++ b/src/main/scala/lms/collection/ArrayOps.scala
@@ -10,28 +10,43 @@ import lms.macros.SourceContext
 
 trait ArrayOps { b: Base =>
 
-  def NewArray[T:Manifest](x: Rep[Int]): Rep[Array[T]] = {
+  def NewArray[T: Manifest](x: Rep[Int]): Rep[Array[T]] = {
     Wrap[Array[T]](Adapter.g.reflectMutable("NewArray", Unwrap(x)))
   }
-  def Array[T:Manifest](xs: Rep[T]*): Rep[Array[T]] = {
-    Wrap[Array[T]](Adapter.g.reflectMutable("Array", xs.map(Unwrap(_)):_*))
+  def Array[T: Manifest](xs: Rep[T]*): Rep[Array[T]] = {
+    Wrap[Array[T]](Adapter.g.reflectMutable("Array", xs.map(Unwrap(_)): _*))
   }
-  implicit class ArrayOps[A:Manifest](x: Rep[Array[A]]) {
-    def apply(i: Rep[Int]): Rep[A] = x match {
-      case Wrap(_) => Wrap[A](Adapter.g.reflectRead("array_get", Unwrap(x), Unwrap(i))(Unwrap(x)))
-      case EffectView(x, base) => Wrap[A](Adapter.g.reflectRead("array_get", Unwrap(x), Unwrap(i))(Unwrap(base)))
-    }
-    def update(i: Rep[Int], y: Rep[A]): Unit = x match {
-      case Wrap(_) => Adapter.g.reflectWrite("array_set", Unwrap(x), Unwrap(i), Unwrap(y))(Unwrap(x))
-      case EffectView(x, base) => Adapter.g.reflectWrite("array_set", Unwrap(x), Unwrap(i), Unwrap(y))(Unwrap(base))
-    }
+  implicit class ArrayOps[A: Manifest](x: Rep[Array[A]]) {
+    def apply(i: Rep[Int]): Rep[A] =
+      x match {
+        case Wrap(_) => Wrap[A](Adapter.g.reflectRead("array_get", Unwrap(x), Unwrap(i))(Unwrap(x)))
+        case EffectView(x, base) => Wrap[A](Adapter.g.reflectRead("array_get", Unwrap(x), Unwrap(i))(Unwrap(base)))
+      }
+    def update(i: Rep[Int], y: Rep[A]): Unit =
+      x match {
+        case Wrap(_) => Adapter.g.reflectWrite("array_set", Unwrap(x), Unwrap(i), Unwrap(y))(Unwrap(x))
+        case EffectView(x, base) => Adapter.g.reflectWrite("array_set", Unwrap(x), Unwrap(i), Unwrap(y))(Unwrap(base))
+      }
     def length: Rep[Int] = Wrap[Int](Adapter.g.reflect("array_length", Unwrap(x)))
-    def slice(s: Rep[Int], e: Rep[Int]): Rep[Array[A]] = EffectView[Array[A]](Wrap[Array[A]](Adapter.g.reflect("array_slice", Unwrap(x), Unwrap(s), Unwrap(e))), x) // (Unwrap(x), Adapter.STORE)())
+    def slice(s: Rep[Int], e: Rep[Int]): Rep[Array[A]] =
+      EffectView[Array[A]](
+        Wrap[Array[A]](Adapter.g.reflect("array_slice", Unwrap(x), Unwrap(s), Unwrap(e))),
+        x
+      ) // (Unwrap(x), Adapter.STORE)())
     def free: Unit = Adapter.g.reflectFree("array_free", Unwrap(x))(Unwrap(x))
-    def copyToArray(arr: Rep[Array[A]], start: Rep[Int], len: Rep[Int]) = Adapter.g.reflectEffect("array_copyTo", Unwrap(x), Unwrap(arr), Unwrap(start), Unwrap(len))(Unwrap(x))(Unwrap(arr))
-    def copyToLongArray(arr: Rep[LongArray[A]], start: Rep[Long], len: Rep[Int]) = Adapter.g.reflectEffect("array_copyTo", Unwrap(x), Unwrap(arr), Unwrap(start), Unwrap(len))(Unwrap(x))(Unwrap(arr))
+    def copyToArray(arr: Rep[Array[A]], start: Rep[Int], len: Rep[Int]) =
+      Adapter.g.reflectEffect("array_copyTo", Unwrap(x), Unwrap(arr), Unwrap(start), Unwrap(len))(Unwrap(x))(
+        Unwrap(arr)
+      )
+    def copyToLongArray(arr: Rep[LongArray[A]], start: Rep[Long], len: Rep[Int]) =
+      Adapter.g.reflectEffect("array_copyTo", Unwrap(x), Unwrap(arr), Unwrap(start), Unwrap(len))(Unwrap(x))(
+        Unwrap(arr)
+      )
     // FIXME: currently copy!!
-    def sort(size: Rep[Int] /* , sort: (Rep[A], Rep[A]) => Rep[Int] */) = Wrap[Array[A]](Adapter.g.reflectMutable("array_sort_scala", Unwrap(x), Unwrap(size))) //, Adapter.g.reify((x, y) => Unwrap(sort(Wrap[A](x), Wrap[A](y)))))(Unwrap(x))(Unwrap(x))
+    def sort(size: Rep[Int] /* , sort: (Rep[A], Rep[A]) => Rep[Int] */ ) =
+      Wrap[Array[A]](
+        Adapter.g.reflectMutable("array_sort_scala", Unwrap(x), Unwrap(size))
+      ) //, Adapter.g.reify((x, y) => Unwrap(sort(Wrap[A](x), Wrap[A](y)))))(Unwrap(x))(Unwrap(x))
   }
   implicit class CharArrayOps(x: Rep[Array[Char]]) {
     def ArrayOfCharToString(): Rep[String] = {
@@ -40,25 +55,33 @@ trait ArrayOps { b: Base =>
   }
 
   trait LongArray[+T]
-  def NewLongArray[T:Manifest](x: Rep[Long], init: Option[Int] = None): Rep[LongArray[T]] = init match {
-    case Some(v) => Wrap[LongArray[T]](Adapter.g.reflectMutable("NewArray", Unwrap(x), Backend.Const(v)))
-    case _ => Wrap[LongArray[T]](Adapter.g.reflectMutable("NewArray", Unwrap(x)))
-  }
-  def LongArray[T:Manifest](xs: Rep[T]*): Rep[LongArray[T]] = {
-    Wrap[LongArray[T]](Adapter.g.reflectMutable("Array", xs.map(Unwrap(_)):_*))
-  }
-  implicit class LongArrayOps[A:Manifest](x: Rep[LongArray[A]]) {
-    def apply(i: Rep[Long]): Rep[A] = x match {
-      case Wrap(_) => Wrap[A](Adapter.g.reflectRead("array_get", Unwrap(x), Unwrap(i))(Unwrap(x)))
-      case EffectView(x, base) => Wrap[A](Adapter.g.reflectRead("array_get", Unwrap(x), Unwrap(i))(Unwrap(base)))
+  def NewLongArray[T: Manifest](x: Rep[Long], init: Option[Int] = None): Rep[LongArray[T]] =
+    init match {
+      case Some(v) => Wrap[LongArray[T]](Adapter.g.reflectMutable("NewArray", Unwrap(x), Backend.Const(v)))
+      case _ => Wrap[LongArray[T]](Adapter.g.reflectMutable("NewArray", Unwrap(x)))
     }
-    def update(i: Rep[Long], y: Rep[A]): Unit = x match {
-      case Wrap(_) => Adapter.g.reflectWrite("array_set", Unwrap(x), Unwrap(i), Unwrap(y))(Unwrap(x))
-      case EffectView(x, base) => Adapter.g.reflectWrite("array_set", Unwrap(x), Unwrap(i), Unwrap(y))(Unwrap(base))
-    }
+  def LongArray[T: Manifest](xs: Rep[T]*): Rep[LongArray[T]] = {
+    Wrap[LongArray[T]](Adapter.g.reflectMutable("Array", xs.map(Unwrap(_)): _*))
+  }
+  implicit class LongArrayOps[A: Manifest](x: Rep[LongArray[A]]) {
+    def apply(i: Rep[Long]): Rep[A] =
+      x match {
+        case Wrap(_) => Wrap[A](Adapter.g.reflectRead("array_get", Unwrap(x), Unwrap(i))(Unwrap(x)))
+        case EffectView(x, base) => Wrap[A](Adapter.g.reflectRead("array_get", Unwrap(x), Unwrap(i))(Unwrap(base)))
+      }
+    def update(i: Rep[Long], y: Rep[A]): Unit =
+      x match {
+        case Wrap(_) => Adapter.g.reflectWrite("array_set", Unwrap(x), Unwrap(i), Unwrap(y))(Unwrap(x))
+        case EffectView(x, base) => Adapter.g.reflectWrite("array_set", Unwrap(x), Unwrap(i), Unwrap(y))(Unwrap(base))
+      }
     def length: Rep[Long] = Wrap[Long](Adapter.g.reflect("array_length", Unwrap(x)))
-    def slice(s: Rep[Long], e: Rep[Long] = unit(-1L)): Rep[LongArray[A]] = EffectView[LongArray[A]](Wrap[LongArray[A]](Adapter.g.reflect("array_slice", Unwrap(x), Unwrap(s), Unwrap(e))), x) // FIXME: borrowing effect?
-    def resize(s: Rep[Long]): Rep[LongArray[A]] = Wrap[LongArray[A]](Adapter.g.reflectRealloc("array_resize", Unwrap(x), Unwrap(s))(Unwrap(x)))
+    def slice(s: Rep[Long], e: Rep[Long] = unit(-1L)): Rep[LongArray[A]] =
+      EffectView[LongArray[A]](
+        Wrap[LongArray[A]](Adapter.g.reflect("array_slice", Unwrap(x), Unwrap(s), Unwrap(e))),
+        x
+      ) // FIXME: borrowing effect?
+    def resize(s: Rep[Long]): Rep[LongArray[A]] =
+      Wrap[LongArray[A]](Adapter.g.reflectRealloc("array_resize", Unwrap(x), Unwrap(s))(Unwrap(x)))
     def free: Unit = Adapter.g.reflectFree("array_free", Unwrap(x))(Unwrap(x))
   }
 }
@@ -68,31 +91,33 @@ trait ArrayOps { b: Base =>
 // StackArray is the array using stack (i.e. int a[5] = {1,2,3,4,5};)
 trait StackArrayOps extends ArrayOps { b: Base =>
 
-  def NewStackArray[T:Manifest](x: Rep[Int]): Rep[Array[T]] = {
+  def NewStackArray[T: Manifest](x: Rep[Int]): Rep[Array[T]] = {
     Wrap[Array[T]](Adapter.g.reflectMutable("NewStackArray", Unwrap(x)))
   }
 
-  def StackArray[T:Manifest](xs: Rep[T]*): Rep[Array[T]] = {
+  def StackArray[T: Manifest](xs: Rep[T]*): Rep[Array[T]] = {
     Wrap[Array[T]](Adapter.g.reflectMutable("StackArray", xs.map(Unwrap(_)): _*))
   }
 }
 
 trait CCodeGenStackArray extends ExtendedCCodeGen {
 
-  override def traverse(n: Node): Unit = n match {
-    case n @ Node(s, "NewStackArray", List(x), _) =>
-      val tpe = remap(typeMap.get(s).map(_.typeArguments.head).getOrElse(manifest[Unknown]))
-      emit(s"$tpe "); shallow(s); emit("["); shallow(x); emitln("];")
-    case n @ Node(s, "StackArray", xs, _) =>
-      val tpe = remap(typeMap.get(s).map(_.typeArguments.head).getOrElse(manifest[Unknown]))
-      emit(s"$tpe "); shallow(s); emit("[] = {"); shallow(xs.head)
-      xs.tail.foreach(x => {emit(", "); shallow(x)}); emitln("};")
-    case _ => super.traverse(n)
-  }
+  override def traverse(n: Node): Unit =
+    n match {
+      case n @ Node(s, "NewStackArray", List(x), _) =>
+        val tpe = remap(typeMap.get(s).map(_.typeArguments.head).getOrElse(manifest[Unknown]))
+        emit(s"$tpe "); shallow(s); emit("["); shallow(x); emitln("];")
+      case n @ Node(s, "StackArray", xs, _) =>
+        val tpe = remap(typeMap.get(s).map(_.typeArguments.head).getOrElse(manifest[Unknown]))
+        emit(s"$tpe "); shallow(s); emit("[] = {"); shallow(xs.head)
+        xs.tail.foreach(x => { emit(", "); shallow(x) }); emitln("};")
+      case _ => super.traverse(n)
+    }
 
-  override def mayInline(n: Node): Boolean = n match {
-    case Node(s, "NewStackArray", _, _) => false
-    case Node(s, "StackArray", _, _) => false
-    case _ => super.mayInline(n)
-  }
+  override def mayInline(n: Node): Boolean =
+    n match {
+      case Node(s, "NewStackArray", _, _) => false
+      case Node(s, "StackArray", _, _) => false
+      case _ => super.mayInline(n)
+    }
 }

--- a/src/main/scala/lms/collection/MapOps.scala
+++ b/src/main/scala/lms/collection/MapOps.scala
@@ -14,13 +14,13 @@ trait MapOps { b: Base =>
       val mK = Backend.Const(manifest[K])
       val mV = Backend.Const(manifest[V])
       val unwrapped_kvs: Seq[Backend.Exp] = Seq(mK, mV) ++ kvs.map(Unwrap).toSeq
-      Wrap[Map[K, V]](Adapter.g.reflect("map-new", unwrapped_kvs:_*))
+      Wrap[Map[K, V]](Adapter.g.reflect("map-new", unwrapped_kvs: _*))
     }
     def empty[K: Manifest, V: Manifest](implicit pos: SourceContext) = {
       val mK = Backend.Const(manifest[K])
       val mV = Backend.Const(manifest[V])
       val unwrapped_kvs: Seq[Backend.Exp] = Seq[Backend.Exp](mK, mV)
-      Wrap[Map[K, V]](Adapter.g.reflect("map-new", unwrapped_kvs:_*))
+      Wrap[Map[K, V]](Adapter.g.reflect("map-new", unwrapped_kvs: _*))
     }
   }
 
@@ -44,13 +44,16 @@ trait MapOps { b: Base =>
     def keySet: Rep[Set[K]] = Wrap[Set[K]](Adapter.g.reflect("map-keySet", Unwrap(m)))
     def isEmpty: Rep[Boolean] = Wrap[Boolean](Adapter.g.reflect("map-isEmpty", Unwrap(m)))
     def foldLeft[B: Manifest](z: Rep[B])(f: (Rep[B], (Rep[K], Rep[V])) => Rep[B]) = {
-      def block2 = Adapter.g.reify(2, { syms =>
-        val k = Wrap[K](Adapter.g.reflect("tuple2-1", syms(1)))
-        val v = Wrap[V](Adapter.g.reflect("tuple2-2", syms(1)))
-        Unwrap(f(Wrap[B](syms(0)), (k, v)))
-      })
-      val block3 = Adapter.g.reify(3, syms =>
-        Unwrap(f(Wrap[B](syms(0)), (Wrap[K](syms(1)), Wrap[V](syms(2))))))
+      def block2 =
+        Adapter.g.reify(
+          2,
+          { syms =>
+            val k = Wrap[K](Adapter.g.reflect("tuple2-1", syms(1)))
+            val v = Wrap[V](Adapter.g.reflect("tuple2-2", syms(1)))
+            Unwrap(f(Wrap[B](syms(0)), (k, v)))
+          }
+        )
+      val block3 = Adapter.g.reify(3, syms => Unwrap(f(Wrap[B](syms(0)), (Wrap[K](syms(1)), Wrap[V](syms(2))))))
       Wrap[B](Adapter.g.reflect("map-foldLeft", Unwrap(m), Unwrap(z), block3, block2))
     }
     def foreach(f: ((Rep[K], Rep[V])) => Rep[Unit]): Rep[Unit] = {
@@ -65,7 +68,7 @@ trait MapOps { b: Base =>
       val block = Adapter.g.reify(2, syms => Unwrap(f(Wrap[K](syms(0)), Wrap[V](syms(1)))))
       Wrap[List[A]](Adapter.g.reflect("map-map", Unwrap(m), block))
     }
-    def map[K1: Manifest, V1: Manifest](f: ((Rep[K], Rep[V])) => Rep[(K1, V1)]): Rep[Map[K1,V1]] = {
+    def map[K1: Manifest, V1: Manifest](f: ((Rep[K], Rep[V])) => Rep[(K1, V1)]): Rep[Map[K1, V1]] = {
       val block = Adapter.g.reify(2, syms => Unwrap(f(Wrap[K](syms(0)), Wrap[V](syms(1)))))
       Wrap[Map[K1, V1]](Adapter.g.reflect("map-mapmap", Unwrap(m), block))
     }
@@ -73,19 +76,19 @@ trait MapOps { b: Base =>
 }
 
 trait MapOpsOpt extends MapOps { b: Base with TupleOps =>
-  implicit override def __liftConstMap[K: Manifest, V: Manifest](m: Map[K, V]): MapOps[K, V] = 
+  implicit override def __liftConstMap[K: Manifest, V: Manifest](m: Map[K, V]): MapOps[K, V] =
     new MapOpsOpt(m)
-  implicit override def __liftVarMap[K: Manifest, V: Manifest](m: Var[Map[K, V]]): MapOps[K, V] = 
+  implicit override def __liftVarMap[K: Manifest, V: Manifest](m: Var[Map[K, V]]): MapOps[K, V] =
     new MapOpsOpt(readVar(m))
 
   implicit class MapOpsOpt[K: Manifest, V: Manifest](m: Rep[Map[K, V]]) extends MapOps[K, V](m) {
-    override def foldLeft[B: Manifest](z: Rep[B])(f: (Rep[B], (Rep[K], Rep[V])) => Rep[B]) = 
+    override def foldLeft[B: Manifest](z: Rep[B])(f: (Rep[B], (Rep[K], Rep[V])) => Rep[B]) =
       Unwrap(m) match {
-        case Adapter.g.Def("map-new", mK::mV::(kvs: List[Backend.Exp])) =>
+        case Adapter.g.Def("map-new", mK :: mV :: (kvs: List[Backend.Exp])) =>
           val kv_tps = kvs.map {
             case Adapter.g.Def("tuple2-new", List(k: Backend.Exp, v: Backend.Exp)) =>
               (Wrap[K](k), Wrap[V](v))
-            case s@Backend.Sym(n) =>
+            case s @ Backend.Sym(n) =>
               val t = Wrap[(K, V)](s)
               (t._1, t._2)
           }
@@ -104,75 +107,79 @@ trait ScalaCodeGen_Map extends ExtendedScalaCodeGen {
     } else { super.remap(m) }
   }
 
-  override def mayInline(n: Node): Boolean = n match {
-    case Node(_, "map-new", _, _) => false
-    case Node(_, "map-+", _, _) => false
-    case Node(_, "map-++", _, _) => false
-    case Node(_, "map-getOrElse", _, _) => false
-    case Node(_, "map-foldLeft", _, _) => false
-    case Node(_, "map-foreach", _, _) => false
-    case Node(_, "map-filter", _, _) => false
-    case Node(_, "map-map", _, _) => false
-    case Node(_, "map-mapmap", _, _) => false
-    case _ => super.mayInline(n)
-  }
+  override def mayInline(n: Node): Boolean =
+    n match {
+      case Node(_, "map-new", _, _) => false
+      case Node(_, "map-+", _, _) => false
+      case Node(_, "map-++", _, _) => false
+      case Node(_, "map-getOrElse", _, _) => false
+      case Node(_, "map-foldLeft", _, _) => false
+      case Node(_, "map-foreach", _, _) => false
+      case Node(_, "map-filter", _, _) => false
+      case Node(_, "map-map", _, _) => false
+      case Node(_, "map-mapmap", _, _) => false
+      case _ => super.mayInline(n)
+    }
 
-  override def quote(s: Def): String = s match {
-    case Const(m: Map[_, _]) =>
-      val kvs = m.map {
-        case (k, v) => "(" + quote(Const(k)) + ", " + quote(Const(v)) + ")"
-      }
-      "Map(" + kvs.mkString(", ") + ")"
-    case _ => super.quote(s)
-  }
+  override def quote(s: Def): String =
+    s match {
+      case Const(m: Map[_, _]) =>
+        val kvs = m.map {
+          case (k, v) => "(" + quote(Const(k)) + ", " + quote(Const(v)) + ")"
+        }
+        "Map(" + kvs.mkString(", ") + ")"
+      case _ => super.quote(s)
+    }
 
-  override def shallow(n: Node): Unit = n match {
-    case Node(s, "map-new", Const(mK: Manifest[_])::Const(mV: Manifest[_])::kvs, _) =>
-      val kty = remap(mK)
-      val vty = remap(mV)
-      emit("Map[")
-      emit(kty); emit(", "); emit(vty)
-      emit("](")
-      kvs.zipWithIndex.map { case (kv, i) =>
-        shallow(kv)
-        if (i != kvs.length-1) emit(", ")
-      }
-      emit(")")
-    case Node(s, "map-apply", List(m, k), _) =>
-      shallow(m); emit("("); shallow(k); emit(")")
-    case Node(s, "map-contains", List(m, k), _) =>
-      shallow(m); emit(".contains("); shallow(k); emit(")")
-    case Node(s, "map-get", List(m, k), _) =>
-      shallow(m); emit(".get("); shallow(k); emit(")")
-    case Node(s, "map-getOrElse", List(m, k, d), _) =>
-      shallow(m); emit(".getOrElse("); shallow(k); emit(", "); shallow(d); emit(")")
-    case Node(s, "map-size", List(m), _) =>
-      shallow(m); emit(".size");
-    case Node(s, "map-+", List(m, kv), _) =>
-      shallow(m); emit(" + ("); shallow(kv); emit(")")
-    case Node(s, "map-++", List(m1, m2), _) =>
-      shallow(m1); emit(" ++ "); shallow(m2)
-    case Node(s, "map-keySet", List(m), _) =>
-      shallow(m); emit(".keySet");
-    case Node(s, "map-isEmpty", List(m), _) =>
-      shallow(m); emit(".isEmpty");
-    case Node(s, "map-foldLeft", List(m, z, b: Block, _), _) =>
-      val p = PTuple(List(PVar(b.in(0)), PTuple(List(PVar(b.in(1)), PVar(b.in(2))))))
-      shallow(m); emit(".foldLeft(")
-      shallow(z); emit(") ")
-      quoteCaseBlock(b, p) //Note: quoteBlock will emit `{` and `}`
-    case Node(s, "map-foreach", List(m, b: Block), _) =>
-      val p = PTuple(b.in.map(PVar(_)))
-      shallow(m); emit(".foreach "); quoteCaseBlock(b, p)
-    case Node(s, "map-filter", List(m, b: Block), _) =>
-      val p = PTuple(b.in.map(PVar(_)))
-      shallow(m); emit(".filter "); quoteCaseBlock(b, p)
-    case Node(s, "map-map", List(m, b: Block), _) =>
-      val p = PTuple(b.in.map(PVar(_)))
-      shallow(m); emit(".map "); quoteCaseBlock(b, p)
-    case Node(s, "map-mapmap", List(m, b: Block), _) =>
-      val p = PTuple(b.in.map(PVar(_)))
-      shallow(m); emit(".map "); quoteCaseBlock(b, p)
-    case _ => super.shallow(n)
-  }
+  override def shallow(n: Node): Unit =
+    n match {
+      case Node(s, "map-new", Const(mK: Manifest[_]) :: Const(mV: Manifest[_]) :: kvs, _) =>
+        val kty = remap(mK)
+        val vty = remap(mV)
+        emit("Map[")
+        emit(kty); emit(", "); emit(vty)
+        emit("](")
+        kvs.zipWithIndex.map {
+          case (kv, i) =>
+            shallow(kv)
+            if (i != kvs.length - 1) emit(", ")
+        }
+        emit(")")
+      case Node(s, "map-apply", List(m, k), _) =>
+        shallow(m); emit("("); shallow(k); emit(")")
+      case Node(s, "map-contains", List(m, k), _) =>
+        shallow(m); emit(".contains("); shallow(k); emit(")")
+      case Node(s, "map-get", List(m, k), _) =>
+        shallow(m); emit(".get("); shallow(k); emit(")")
+      case Node(s, "map-getOrElse", List(m, k, d), _) =>
+        shallow(m); emit(".getOrElse("); shallow(k); emit(", "); shallow(d); emit(")")
+      case Node(s, "map-size", List(m), _) =>
+        shallow(m); emit(".size");
+      case Node(s, "map-+", List(m, kv), _) =>
+        shallow(m); emit(" + ("); shallow(kv); emit(")")
+      case Node(s, "map-++", List(m1, m2), _) =>
+        shallow(m1); emit(" ++ "); shallow(m2)
+      case Node(s, "map-keySet", List(m), _) =>
+        shallow(m); emit(".keySet");
+      case Node(s, "map-isEmpty", List(m), _) =>
+        shallow(m); emit(".isEmpty");
+      case Node(s, "map-foldLeft", List(m, z, b: Block, _), _) =>
+        val p = PTuple(List(PVar(b.in(0)), PTuple(List(PVar(b.in(1)), PVar(b.in(2))))))
+        shallow(m); emit(".foldLeft(")
+        shallow(z); emit(") ")
+        quoteCaseBlock(b, p) //Note: quoteBlock will emit `{` and `}`
+      case Node(s, "map-foreach", List(m, b: Block), _) =>
+        val p = PTuple(b.in.map(PVar(_)))
+        shallow(m); emit(".foreach "); quoteCaseBlock(b, p)
+      case Node(s, "map-filter", List(m, b: Block), _) =>
+        val p = PTuple(b.in.map(PVar(_)))
+        shallow(m); emit(".filter "); quoteCaseBlock(b, p)
+      case Node(s, "map-map", List(m, b: Block), _) =>
+        val p = PTuple(b.in.map(PVar(_)))
+        shallow(m); emit(".map "); quoteCaseBlock(b, p)
+      case Node(s, "map-mapmap", List(m, b: Block), _) =>
+        val p = PTuple(b.in.map(PVar(_)))
+        shallow(m); emit(".map "); quoteCaseBlock(b, p)
+      case _ => super.shallow(n)
+    }
 }

--- a/src/main/scala/lms/collection/TupleOps.scala
+++ b/src/main/scala/lms/collection/TupleOps.scala
@@ -70,32 +70,37 @@ trait TupleOps { b: Base =>
 
 trait TupleOpsOpt extends TupleOps { b: Base =>
   implicit class Tuple2OpsOpt[A: Manifest, B: Manifest](t: Rep[(A, B)]) extends Tuple2Ops[A, B](t) {
-    override def _1: Rep[A] = Unwrap(t) match {
-      case Adapter.g.Def("tuple2-new", List(t1: Backend.Exp, t2: Backend.Exp)) => Wrap[A](t1)
-      case _ => super._1
-    }
-    override def _2: Rep[B] = Unwrap(t) match {
-      case Adapter.g.Def("tuple2-new", List(t1: Backend.Exp, t2: Backend.Exp)) => Wrap[B](t2)
-      case _ => super._2
-    }
+    override def _1: Rep[A] =
+      Unwrap(t) match {
+        case Adapter.g.Def("tuple2-new", List(t1: Backend.Exp, t2: Backend.Exp)) => Wrap[A](t1)
+        case _ => super._1
+      }
+    override def _2: Rep[B] =
+      Unwrap(t) match {
+        case Adapter.g.Def("tuple2-new", List(t1: Backend.Exp, t2: Backend.Exp)) => Wrap[B](t2)
+        case _ => super._2
+      }
   }
 
   implicit class Tuple3OpsOpt[A: Manifest, B: Manifest, C: Manifest](t: Rep[(A, B, C)]) extends Tuple3Ops[A, B, C](t) {
-    override def _1: Rep[A] = Unwrap(t) match {
-      case Adapter.g.Def("tuple3-new", List(t1: Backend.Exp, t2: Backend.Exp, t3: Backend.Exp)) =>
-        Wrap[A](t1)
-      case _ => Wrap[A](Adapter.g.reflect("tuple3-1", Unwrap(t)))
-    }
-    override def _2: Rep[B] = Unwrap(t) match {
-      case Adapter.g.Def("tuple3-new", List(t1: Backend.Exp, t2: Backend.Exp, t3: Backend.Exp)) =>
-        Wrap[B](t2)
-      case _ => Wrap[B](Adapter.g.reflect("tuple3-2", Unwrap(t)))
-    }
-    override def _3: Rep[C] = Unwrap(t) match {
-      case Adapter.g.Def("tuple3-new", List(t1: Backend.Exp, t2: Backend.Exp, t3: Backend.Exp)) =>
-        Wrap[C](t3)
-      case _ => Wrap[C](Adapter.g.reflect("tuple3-3", Unwrap(t)))
-    }
+    override def _1: Rep[A] =
+      Unwrap(t) match {
+        case Adapter.g.Def("tuple3-new", List(t1: Backend.Exp, t2: Backend.Exp, t3: Backend.Exp)) =>
+          Wrap[A](t1)
+        case _ => Wrap[A](Adapter.g.reflect("tuple3-1", Unwrap(t)))
+      }
+    override def _2: Rep[B] =
+      Unwrap(t) match {
+        case Adapter.g.Def("tuple3-new", List(t1: Backend.Exp, t2: Backend.Exp, t3: Backend.Exp)) =>
+          Wrap[B](t2)
+        case _ => Wrap[B](Adapter.g.reflect("tuple3-2", Unwrap(t)))
+      }
+    override def _3: Rep[C] =
+      Unwrap(t) match {
+        case Adapter.g.Def("tuple3-new", List(t1: Backend.Exp, t2: Backend.Exp, t3: Backend.Exp)) =>
+          Wrap[C](t3)
+        case _ => Wrap[C](Adapter.g.reflect("tuple3-3", Unwrap(t)))
+      }
   }
 }
 
@@ -116,36 +121,38 @@ trait ScalaCodeGen_Tuple extends ExtendedScalaCodeGen {
     }
   }
 
-  override def quote(s: Def): String = s match {
-    case Const(t: Tuple2[_, _]) =>
-      "(" + quote(Const(t._1)) + ", " + quote(Const(t._2)) + ")"
-    case Const(t: Tuple3[_, _, _]) =>
-      "(" + quote(Const(t._1)) + ", " + quote(Const(t._2)) + ", " + quote(Const(t._3)) + ")"
-    case _ => super.quote(s)
-  }
+  override def quote(s: Def): String =
+    s match {
+      case Const(t: Tuple2[_, _]) =>
+        "(" + quote(Const(t._1)) + ", " + quote(Const(t._2)) + ")"
+      case Const(t: Tuple3[_, _, _]) =>
+        "(" + quote(Const(t._1)) + ", " + quote(Const(t._2)) + ", " + quote(Const(t._3)) + ")"
+      case _ => super.quote(s)
+    }
 
-  override def shallow(n: Node): Unit = n match {
-    // Tuple2
-    case Node(s, "tuple2-new", List(fst, snd), _) =>
-      emit("("); shallow(fst); emit(", "); shallow(snd); emit(")")
-    case Node(s, "tuple2-1", List(t), _) =>
-      shallow(t); emit("._1")
-    case Node(s, "tuple2-2", List(t), _) =>
-      shallow(t); emit("._2")
-    case Node(s, "tuple2-swap", List(t), _) =>
-      shallow(t); emit(".swap")
-    // Tuple3
-    case Node(s, "tuple3-new", List(fst, snd, trd), _) =>
-      emit("(")
-      shallow(fst); emit(", ")
-      shallow(snd); emit(", ")
-      shallow(trd); emit(")")
-    case Node(s, "tuple3-1", List(t), _) =>
-      shallow(t); emit("._1")
-    case Node(s, "tuple3-2", List(t), _) =>
-      shallow(t); emit("._2")
-    case Node(s, "tuple3-3", List(t), _) =>
-      shallow(t); emit("._3")
-    case _ => super.shallow(n)
-  }
+  override def shallow(n: Node): Unit =
+    n match {
+      // Tuple2
+      case Node(s, "tuple2-new", List(fst, snd), _) =>
+        emit("("); shallow(fst); emit(", "); shallow(snd); emit(")")
+      case Node(s, "tuple2-1", List(t), _) =>
+        shallow(t); emit("._1")
+      case Node(s, "tuple2-2", List(t), _) =>
+        shallow(t); emit("._2")
+      case Node(s, "tuple2-swap", List(t), _) =>
+        shallow(t); emit(".swap")
+      // Tuple3
+      case Node(s, "tuple3-new", List(fst, snd, trd), _) =>
+        emit("(")
+        shallow(fst); emit(", ")
+        shallow(snd); emit(", ")
+        shallow(trd); emit(")")
+      case Node(s, "tuple3-1", List(t), _) =>
+        shallow(t); emit("._1")
+      case Node(s, "tuple3-2", List(t), _) =>
+        shallow(t); emit("._2")
+      case Node(s, "tuple3-3", List(t), _) =>
+        shallow(t); emit("._3")
+      case _ => super.shallow(n)
+    }
 }

--- a/src/main/scala/lms/core/codegen.scala
+++ b/src/main/scala/lms/core/codegen.scala
@@ -11,9 +11,9 @@ import Backend._
 class Unknown // HACK: Sentinel for typeMap
 
 /**
- * This `GenericCodeGen` class demonstrates a minimal code generator from Traverser.
- * It is not used in production.
- */
+  * This `GenericCodeGen` class demonstrates a minimal code generator from Traverser.
+  * It is not used in production.
+  */
 class GenericCodeGen extends Traverser {
 
   def emit(s: String) = println(s)
@@ -24,34 +24,35 @@ class GenericCodeGen extends Traverser {
     emit(y.res.toString + " // out effect: " + y.eff.toString)
   }
 
-  override def traverse(n: Node): Unit = n match {
-    case n @ Node(f, "λ", List(y: Block), _) =>
-      emit(s"$f = (λ {")
-      traverse(y, f)
-      emit(s"})")
-    case n @ Node(f, op, es, eff) =>
-      val ss = es map {
-        case e @ Block(_,_,_,_) => "{" + utils.captureOut(traverse(e)) + "}" // FIXME freq!!
-        case e => e.toString
-      }
-      val efc = if (eff.deps.nonEmpty) s" // Eff: ${eff}" else ""
-      emit(s"$f = ($op ${ss.mkString(" ")})$efc")
-  }
+  override def traverse(n: Node): Unit =
+    n match {
+      case n @ Node(f, "λ", List(y: Block), _) =>
+        emit(s"$f = (λ {")
+        traverse(y, f)
+        emit(s"})")
+      case n @ Node(f, op, es, eff) =>
+        val ss = es map {
+          case e @ Block(_, _, _, _) => "{" + utils.captureOut(traverse(e)) + "}" // FIXME freq!!
+          case e => e.toString
+        }
+        val efc = if (eff.deps.nonEmpty) s" // Eff: ${eff}" else ""
+        emit(s"$f = ($op ${ss.mkString(" ")})$efc")
+    }
 }
 
 /**
- * This `ExtendedCodeGen` trait defines several interfaces for all Extend*CodeGen,
- * where * refers to a target language such as Scala, C, CPP, Rust.
- * 1. Interface for code gen stream, emit, emitln.
- * 2. Interface for typeMap (from backend.Exp to Manifest).
- * 3. Interface for remap (from Manifest to String representation of the type).
- * 4. Interface for dead code elimination (DCE).
- * 5. Interface for quote* (code gen of Exp, Block, and static data).
- * 5* Interface for shallow* (code gen of a target langauge right-hand-side)
- * 5* Interface for traverse* (code gen of a target language statement)
- * 6. Interface for nameMap (from IR Op string to target language function).
- * 7. Interface for code gen (emitAll).
- */
+  * This `ExtendedCodeGen` trait defines several interfaces for all Extend*CodeGen,
+  * where * refers to a target language such as Scala, C, CPP, Rust.
+  * 1. Interface for code gen stream, emit, emitln.
+  * 2. Interface for typeMap (from backend.Exp to Manifest).
+  * 3. Interface for remap (from Manifest to String representation of the type).
+  * 4. Interface for dead code elimination (DCE).
+  * 5. Interface for quote* (code gen of Exp, Block, and static data).
+  * 5* Interface for shallow* (code gen of a target langauge right-hand-side)
+  * 5* Interface for traverse* (code gen of a target language statement)
+  * 6. Interface for nameMap (from IR Op string to target language function).
+  * 7. Interface for code gen (emitAll).
+  */
 trait ExtendedCodeGen {
 
   // Method Group 1: stream and emit (for codegen string handling)
@@ -74,17 +75,18 @@ trait ExtendedCodeGen {
   // Method Group 2: typeMap (from core Exp to type Manifest, the information
   //                 of which is collection in the frontend)
   var typeMap: collection.Map[lms.core.Backend.Exp, Manifest[_]] = _
-  def typeBlockRes(x: lms.core.Backend.Exp) = x match {
-    case Const(()) => manifest[Unit]
-    case Const(x: Int) => manifest[Int]
-    case Const(x: Long) => manifest[Long]
-    case Const(x: Float) => manifest[Float]
-    case Const(x: Double) => manifest[Double]
-    case Const(x: Char) => manifest[Char]
-    case Const(x: String) => manifest[String]
-    case Const(_) => ???
-    case _ => typeMap.getOrElse(x, manifest[Unknown])
-  }
+  def typeBlockRes(x: lms.core.Backend.Exp) =
+    x match {
+      case Const(()) => manifest[Unit]
+      case Const(x: Int) => manifest[Int]
+      case Const(x: Long) => manifest[Long]
+      case Const(x: Float) => manifest[Float]
+      case Const(x: Double) => manifest[Double]
+      case Const(x: Char) => manifest[Char]
+      case Const(x: String) => manifest[String]
+      case Const(_) => ???
+      case _ => typeMap.getOrElse(x, manifest[Unknown])
+    }
 
   // Method Group 3: remap (from type Manifest to string representation of type)
   def array(innerType: String): String
@@ -92,14 +94,16 @@ trait ExtendedCodeGen {
   def record(man: RefinedManifest[_]): String
   def function(sig: List[Manifest[_]]): String
   def remapUnsigned(m: Manifest[_]): String
-  def remap(m: Manifest[_]): String = m.typeArguments match {
-    case Nil => m match {
-      case ref: RefinedManifest[_] => record(ref)
-      case _ => primitive(m.toString)
+  def remap(m: Manifest[_]): String =
+    m.typeArguments match {
+      case Nil =>
+        m match {
+          case ref: RefinedManifest[_] => record(ref)
+          case _ => primitive(m.toString)
+        }
+      case List(inner) => array(remap(inner))
+      case sig => function(sig)
     }
-    case List(inner) => array(remap(inner))
-    case sig => function(sig)
-  }
 
   // Method Group 4: dead code elimination
   val dce = new DeadCodeElimCG
@@ -108,17 +112,19 @@ trait ExtendedCodeGen {
   // Method Group 5: quote (for generating string of a unit of code generation:
   //                 variable, const, or block)
   def quote(s: Def): String
-  def quoteStatic(n: Node) = n match {
-    case Node(s, "staticData", List(Const(a)), _) =>
-      val arg = "p"+quote(s)
-      val tpe = remap(typeMap.getOrElse(s, manifest[Unknown]))
-      s"$arg: $tpe"
-  }
+  def quoteStatic(n: Node) =
+    n match {
+      case Node(s, "staticData", List(Const(a)), _) =>
+        val arg = "p" + quote(s)
+        val tpe = remap(typeMap.getOrElse(s, manifest[Unknown]))
+        s"$arg: $tpe"
+    }
 
-  def extractStatic(n: Node) = n match {
-    case Node(s, "staticData", List(Const(a)), _) =>
-      (a.getClass, a)
-  }
+  def extractStatic(n: Node) =
+    n match {
+      case Node(s, "staticData", List(Const(a)), _) =>
+        (a.getClass, a)
+    }
 
   def extractAllStatics() = dce.statics.toList.map(extractStatic)
 
@@ -126,9 +132,8 @@ trait ExtendedCodeGen {
   def nameMap: Map[String, String]
 
   // Head Function: emitAll take a graph and generate the code.
-  def emitAll(g: Graph, name: String)(m1:Manifest[_],m2:Manifest[_]): Unit
+  def emitAll(g: Graph, name: String)(m1: Manifest[_], m2: Manifest[_]): Unit
 }
-
 
 abstract class CompactCodeGen extends CompactTraverser {
 
@@ -148,27 +153,29 @@ abstract class CompactCodeGen extends CompactTraverser {
   def emitln(s: String = ""): Unit
 
   /**
-   * `quote` family of methods are used to emit a codegen unit (a variable, constant, or block)
-   * We have `quote` for variable/const
-   *         `quoteEff` for effects
-   *         `quoteBlock` `quoteBlockP` `quoteElseBlock` for
-   *          block,    block with precedence, and else block
-   */
+    * `quote` family of methods are used to emit a codegen unit (a variable, constant, or block)
+    * We have `quote` for variable/const
+    *         `quoteEff` for effects
+    *         `quoteBlock` `quoteBlockP` `quoteElseBlock` for
+    *          block,    block with precedence, and else block
+    */
   // with `rename` `doRename` and the usage of them in `quote`, we may
   // rename variables (say from x6 to x4).
-  val rename = new mutable.HashMap[Sym,String]
+  val rename = new mutable.HashMap[Sym, String]
   var doRename = true
-  def quote(s: Def): String = s match {
-    case s @ Sym(n) if doRename => rename.getOrElseUpdate(s, s"x${rename.size}")
-    case Sym(n) => s.toString
-    case Const(s: String) => "\""+s.replace("\"", "\\\"").replace("\n","\\n").replace("\t","\\t")+"\"" // TODO: more escapes?
-    case Const(x: Char) if x == '\n' => "'\\n'"
-    case Const(x: Char) if x == '\t' => "'\\t'"
-    case Const(x: Char) if x == 0    => "'\\0'"
-    case Const(x: Char) => "'"+x+"'"
-    case Const(x: Long) => x.toString + "L"
-    case Const(x) => x.toString
-  }
+  def quote(s: Def): String =
+    s match {
+      case s @ Sym(n) if doRename => rename.getOrElseUpdate(s, s"x${rename.size}")
+      case Sym(n) => s.toString
+      case Const(s: String) =>
+        "\"" + s.replace("\"", "\\\"").replace("\n", "\\n").replace("\t", "\\t") + "\"" // TODO: more escapes?
+      case Const(x: Char) if x == '\n' => "'\\n'"
+      case Const(x: Char) if x == '\t' => "'\\t'"
+      case Const(x: Char) if x == 0 => "'\\0'"
+      case Const(x: Char) => "'" + x + "'"
+      case Const(x: Long) => x.toString + "L"
+      case Const(x) => x.toString
+    }
 
   // with `doPrintEffects` and `quoteEff`, we can optionally print the effect information
   var doPrintEffects = false
@@ -182,13 +189,16 @@ abstract class CompactCodeGen extends CompactTraverser {
 
   def quoteEff(x: EffectSummary): String = quoteEff(x.deps)
 
-  def quoteEff(n: Node): String = if (!doPrintEffects) "" else {
-    if (n.eff.isEmpty) "" else {
-      s"/* val ${quote(n.n)} = ${n.eff.repr(quote)} */"
+  def quoteEff(n: Node): String =
+    if (!doPrintEffects) ""
+    else {
+      if (n.eff.isEmpty) ""
+      else {
+        s"/* val ${quote(n.n)} = ${n.eff.repr(quote)} */"
+      }
     }
-  }
 
-  type WrapFun = (Int, Option[Node], Block) => (=> Unit) =>Unit
+  type WrapFun = (Int, Option[Node], Block) => (=> Unit) => Unit
   var wraper: WrapFun = nowraper _
   def withWraper(w: WrapFun)(f: => Unit) = {
     val save = wraper
@@ -204,17 +214,38 @@ abstract class CompactCodeGen extends CompactTraverser {
   def quoteBlock(header: String)(f: => Unit): Unit
   def quoteBlock(b: Block, argType: Boolean = false): Unit
 
-  val unaryop = Set("-","!","&")
-  val binop = Set("+","-","*","/","%","==","!=","<",">",">=","<=","&","|","<<",">>", ">>>", "&&", "||", "^")
+  val unaryop = Set("-", "!", "&")
+  val binop = Set(
+    "+",
+    "-",
+    "*",
+    "/",
+    "%",
+    "==",
+    "!=",
+    "<",
+    ">",
+    ">=",
+    "<=",
+    "&",
+    "|",
+    "<<",
+    ">>",
+    ">>>",
+    "&&",
+    "||",
+    "^"
+  )
   val math = Set("sin", "cos", "tanh", "exp", "sqrt")
   final def unaryPrecedence(op: String): Int = 12
   def precedence(op: String): Int
-  def precedence(n: Node): Int = n match {
-    case Node(s,"?",List(c,a,b:Block),_) if b.isPure && b.res == Const(false) => precedence("&&")
-    case Node(s,"?",List(c,a:Block,b),_) if a.isPure && a.res == Const(true) => precedence("||")
-    case Node(s,op,List(x),_) if unaryop(op) => unaryPrecedence(op)
-    case _ => precedence(n.op)
-  }
+  def precedence(n: Node): Int =
+    n match {
+      case Node(s, "?", List(c, a, b: Block), _) if b.isPure && b.res == Const(false) => precedence("&&")
+      case Node(s, "?", List(c, a: Block, b), _) if a.isPure && a.res == Const(true) => precedence("||")
+      case Node(s, op, List(x), _) if unaryop(op) => unaryPrecedence(op)
+      case _ => precedence(n.op)
+    }
 
   def quoteBlockP(f: => Unit): Unit = quoteBlockP(0)(f)
   def quoteBlockP(prec: Int)(f: => Unit) = {
@@ -246,47 +277,53 @@ abstract class CompactCodeGen extends CompactTraverser {
   }
 
   /**
-   * The `shallow` family of codegen methods handle `Def`s that are in the RHS of target langauge.
-   * They are different from `traverse` because they don't generate a variable bindings for the nodes.
-   */
-  def shallow(n: Def): Unit = n match {
-    case InlineSym(n) => shallow(n)
-    case b:Block => quoteBlock(b)
-    case _ => emit(quote(n))
-  }
+    * The `shallow` family of codegen methods handle `Def`s that are in the RHS of target langauge.
+    * They are different from `traverse` because they don't generate a variable bindings for the nodes.
+    */
+  def shallow(n: Def): Unit =
+    n match {
+      case InlineSym(n) => shallow(n)
+      case b: Block => quoteBlock(b)
+      case _ => emit(quote(n))
+    }
 
-  def shallowP(n: Def, prec: Int = 20): Unit = n match {
-    case InlineSym(n) if precedence(n) < prec => emit("("); shallow(n); emit(")")
-    case _ => shallow(n)
-  }
+  def shallowP(n: Def, prec: Int = 20): Unit =
+    n match {
+      case InlineSym(n) if precedence(n) < prec => emit("("); shallow(n); emit(")")
+      case _ => shallow(n)
+    }
 
   // generate string for node's right-hand-size
   // (either inline or as part of val def)
   // XXX TODO: precedence of nested expressions!!
-  def shallow(n: Node): Unit = n match {
-    case n @ Node(s, op,List(x,y),_) if binop(op) => // associativity??
-      shallowP(x, precedence(op)); emit(" "); emit(op); emit(" "); shallowP(y, precedence(op)+1)
+  def shallow(n: Node): Unit =
+    n match {
+      case n @ Node(s, op, List(x, y), _) if binop(op) => // associativity??
+        shallowP(x, precedence(op)); emit(" "); emit(op); emit(" "); shallowP(y, precedence(op) + 1)
 
-    case n @ Node(s, op,List(x),_) if unaryop(op) => // associativity??
-      emit(op); shallowP(x, unaryPrecedence(op))
+      case n @ Node(s, op, List(x), _) if unaryop(op) => // associativity??
+        emit(op); shallowP(x, unaryPrecedence(op))
 
-    case n @ Node(s,"var_get",List(x),_) =>
-      shallow(x)
+      case n @ Node(s, "var_get", List(x), _) =>
+        shallow(x)
 
-    case n @ Node(f,"?",c::(a:Block)::(b:Block)::_,_) =>
-      emit("if ("); shallow(c); emit(") ")
-      quoteBlockP(traverse(a))
-      emit(" else ")
-      quoteBlockP(traverse(b))
+      case n @ Node(f, "?", c :: (a: Block) :: (b: Block) :: _, _) =>
+        emit("if ("); shallow(c); emit(") ")
+        quoteBlockP(traverse(a))
+        emit(" else ")
+        quoteBlockP(traverse(b))
 
-    case n @ Node(f,"W",List(c:Block,b:Block),_) =>
-      emit("while ("); quoteBlockP(traverse(c)); emit(") ")
-      quoteBlock(traverse(b))
+      case n @ Node(f, "W", List(c: Block, b: Block), _) =>
+        emit("while ("); quoteBlockP(traverse(c)); emit(") ")
+        quoteBlock(traverse(b))
 
-    case n @ Node(s,"@",x::y,_) =>
-      shallowP(x); emit("("); y.headOption.foreach(h => { shallowP(h, 0); y.tail.foreach(a => { emit(", "); shallowP(a, 0) }) }); emit(")")
+      case n @ Node(s, "@", x :: y, _) =>
+        shallowP(x); emit("(");
+        y.headOption.foreach(h => { shallowP(h, 0); y.tail.foreach(a => { emit(", "); shallowP(a, 0) }) }); emit(")")
 
-    case n @ Node(_,op,args,_) =>
-      emit(op); emit("("); args.headOption.foreach(h => { shallowP(h, 0); args.tail.foreach(a => { emit(", "); shallowP(a, 0) }) }); emit(")")
-  }
+      case n @ Node(_, op, args, _) =>
+        emit(op); emit("(");
+        args.headOption.foreach(h => { shallowP(h, 0); args.tail.foreach(a => { emit(", "); shallowP(a, 0) }) });
+        emit(")")
+    }
 }

--- a/src/main/scala/lms/core/codegen/C_codegen.scala
+++ b/src/main/scala/lms/core/codegen/C_codegen.scala
@@ -13,27 +13,29 @@ class ExtendedCCodeGen extends CompactCodeGen with ExtendedCodeGen {
   override def emit(s: String): Unit = { stream.print(s); lastNL = false }
   override def emitln(s: String = "") = if (s != "" || !lastNL) { stream.println(s); lastNL = true }
 
-  override def quote(x: Def) = x match {
-    case Const(scala.Int.MinValue) => "0x" + scala.Int.MinValue.toHexString
-    case Const(scala.Long.MinValue) => "0x" + scala.Long.MinValue.toHexString + "L"
-    case Const(x: Double) if x.isNaN => "NAN"
-    case Const(null) => "NULL"
-    case Const(c: Char) if c.toInt < 0x20 || c.toInt > 0x7F =>
-      val res = super.quote(x) // if escaped
-      if (res.charAt(1) == '\\') res else "0x" + c.toHexString
-    case Const(x: List[_]) => "{" + x.mkString(", ") + "}" // translate a Scala List literal to C List literal
-    case _ =>
-      super.quote(x)
-  }
+  override def quote(x: Def) =
+    x match {
+      case Const(scala.Int.MinValue) => "0x" + scala.Int.MinValue.toHexString
+      case Const(scala.Long.MinValue) => "0x" + scala.Long.MinValue.toHexString + "L"
+      case Const(x: Double) if x.isNaN => "NAN"
+      case Const(null) => "NULL"
+      case Const(c: Char) if c.toInt < 0x20 || c.toInt > 0x7f =>
+        val res = super.quote(x) // if escaped
+        if (res.charAt(1) == '\\') res else "0x" + c.toHexString
+      case Const(x: List[_]) => "{" + x.mkString(", ") + "}" // translate a Scala List literal to C List literal
+      case _ =>
+        super.quote(x)
+    }
 
   // Remap auxiliary function C specific
-  def primitive(rawType: String): String = rawType match {
-    case "Unit" => "void"
-    case "Boolean" => "bool"
-    case "java.lang.String" => "char*"
-    // case "Nothing" | "Any" => ???
-    case _ => rawType.toLowerCase
-  }
+  def primitive(rawType: String): String =
+    rawType match {
+      case "Unit" => "void"
+      case "Boolean" => "bool"
+      case "java.lang.String" => "char*"
+      // case "Nothing" | "Any" => ???
+      case _ => rawType.toLowerCase
+    }
   def remapUnsigned(m: Manifest[_]): String = "unsigned " + remap(m)
   def array(innerType: String) = innerType + "*"
   def function(sig: List[Manifest[_]]): String = ???
@@ -49,11 +51,11 @@ class ExtendedCCodeGen extends CompactCodeGen with ExtendedCodeGen {
     tpe
   }
   override val nameMap = Map( // FIXME: tutorial specific
-    "ScannerNew"     -> "new scala.lms.tutorial.Scanner",
+    "ScannerNew" -> "new scala.lms.tutorial.Scanner",
     "ScannerHasNext" -> "Scanner.hasNext",
-    "ScannerNext"    -> "Scanner.next",
-    "ScannerClose"   -> "Scanner.close",
-    "ObjHashCode"    -> "Object.hashCode",
+    "ScannerNext" -> "Scanner.next",
+    "ScannerClose" -> "Scanner.close",
+    "ObjHashCode" -> "Object.hashCode",
     "StrSubHashCode" -> "hash"
   )
 
@@ -106,32 +108,35 @@ class ExtendedCCodeGen extends CompactCodeGen with ExtendedCodeGen {
   //   | &= ^= |=    | Assignment by bitwise AND, XOR, and OR
   //
   // 15|,            | Comma|  Left-to-right
-  final def precedence(op: String): Int = op match {
-    case "?" => 1
-    case "||" => 2
-    case "&&" => 3
-    case "|" => 4
-    case "^" => 5
-    case "&" => 6
-    case "==" | "!=" | "String.equalsTo" => 7
-    case "<" | ">" | "<=" | ">=" => 8
-    case "<<" | ">>" | ">>>" => 9
-    case "+" | "-" | "array_slice" | "String.slice" => 10
-    case "*" | "/" | "%" => 11
-    case "cast" => 12
-    case "ref_new" => 13 // & address of
-    case "reffield_get" => 14 // -> pointer member access
-    // type casting is lower in precedence?
-    case "NewArray" | "mmap" => 19 // there might be type conversion before array access, which should be put in parenthesis
-    case _ if op.startsWith("unchecked") => 0 // force parenthesis if nested: 3 * unchecked(5 + 4)
-    case _ => 20
-  }
+  final def precedence(op: String): Int =
+    op match {
+      case "?" => 1
+      case "||" => 2
+      case "&&" => 3
+      case "|" => 4
+      case "^" => 5
+      case "&" => 6
+      case "==" | "!=" | "String.equalsTo" => 7
+      case "<" | ">" | "<=" | ">=" => 8
+      case "<<" | ">>" | ">>>" => 9
+      case "+" | "-" | "array_slice" | "String.slice" => 10
+      case "*" | "/" | "%" => 11
+      case "cast" => 12
+      case "ref_new" => 13 // & address of
+      case "reffield_get" => 14 // -> pointer member access
+      // type casting is lower in precedence?
+      case "NewArray" | "mmap" =>
+        19 // there might be type conversion before array access, which should be put in parenthesis
+      case _ if op.startsWith("unchecked") => 0 // force parenthesis if nested: 3 * unchecked(5 + 4)
+      case _ => 20
+    }
 
   def emitFunction(name: String, body: Block) = {
     val res = body.res
     val args = body.in
     val ret = s"${remap(typeBlockRes(res))} "
-    val params = "(" + args.map(s => s"${remap(typeMap.getOrElse(s, manifest[Unknown]))} ${quote(s)}").mkString(", ") + ") "
+    val params =
+      "(" + args.map(s => s"${remap(typeMap.getOrElse(s, manifest[Unknown]))} ${quote(s)}").mkString(", ") + ") "
     val sig = ret + name + params
     emit(sig)
     quoteBlockPReturn(traverse(body))
@@ -199,7 +204,7 @@ class ExtendedCCodeGen extends CompactCodeGen with ExtendedCodeGen {
   // block of statement of an else branch
   override def quoteElseBlock(f: => Unit) = {
     def wraper(numStms: Int, l: Option[Node], y: Block)(f: => Unit) = {
-      if (numStms > 0 /* y.res == Const(()) should always be true for else */) {
+      if (numStms > 0 /* y.res == Const(()) should always be true for else */ ) {
         assert(y.res == Const(()))
         emit(" else ")
         if (numStms > 1) emitln("{")
@@ -210,52 +215,55 @@ class ExtendedCCodeGen extends CompactCodeGen with ExtendedCodeGen {
     withWraper(wraper _)(f)
   }
 
-  override def shallow(n: Def): Unit = n match {
-    case InlineSym(t: Node) => shallow(t)
-    case b:Block => quoteBlock(b)
-    case _ => emit(quote(n))
-  }
+  override def shallow(n: Def): Unit =
+    n match {
+      case InlineSym(t: Node) => shallow(t)
+      case b: Block => quoteBlock(b)
+      case _ => emit(quote(n))
+    }
 
   private val defines = mutable.HashSet[String]()
   def registerDefine(define: String*) = defines ++= define.toSet
-  private val headers = mutable.HashSet[String]("<stdio.h>", "<stdlib.h>", "<stdint.h>","<stdbool.h>")
+  private val headers = mutable.HashSet[String]("<stdio.h>", "<stdlib.h>", "<stdint.h>", "<stdbool.h>")
   def registerHeader(nHeaders: String*) = headers ++= nHeaders.toSet
   def unregisterHeader(nHeaders: String*) = headers --= nHeaders.toSet
   def registerHeader(includePath: String, header: String): Unit = {
     registerIncludePath(includePath)
     registerHeader(header)
   }
-  def emitHeaders(out: PrintStream) = headers.foreach { f =>
-    out.println(s"#include $f")
-    if (f == "<scanner_header.h>") {
-      // this is a resource in LMS clean
-      val curPath = System.getProperty("user.dir")
-      val path = new File(curPath + "/scanner_header.h")
-      val src = scala.io.Source.fromInputStream(getClass.getResourceAsStream("/scanner_header.h"))
-      val temp_out = new PrintWriter(path)
-      temp_out.println(src.getLines.mkString("\n"))
-      temp_out.flush
-      temp_out.close
-      registerIncludePath(curPath)
+  def emitHeaders(out: PrintStream) =
+    headers.foreach { f =>
+      out.println(s"#include $f")
+      if (f == "<scanner_header.h>") {
+        // this is a resource in LMS clean
+        val curPath = System.getProperty("user.dir")
+        val path = new File(curPath + "/scanner_header.h")
+        val src = scala.io.Source.fromInputStream(getClass.getResourceAsStream("/scanner_header.h"))
+        val temp_out = new PrintWriter(path)
+        temp_out.println(src.getLines.mkString("\n"))
+        temp_out.flush
+        temp_out.close
+        registerIncludePath(curPath)
+      }
+      if (f == "<cuda_header.h>") {
+        // this is a resouce in LMS clean
+        val curPath = System.getProperty("user.dir")
+        val path = new File(curPath + "/cuda_header.h")
+        val src = scala.io.Source.fromInputStream(getClass.getResourceAsStream("/cuda_header.h"))
+        val temp_out = new PrintWriter(path)
+        temp_out.println(src.getLines.mkString("\n"))
+        temp_out.flush
+        temp_out.close
+        registerIncludePath(curPath)
+      }
     }
-    if (f == "<cuda_header.h>") {
-      // this is a resouce in LMS clean
-      val curPath = System.getProperty("user.dir")
-      val path = new File(curPath + "/cuda_header.h")
-      val src = scala.io.Source.fromInputStream(getClass.getResourceAsStream("/cuda_header.h"))
-      val temp_out = new PrintWriter(path)
-      temp_out.println(src.getLines.mkString("\n"))
-      temp_out.flush
-      temp_out.close
-      registerIncludePath(curPath)
-    }
-  }
 
-  def emitDefines(out: PrintStream) = defines.foreach { f =>
-    out.println(s"#ifndef $f")
-    out.println(s"#define $f")
-    out.println(s"#endif")
-  }
+  def emitDefines(out: PrintStream) =
+    defines.foreach { f =>
+      out.println(s"#ifndef $f")
+      out.println(s"#define $f")
+      out.println(s"#endif")
+    }
 
   val includePaths = mutable.HashSet[String]()
   def registerIncludePath(paths: String*) = includePaths ++= paths.toSet
@@ -266,19 +274,26 @@ class ExtendedCCodeGen extends CompactCodeGen with ExtendedCodeGen {
   private val registeredFunctions = mutable.HashSet[String]()
   private val functionsStreams = new mutable.LinkedHashMap[String, (PrintStream, ByteArrayOutputStream)]()
   private val ongoingFun = new mutable.HashSet[String]()
-  def registerTopLevelFunction(id: String, streamId: String = "general")(f: => Unit) = if (!registeredFunctions(id)) {
-    if (ongoingFun(streamId)) ???
-    ongoingFun += streamId
-    registeredFunctions += id
-    withStream(functionsStreams.getOrElseUpdate(streamId, {
-      val functionsStream = new ByteArrayOutputStream()
-      val functionsWriter = new PrintStream(functionsStream)
-      (functionsWriter, functionsStream)
-    })._1)(f)
-    ongoingFun -= streamId
-  }
+  def registerTopLevelFunction(id: String, streamId: String = "general")(f: => Unit) =
+    if (!registeredFunctions(id)) {
+      if (ongoingFun(streamId)) ???
+      ongoingFun += streamId
+      registeredFunctions += id
+      withStream(
+        functionsStreams
+          .getOrElseUpdate(
+            streamId, {
+              val functionsStream = new ByteArrayOutputStream()
+              val functionsWriter = new PrintStream(functionsStream)
+              (functionsWriter, functionsStream)
+            }
+          )
+          ._1
+      )(f)
+      ongoingFun -= streamId
+    }
   def emitFunctions(out: PrintStream): Unit =
-    if (functionsStreams.size > 0){
+    if (functionsStreams.size > 0) {
       out.println("\n/************* Functions **************/")
       for ((_, functionsStream) <- functionsStreams.values.toSeq.reverse) // ensure dependencies
         functionsStream.writeTo(out)
@@ -292,9 +307,9 @@ class ExtendedCCodeGen extends CompactCodeGen with ExtendedCodeGen {
     if (!registeredDatastructures(id)) {
       if (ongoingData) ???
       ongoingData = true
-    registeredDatastructures += id
-    withStream(datastructuresWriter)(f)
-    ongoingData = false
+      registeredDatastructures += id
+      withStream(datastructuresWriter)(f)
+      ongoingData = false
     }
   def emitDatastructures(out: PrintStream): Unit =
     if (datastructuresStream.size > 0) {
@@ -306,20 +321,22 @@ class ExtendedCCodeGen extends CompactCodeGen with ExtendedCodeGen {
   protected val initStream = new ByteArrayOutputStream()
   protected val initWriter = new PrintStream(initStream)
   protected var ongoingInit = false
-  def registerInit(id: String)(f: => Unit) = if (!registeredInit(id)) {
-    if (ongoingInit) ???
-    ongoingInit = true
-    registeredInit += id
-    withStream(initWriter)(f)
-    ongoingInit = false
-  }
+  def registerInit(id: String)(f: => Unit) =
+    if (!registeredInit(id)) {
+      if (ongoingInit) ???
+      ongoingInit = true
+      registeredInit += id
+      withStream(initWriter)(f)
+      ongoingInit = false
+    }
 
-  def emitInit(out: PrintStream) = if (initStream.size > 0) {
-    out.println("\n/*********** Init ***********/")
-    out.println("inline int init() {")
-    initStream.writeTo(out)
-    out.println("  return 0;\n}")
-  }
+  def emitInit(out: PrintStream) =
+    if (initStream.size > 0) {
+      out.println("\n/*********** Init ***********/")
+      out.println("inline int init() {")
+      initStream.writeTo(out)
+      out.println("  return 0;\n}")
+    }
 
   def emitValDef(n: Node): Unit = {
     if (dce.live(n.n))
@@ -331,232 +348,240 @@ class ExtendedCCodeGen extends CompactCodeGen with ExtendedCodeGen {
     // emit(s"var ${quote(s)} = $rhs; // ${dce.reach(s)} ${dce.live(s)} ")
     // TODO: enable dce for vars ... but currently getting unused expression warnings ...
     // if (dce.live(s))
-      emit(s"${remap(typeMap.getOrElse(n.n, manifest[Unknown]))} ${quote(n.n)} = "); shallow(n.rhs.head); emitln(";")
+    emit(s"${remap(typeMap.getOrElse(n.n, manifest[Unknown]))} ${quote(n.n)} = "); shallow(n.rhs.head); emitln(";")
     // else
-      // emit(s"$rhs;")
+    // emit(s"$rhs;")
   }
 
-  override def shallow(n: Node): Unit = n match {
-    case Node(s, ">>>", List(a, b), _) =>
-      emit("(("); emit(remapUnsigned(typeMap.getOrElse(s, manifest[Unknown]))); emit(") ")
-      shallowP(a, precedence("cast") + 1); emit(") >> "); shallowP(b, precedence(">>") + 1)
-    case Node(s, op, List(a), _) if math.contains(op) =>
-      registerHeader("<math.h>")
-      registerLibrary("-lm")
-      emit(s"$op("); shallow(a); emit(")")
-    case Node(s, "cast", a::_, _) =>
-      // NOTE: removing upcast can lead to errors because if inlining:
-      // int32_t x = ...
-      // int64_t hash = (x << 6) + ...
-      // is different from
-      // int32_t x = ...
-      // int64_t hash = ((int64_t)x << 6) + ...
-      val tpe = typeMap.getOrElse(s, manifest[Unknown])
-      emit(s"(${remap(tpe)})"); shallowP(a, precedence("cast"))
-    case Node(s,"String.charAt",List(a,i),_) =>
-      shallowP(a); emit("["); shallow(i); emit("]")
-    case Node(s,"array_get",List(a,i),_) =>
-      shallowP(a); emit("["); shallow(i); emit("]")
-    // case Node(s,"var_get",List(a),_) =>
+  override def shallow(n: Node): Unit =
+    n match {
+      case Node(s, ">>>", List(a, b), _) =>
+        emit("(("); emit(remapUnsigned(typeMap.getOrElse(s, manifest[Unknown]))); emit(") ")
+        shallowP(a, precedence("cast") + 1); emit(") >> "); shallowP(b, precedence(">>") + 1)
+      case Node(s, op, List(a), _) if math.contains(op) =>
+        registerHeader("<math.h>")
+        registerLibrary("-lm")
+        emit(s"$op("); shallow(a); emit(")")
+      case Node(s, "cast", a :: _, _) =>
+        // NOTE: removing upcast can lead to errors because if inlining:
+        // int32_t x = ...
+        // int64_t hash = (x << 6) + ...
+        // is different from
+        // int32_t x = ...
+        // int64_t hash = ((int64_t)x << 6) + ...
+        val tpe = typeMap.getOrElse(s, manifest[Unknown])
+        emit(s"(${remap(tpe)})"); shallowP(a, precedence("cast"))
+      case Node(s, "String.charAt", List(a, i), _) =>
+        shallowP(a); emit("["); shallow(i); emit("]")
+      case Node(s, "array_get", List(a, i), _) =>
+        shallowP(a); emit("["); shallow(i); emit("]")
+      // case Node(s,"var_get",List(a),_) =>
       // quote(a)+s"/*${quote(s)}*/"
 
-    // case n @ Node(s,"comment",_,_) =>
+      // case n @ Node(s,"comment",_,_) =>
       // s"(${super.shallow(n)})" // GNU C block expr
-     // Have to be duplicated to be bfore generic C version
-    case n @ Node(s,"?",List(c, a: Block, b: Block),_) if b.isPure && b.res == Const(false) =>
-      shallowP(c, precedence("&&")); emit(" && "); quoteBlockP(precedence("&&") + 1)(traverse(a))
-    case n @ Node(s,"?",List(c, a: Block, b: Block),_) if a.isPure && a.res == Const(true) =>
-      shallowP(c, precedence("||")); emit(" || "); quoteBlockP(precedence("||") + 1)(traverse(b))
-    case n @ Node(f,"?",c::(a:Block)::(b:Block)::_,_) =>
-      shallowP(c, precedence("?") + 1); emit(" ? ")
-      quoteBlockP(precedence("?") + 1)(traverse(a))
-      emit(" : ")
-      quoteBlockP(precedence("?") + 1)(traverse(b))
-    case n @ Node(f,"W",List(c:Block,b:Block),_) => ???
-    case n @ Node(s,"generate-comment",List(Const(x: String)),_) => ???
+      // Have to be duplicated to be bfore generic C version
+      case n @ Node(s, "?", List(c, a: Block, b: Block), _) if b.isPure && b.res == Const(false) =>
+        shallowP(c, precedence("&&")); emit(" && "); quoteBlockP(precedence("&&") + 1)(traverse(a))
+      case n @ Node(s, "?", List(c, a: Block, b: Block), _) if a.isPure && a.res == Const(true) =>
+        shallowP(c, precedence("||")); emit(" || "); quoteBlockP(precedence("||") + 1)(traverse(b))
+      case n @ Node(f, "?", c :: (a: Block) :: (b: Block) :: _, _) =>
+        shallowP(c, precedence("?") + 1); emit(" ? ")
+        quoteBlockP(precedence("?") + 1)(traverse(a))
+        emit(" : ")
+        quoteBlockP(precedence("?") + 1)(traverse(b))
+      case n @ Node(f, "W", List(c: Block, b: Block), _) => ???
+      case n @ Node(s, "generate-comment", List(Const(x: String)), _) => ???
 
-    case n @ Node(s,"P",List(x),_) =>
-      emit("""printf("%s\n", """); shallow(x); emit(")");
-    case n @ Node(s, "λ", (block: Block)::Const(0)::Nil, _) =>
-      registerTopLevelFunction(quote(s)) {
-        emitFunction(quote(s), block)
-      }
-      emit(quote(s))
-    case n @ Node(s, "reffield_get", List(ptr, Const(field: String)), _) =>
-      shallowP(ptr, precedence("reffield_get")); emit("->"); emit(field)
-    case n @ Node(s, "ref_new", List(v), _) =>
-      emit("&"); shallowP(v, precedence("ref_new"))
-    case n @ Node(s, "NewArray" ,List(x), _) =>
-      val tpe = remap(typeMap.get(s).map(_.typeArguments.head).getOrElse(manifest[Unknown]))
-      emit(s"($tpe*)malloc("); shallowP(x, precedence("*")); emit(s" * sizeof($tpe))")
-    case n @ Node(s, "mmap" ,List(len, fd), _) =>
-      val tpe = remap(typeMap.get(s).map(_.typeArguments.head).getOrElse(manifest[Unknown]))
-      emit(s"($tpe*)mmap(0, "); shallow(len); emit(", PROT_READ, MAP_FILE | MAP_SHARED, "); shallow(fd); emit(", 0)")
-    case n @ Node(s, "NewArray" ,List(x, Const(0)), _) =>
-      val tpe = remap(typeMap.get(s).map(_.typeArguments.head).getOrElse(manifest[Unknown]))
-      emit(s"($tpe*)calloc("); shallow(x); emit(s", sizeof($tpe))")
-    case n @ Node(s,"array_new",List(x),_) =>
-      emit(s"(int*)malloc("); shallowP(x, precedence("*")); emit(s" * sizeof(int))")
-    case n @ Node(s,"array_slice",List(x, idx, _), _) =>
-      shallowP(x, precedence("+")); emit(" + "); shallowP(idx, precedence("+") + 1)
-    case n @ Node(s,"array_length",List(x), _) => ???
-    case n @ Node(s,"array_sort",List(arr, len, arr2, comp),_) => // FIXME: not arr duplicated?
-      emit("qsort("); shallow(arr); emit(" ,"); shallow(len); emit(", sizeof(*"); shallow(arr2); emit("), (__compar_fn_t)"); shallow(comp); emit(")")
-    case n @ Node(s,"array_free", List(arr), _) =>
-      emit("free("); shallow(arr); emit(")")
-    case n @ Node(s,"array_resize", List(arr, nsize), _) =>
-      val tpe = remap(typeMap.get(s).map(_.typeArguments.head).getOrElse(manifest[Unknown]))
-      emit(s"($tpe*)realloc("); shallow(arr); emit(", "); shallowP(nsize, precedence("*")); emit(s" * sizeof($tpe))")
-    case n @ Node(s, "array-of-char-to-string", List(x:Sym), _) =>
-      shallow(x) // FIXME(feiw): this is currently wrong: should have array copy
-    case n @ Node(s,op,args,_) if nameMap contains op =>
-      shallow(n.copy(op = nameMap(n.op)))
-    case n @ Node(f, "λforward", _, _) => ??? // this case is short cut at traverse function!
-    case n @ Node(s,op,args,_) if op.startsWith("unchecked") => // unchecked
-      var next = 9 // skip unchecked
-      for (a <- args) {
-        val i = op.indexOf("[ ]", next)
-        assert(i >= next)
-        emit(op.substring(next,i))
-        shallow(a)
-        next = i + 3
-      }
-      emit(op.substring(next))
-    case n @ Node(s,op,args,_) if op.startsWith("String") => // String methods
-      registerHeader("<string.h>")
-      (op.substring(7), args) match {
-        case ("slice", List(lhs, idx, _)) => shallowP(lhs, precedence("+")); emit(" + "); shallowP(idx, precedence("+") + 1)
-        case ("equalsTo", List(lhs, rhs)) => emit("strcmp("); shallow(lhs); emit(", "); shallow(rhs); emit(" == 0");
-        case ("toDouble", List(rhs)) => emit("atof("); shallow(rhs); emit(")")
-        case ("toInt", List(rhs)) => emit("atoi("); shallow(rhs); emit(")")
-        case ("length", List(rhs)) => emit("strlen("); shallow(rhs); emit(")")
-        case (a, _) => System.out.println(s"TODO: $a - ${args.length}"); ???
-      }
-    case n @ Node(s,op,args,_) if op.contains('.') && !op.contains(' ') => // method call
-      val (recv::args1) = args
-      if (args1.length > 0) {
-        shallowP(recv); emit("."); emit(op.drop(op.lastIndexOf('.') + 1)); emit("("); shallow(args1.head); args1.tail.foreach { emit(", "); shallow(_) }; emit(")")
-      } else {
-        shallowP(recv); emit("."); emit(op.drop(op.lastIndexOf('.') + 1))
-      }
-    case n =>
-      super.shallow(n)
-  }
+      case n @ Node(s, "P", List(x), _) =>
+        emit("""printf("%s\n", """); shallow(x); emit(")");
+      case n @ Node(s, "λ", (block: Block) :: Const(0) :: Nil, _) =>
+        registerTopLevelFunction(quote(s)) {
+          emitFunction(quote(s), block)
+        }
+        emit(quote(s))
+      case n @ Node(s, "reffield_get", List(ptr, Const(field: String)), _) =>
+        shallowP(ptr, precedence("reffield_get")); emit("->"); emit(field)
+      case n @ Node(s, "ref_new", List(v), _) =>
+        emit("&"); shallowP(v, precedence("ref_new"))
+      case n @ Node(s, "NewArray", List(x), _) =>
+        val tpe = remap(typeMap.get(s).map(_.typeArguments.head).getOrElse(manifest[Unknown]))
+        emit(s"($tpe*)malloc("); shallowP(x, precedence("*")); emit(s" * sizeof($tpe))")
+      case n @ Node(s, "mmap", List(len, fd), _) =>
+        val tpe = remap(typeMap.get(s).map(_.typeArguments.head).getOrElse(manifest[Unknown]))
+        emit(s"($tpe*)mmap(0, "); shallow(len); emit(", PROT_READ, MAP_FILE | MAP_SHARED, "); shallow(fd); emit(", 0)")
+      case n @ Node(s, "NewArray", List(x, Const(0)), _) =>
+        val tpe = remap(typeMap.get(s).map(_.typeArguments.head).getOrElse(manifest[Unknown]))
+        emit(s"($tpe*)calloc("); shallow(x); emit(s", sizeof($tpe))")
+      case n @ Node(s, "array_new", List(x), _) =>
+        emit(s"(int*)malloc("); shallowP(x, precedence("*")); emit(s" * sizeof(int))")
+      case n @ Node(s, "array_slice", List(x, idx, _), _) =>
+        shallowP(x, precedence("+")); emit(" + "); shallowP(idx, precedence("+") + 1)
+      case n @ Node(s, "array_length", List(x), _) => ???
+      case n @ Node(s, "array_sort", List(arr, len, arr2, comp), _) => // FIXME: not arr duplicated?
+        emit("qsort("); shallow(arr); emit(" ,"); shallow(len); emit(", sizeof(*"); shallow(arr2);
+        emit("), (__compar_fn_t)"); shallow(comp); emit(")")
+      case n @ Node(s, "array_free", List(arr), _) =>
+        emit("free("); shallow(arr); emit(")")
+      case n @ Node(s, "array_resize", List(arr, nsize), _) =>
+        val tpe = remap(typeMap.get(s).map(_.typeArguments.head).getOrElse(manifest[Unknown]))
+        emit(s"($tpe*)realloc("); shallow(arr); emit(", "); shallowP(nsize, precedence("*")); emit(s" * sizeof($tpe))")
+      case n @ Node(s, "array-of-char-to-string", List(x: Sym), _) =>
+        shallow(x) // FIXME(feiw): this is currently wrong: should have array copy
+      case n @ Node(s, op, args, _) if nameMap contains op =>
+        shallow(n.copy(op = nameMap(n.op)))
+      case n @ Node(f, "λforward", _, _) => ??? // this case is short cut at traverse function!
+      case n @ Node(s, op, args, _) if op.startsWith("unchecked") => // unchecked
+        var next = 9 // skip unchecked
+        for (a <- args) {
+          val i = op.indexOf("[ ]", next)
+          assert(i >= next)
+          emit(op.substring(next, i))
+          shallow(a)
+          next = i + 3
+        }
+        emit(op.substring(next))
+      case n @ Node(s, op, args, _) if op.startsWith("String") => // String methods
+        registerHeader("<string.h>")
+        (op.substring(7), args) match {
+          case ("slice", List(lhs, idx, _)) =>
+            shallowP(lhs, precedence("+")); emit(" + "); shallowP(idx, precedence("+") + 1)
+          case ("equalsTo", List(lhs, rhs)) => emit("strcmp("); shallow(lhs); emit(", "); shallow(rhs); emit(" == 0");
+          case ("toDouble", List(rhs)) => emit("atof("); shallow(rhs); emit(")")
+          case ("toInt", List(rhs)) => emit("atoi("); shallow(rhs); emit(")")
+          case ("length", List(rhs)) => emit("strlen("); shallow(rhs); emit(")")
+          case (a, _) => System.out.println(s"TODO: $a - ${args.length}"); ???
+        }
+      case n @ Node(s, op, args, _) if op.contains('.') && !op.contains(' ') => // method call
+        val (recv :: args1) = args
+        if (args1.length > 0) {
+          shallowP(recv); emit("."); emit(op.drop(op.lastIndexOf('.') + 1)); emit("("); shallow(args1.head);
+          args1.tail.foreach { emit(", "); shallow(_) }; emit(")")
+        } else {
+          shallowP(recv); emit("."); emit(op.drop(op.lastIndexOf('.') + 1))
+        }
+      case n =>
+        super.shallow(n)
+    }
 
-  override def traverse(n: Node): Unit = n match {
-    case n @ Node(s,"var_new",List(x),_) =>
-      emitVarDef(n)
-    case n @ Node(s, "local_struct", Nil, _) =>
-      val tpe = remap(typeMap.getOrElse(s, manifest[Unknown]))
-      emitln(s"$tpe ${quote(s)} = { 0 };") // FIXME: uninitialized? or add it as argument?
-    case n @ Node(s,"var_set",List(x,y),_) =>
-      emit(s"${quote(x)} = "); shallow(y); emitln(";")
-    case n @ Node(s, "reffield_set", List(ptr, Const(field: String), v), _) =>
-      shallowP(ptr, precedence("reffield_get")); emit("->"); emit(field); emit(" = "); shallow(v); emitln(";")
-    // static array
-    case n @ Node(s, "Array" , xs,_) =>
-      val tpe = remap(typeMap.get(s).map(_.typeArguments.head).getOrElse(manifest[Unknown]))
-      emit(s"$tpe ${quote(s)}[${xs.length}] = { "); shallow(xs.head); xs.tail.foreach(x => {emit(", "); shallow(x)}); emitln(" };")
-
-    case n @ Node(s, "NewArray", List(x, Const(v)), _) if v != 0 =>
-      val tpe = remap(typeMap.get(s).map(_.typeArguments.head).getOrElse(manifest[Unknown]))
-      emit(s"long ${quote(s)}_len = "); shallowP(x, precedence("*")); emitln(s" * sizeof($tpe);")
-      emitln(s"$tpe* ${quote(s)} = ($tpe*)malloc(${quote(s)}_len)")
-      emitln(s"memset(${quote(s)}, $v, ${quote(s)}_len);")
-    // DCE: FIXME:
-    // (a) check that args have no side-effects
-    //      maybe this can be ensured by overriding InlineSym?
-    // DCE: FIXME:
-    // (a) check that args have no side-effects
-    //      maybe this can be ensured by overriding InlineSym?
-    //      should never inline a live expr into something that's not live ...
-    // (b) dce above should anticipate that these will be eliminated
-    //      do not register dependencies as live!
-    case n @ Node(s,"var_get",_,_) if !dce.live(s) => ??? // no-op
-    case n @ Node(s,"array_get",_,_) if !dce.live(s) => ??? // no-op
-
-    case n @ Node(s,"array_set",List(x,i,y),_) =>
-      shallowP(x); emit("["); shallow(i); emit("] = "); shallow(y); emitln(";")
-
-    case n @ Node(s, "array_copyTo", List(src, dst, start, len), _) =>
-      emit("memcpy("); shallowP(dst, precedence("+")); emit(" + "); shallowP(start, precedence("+") + 1); emit(", "); shallow(src); emit(", "); shallow(len); emitln(");")
-
-    case n @ Node(s,"?",c::(a:Block)::(b:Block)::_,_) if !dce.live(s) =>
-      emit(s"if ("); shallow(c); emit(") ")
-      quoteBlock(traverse(a))
-      quoteElseBlock(traverse(b))
-      emitln()
-
-    case n @ Node(s,"W",List(c:Block,b:Block),_) =>
-      emit("while (")
-      quoteBlockP(traverse(c))
-      emit(") ")
-      quoteBlock(traverse(b))
-      emitln()
-
-    case n @ Node(_, "switch", (guard: Exp)::default::others, _) =>
-      val tp = typeBlockRes(guard)
-      assert(tp == manifest[Long] || tp == manifest[Int] || tp == manifest[Short] || tp == manifest[Char])
-      emit("switch ("); shallow(guard); emitln(") {");
-      others.grouped(2).foreach {
-        case Seq(Const(cases: Seq[Const]), block: Block) =>
-          cases.foreach(x => emitln(s"case ${quote(x)}:;")) // extra ; used to avoid error on case 2: int x = 1; ....
-          noquoteBlock(traverse(block))
-          emitln("break;")
-      }
-      default match {
-        case block: Block =>
-          emitln("default:;")
-          noquoteBlock(traverse(block))
-          emitln("break;")
-        case _ =>
-      }
-      emitln("}")
-
-    case n @ Node(s,"generate-comment",List(Const(x: String)),_) =>
-      emit("// "); emitln(x)
-
-    case n @ Node(s,"comment",Const(str: String)::Const(verbose: Boolean)::(b:Block)::_,_) =>
-      emitln("//# " + str)
-      if (verbose) {
-        emitln("// generated code for " + str.replace('_', ' '))
-      } else {
-        emitln("// generated code")
-      }
-      if (dce.live(s)) {
+  override def traverse(n: Node): Unit =
+    n match {
+      case n @ Node(s, "var_new", List(x), _) =>
+        emitVarDef(n)
+      case n @ Node(s, "local_struct", Nil, _) =>
         val tpe = remap(typeMap.getOrElse(s, manifest[Unknown]))
-        emit(tpe); emit(" "); emit(quote(s)); emit(" = "); quoteBlockP(traverse(b))
-      } else {
-        traverse(b)
-      }
-      emitln(";\n//# " + str)
-    case n @ Node(s, "λforward", List(y, arity), _) =>
-      emitln("//# lambda forward is here!")
-      // for this case, adding (f, y) in forwardMap is all we need
-      // XXX: this is most likely not enough in the general case
-      rename(s) = quote(y)
-    case n @ Node(s, "λ", (block: Block)::Const(0)::Nil, _) => // FIXME: check free var?
-      registerTopLevelFunction(quote(s)) {
-        emitFunction(quote(s), block)
-      }
-    case n @ Node(s, "timestamp", _, _) =>
-      registerHeader("<sys/time.h>")
-      emitln(s"struct timeval ${quote(s)}_t;")
-      emitln(s"gettimeofday(&${quote(s)}_t, NULL);")
-      emitln(s"long ${quote(s)} = ${quote(s)}_t.tv_sec * 1000000L + ${quote(s)}_t.tv_usec;");
-    case n @ Node(s, "exit", List(x) ,_) =>
-      emit("fflush(stdout); fflush(stderr); exit("); shallow(x); emitln(");")
-    case _ =>
-      // emit(s"val ${quote(s)} = " + shallow(n))
-      emitValDef(n)
-  }
+        emitln(s"$tpe ${quote(s)} = { 0 };") // FIXME: uninitialized? or add it as argument?
+      case n @ Node(s, "var_set", List(x, y), _) =>
+        emit(s"${quote(x)} = "); shallow(y); emitln(";")
+      case n @ Node(s, "reffield_set", List(ptr, Const(field: String), v), _) =>
+        shallowP(ptr, precedence("reffield_get")); emit("->"); emit(field); emit(" = "); shallow(v); emitln(";")
+      // static array
+      case n @ Node(s, "Array", xs, _) =>
+        val tpe = remap(typeMap.get(s).map(_.typeArguments.head).getOrElse(manifest[Unknown]))
+        emit(s"$tpe ${quote(s)}[${xs.length}] = { "); shallow(xs.head);
+        xs.tail.foreach(x => { emit(", "); shallow(x) }); emitln(" };")
+
+      case n @ Node(s, "NewArray", List(x, Const(v)), _) if v != 0 =>
+        val tpe = remap(typeMap.get(s).map(_.typeArguments.head).getOrElse(manifest[Unknown]))
+        emit(s"long ${quote(s)}_len = "); shallowP(x, precedence("*")); emitln(s" * sizeof($tpe);")
+        emitln(s"$tpe* ${quote(s)} = ($tpe*)malloc(${quote(s)}_len)")
+        emitln(s"memset(${quote(s)}, $v, ${quote(s)}_len);")
+      // DCE: FIXME:
+      // (a) check that args have no side-effects
+      //      maybe this can be ensured by overriding InlineSym?
+      // DCE: FIXME:
+      // (a) check that args have no side-effects
+      //      maybe this can be ensured by overriding InlineSym?
+      //      should never inline a live expr into something that's not live ...
+      // (b) dce above should anticipate that these will be eliminated
+      //      do not register dependencies as live!
+      case n @ Node(s, "var_get", _, _) if !dce.live(s) => ??? // no-op
+      case n @ Node(s, "array_get", _, _) if !dce.live(s) => ??? // no-op
+
+      case n @ Node(s, "array_set", List(x, i, y), _) =>
+        shallowP(x); emit("["); shallow(i); emit("] = "); shallow(y); emitln(";")
+
+      case n @ Node(s, "array_copyTo", List(src, dst, start, len), _) =>
+        emit("memcpy("); shallowP(dst, precedence("+")); emit(" + "); shallowP(start, precedence("+") + 1); emit(", ");
+        shallow(src); emit(", "); shallow(len); emitln(");")
+
+      case n @ Node(s, "?", c :: (a: Block) :: (b: Block) :: _, _) if !dce.live(s) =>
+        emit(s"if ("); shallow(c); emit(") ")
+        quoteBlock(traverse(a))
+        quoteElseBlock(traverse(b))
+        emitln()
+
+      case n @ Node(s, "W", List(c: Block, b: Block), _) =>
+        emit("while (")
+        quoteBlockP(traverse(c))
+        emit(") ")
+        quoteBlock(traverse(b))
+        emitln()
+
+      case n @ Node(_, "switch", (guard: Exp) :: default :: others, _) =>
+        val tp = typeBlockRes(guard)
+        assert(tp == manifest[Long] || tp == manifest[Int] || tp == manifest[Short] || tp == manifest[Char])
+        emit("switch ("); shallow(guard); emitln(") {");
+        others.grouped(2).foreach {
+          case Seq(Const(cases: Seq[Const]), block: Block) =>
+            cases.foreach(x => emitln(s"case ${quote(x)}:;")) // extra ; used to avoid error on case 2: int x = 1; ....
+            noquoteBlock(traverse(block))
+            emitln("break;")
+        }
+        default match {
+          case block: Block =>
+            emitln("default:;")
+            noquoteBlock(traverse(block))
+            emitln("break;")
+          case _ =>
+        }
+        emitln("}")
+
+      case n @ Node(s, "generate-comment", List(Const(x: String)), _) =>
+        emit("// "); emitln(x)
+
+      case n @ Node(s, "comment", Const(str: String) :: Const(verbose: Boolean) :: (b: Block) :: _, _) =>
+        emitln("//# " + str)
+        if (verbose) {
+          emitln("// generated code for " + str.replace('_', ' '))
+        } else {
+          emitln("// generated code")
+        }
+        if (dce.live(s)) {
+          val tpe = remap(typeMap.getOrElse(s, manifest[Unknown]))
+          emit(tpe); emit(" "); emit(quote(s)); emit(" = "); quoteBlockP(traverse(b))
+        } else {
+          traverse(b)
+        }
+        emitln(";\n//# " + str)
+      case n @ Node(s, "λforward", List(y, arity), _) =>
+        emitln("//# lambda forward is here!")
+        // for this case, adding (f, y) in forwardMap is all we need
+        // XXX: this is most likely not enough in the general case
+        rename(s) = quote(y)
+      case n @ Node(s, "λ", (block: Block) :: Const(0) :: Nil, _) => // FIXME: check free var?
+        registerTopLevelFunction(quote(s)) {
+          emitFunction(quote(s), block)
+        }
+      case n @ Node(s, "timestamp", _, _) =>
+        registerHeader("<sys/time.h>")
+        emitln(s"struct timeval ${quote(s)}_t;")
+        emitln(s"gettimeofday(&${quote(s)}_t, NULL);")
+        emitln(s"long ${quote(s)} = ${quote(s)}_t.tv_sec * 1000000L + ${quote(s)}_t.tv_usec;");
+      case n @ Node(s, "exit", List(x), _) =>
+        emit("fflush(stdout); fflush(stderr); exit("); shallow(x); emitln(");")
+      case _ =>
+        // emit(s"val ${quote(s)} = " + shallow(n))
+        emitValDef(n)
+    }
 
   // FIXME Too ugly!!!!
-  var graphCache: Map[Sym,Node] = _
-  def isWritableSym(w: Sym): Boolean = graphCache.get(w) match {
-    case Some(Node(_, "var_new", _, _)) => true // ok
-    case _ => false
-  }
+  var graphCache: Map[Sym, Node] = _
+  def isWritableSym(w: Sym): Boolean =
+    graphCache.get(w) match {
+      case Some(Node(_, "var_new", _, _)) => true // ok
+      case _ => false
+    }
 
   def run(name: String, g: Graph) = {
     capture {
@@ -575,14 +600,14 @@ class ExtendedCCodeGen extends CompactCodeGen with ExtendedCodeGen {
     else "" // manifest[Unit]
   }
 
-  def emitAll(g: Graph, name: String)(m1:Manifest[_],m2:Manifest[_]): Unit = {
+  def emitAll(g: Graph, name: String)(m1: Manifest[_], m2: Manifest[_]): Unit = {
     val ng = init(g)
     val efs = "" //quoteEff(g.block.ein)
     val stt = dce.statics.toList.map(quoteStatic).mkString(", ")
     emitln("""
-    |/*****************************************
-    |Emitting C Generated Code
-    |*******************************************/
+             |/*****************************************
+             |Emitting C Generated Code
+             |*******************************************/
     """.stripMargin)
     val src = run(name, ng)
     emitDefines(stream)
@@ -593,14 +618,14 @@ class ExtendedCCodeGen extends CompactCodeGen with ExtendedCodeGen {
     emitln(s"\n/**************** $name ****************/")
     emit(src)
     emitln("""
-    |/*****************************************
-    |End of C Generated Code
-    |*******************************************/
-    |int main(int argc, char *argv[]) {
-    |  if (argc != 2) {
-    |    printf("usage: %s <arg>\n", argv[0]);
-    |    return 0;
-    |  }""".stripMargin)
+             |/*****************************************
+             |End of C Generated Code
+             |*******************************************/
+             |int main(int argc, char *argv[]) {
+             |  if (argc != 2) {
+             |    printf("usage: %s <arg>\n", argv[0]);
+             |    return 0;
+             |  }""".stripMargin)
     if (initStream.size > 0) emitln("if (init()) return 0;")
     emitln(s"  $name(${convert("argv[1]", m1)});\n  return 0;\n}")
   }

--- a/src/main/scala/lms/core/codegen/cpp_codegen.scala
+++ b/src/main/scala/lms/core/codegen/cpp_codegen.scala
@@ -20,92 +20,259 @@ trait CPPOps { b: Base =>
   case class CapAll(s: String) extends Capture
   case class CopyOne[T: Manifest](s: Rep[T]) extends Capture
   case class RefOne[T: Manifest](s: Rep[T]) extends Capture
-  implicit def liftCapture(s:String) = Capture(s)
-  private def unwrap(c: Capture) = c match {
-    case CapAll(s: String) => lms.core.Backend.Const(s)
-    case CopyOne(s: Rep[_]) => Unwrap(s)
-    case RefOne(s: Rep[_]) => Unwrap(s)
-  }
+  implicit def liftCapture(s: String) = Capture(s)
+  private def unwrap(c: Capture) =
+    c match {
+      case CapAll(s: String) => lms.core.Backend.Const(s)
+      case CopyOne(s: Rep[_]) => Unwrap(s)
+      case RefOne(s: Rep[_]) => Unwrap(s)
+    }
 
-  def fun[A:Manifest,B:Manifest](capture: Seq[Capture], f: Rep[A] => Rep[B]): Rep[A => B] =
-    Wrap[A=>B](__fun(f, 1, xn => Unwrap(f(Wrap[A](xn(0)))), capture.map(unwrap): _*))
+  def fun[A: Manifest, B: Manifest](capture: Seq[Capture], f: Rep[A] => Rep[B]): Rep[A => B] =
+    Wrap[A => B](__fun(f, 1, xn => Unwrap(f(Wrap[A](xn(0)))), capture.map(unwrap): _*))
 
-  def fun[A:Manifest,B:Manifest,C:Manifest](capture: Seq[Capture], f: (Rep[A], Rep[B]) => Rep[C]): Rep[(A, B) => C] =
-    Wrap[(A,B)=>C](__fun(f, 2, xn => Unwrap(f(Wrap[A](xn(0)), Wrap[B](xn(1)))), capture.map(unwrap): _*))
+  def fun[A: Manifest, B: Manifest, C: Manifest](
+      capture: Seq[Capture],
+      f: (Rep[A], Rep[B]) => Rep[C]
+  ): Rep[(A, B) => C] =
+    Wrap[(A, B) => C](__fun(f, 2, xn => Unwrap(f(Wrap[A](xn(0)), Wrap[B](xn(1)))), capture.map(unwrap): _*))
 
-  def fun[A:Manifest,B:Manifest,C:Manifest,D:Manifest](capture: Seq[Capture], f: (Rep[A], Rep[B], Rep[C]) => Rep[D]): Rep[(A, B, C) => D] =
-    Wrap[(A,B,C)=>D](__fun(f, 3, xn => Unwrap(f(Wrap[A](xn(0)), Wrap[B](xn(1)), Wrap[C](xn(2)))), capture.map(unwrap): _*))
+  def fun[A: Manifest, B: Manifest, C: Manifest, D: Manifest](
+      capture: Seq[Capture],
+      f: (Rep[A], Rep[B], Rep[C]) => Rep[D]
+  ): Rep[(A, B, C) => D] =
+    Wrap[(A, B, C) => D](
+      __fun(f, 3, xn => Unwrap(f(Wrap[A](xn(0)), Wrap[B](xn(1)), Wrap[C](xn(2)))), capture.map(unwrap): _*)
+    )
 
-  def fun[A:Manifest,B:Manifest,C:Manifest,D:Manifest,E:Manifest](capture: Seq[Capture], f: (Rep[A], Rep[B], Rep[C], Rep[D]) => Rep[E]): Rep[(A, B, C, D) => E] =
-    Wrap[(A,B,C,D)=>E](__fun(f, 4, xn => Unwrap(f(Wrap[A](xn(0)), Wrap[B](xn(1)), Wrap[C](xn(2)), Wrap[D](xn(3)))), capture.map(unwrap): _*))
+  def fun[A: Manifest, B: Manifest, C: Manifest, D: Manifest, E: Manifest](
+      capture: Seq[Capture],
+      f: (Rep[A], Rep[B], Rep[C], Rep[D]) => Rep[E]
+  ): Rep[(A, B, C, D) => E] =
+    Wrap[(A, B, C, D) => E](
+      __fun(
+        f,
+        4,
+        xn => Unwrap(f(Wrap[A](xn(0)), Wrap[B](xn(1)), Wrap[C](xn(2)), Wrap[D](xn(3)))),
+        capture.map(unwrap): _*
+      )
+    )
 
-  def fun[A:Manifest,B:Manifest,C:Manifest,D:Manifest,E:Manifest,F:Manifest](capture: Seq[Capture], f:(Rep[A], Rep[B], Rep[C], Rep[D], Rep[E]) => Rep[F]):
-    Rep[(A, B, C, D, E) => F] =
-    Wrap[(A,B,C,D,E)=>F](__fun(f, 5, xn => Unwrap(f(Wrap[A](xn(0)), Wrap[B](xn(1)), Wrap[C](xn(2)), Wrap[D](xn(3)), Wrap[E](xn(4)))), capture.map(unwrap): _*))
+  def fun[A: Manifest, B: Manifest, C: Manifest, D: Manifest, E: Manifest, F: Manifest](
+      capture: Seq[Capture],
+      f: (Rep[A], Rep[B], Rep[C], Rep[D], Rep[E]) => Rep[F]
+  ): Rep[(A, B, C, D, E) => F] =
+    Wrap[(A, B, C, D, E) => F](
+      __fun(
+        f,
+        5,
+        xn => Unwrap(f(Wrap[A](xn(0)), Wrap[B](xn(1)), Wrap[C](xn(2)), Wrap[D](xn(3)), Wrap[E](xn(4)))),
+        capture.map(unwrap): _*
+      )
+    )
 
-  def fun[A:Manifest,B:Manifest,C:Manifest,D:Manifest,E:Manifest,F:Manifest,G:Manifest]
-    (capture: Seq[Capture], f:(Rep[A], Rep[B], Rep[C], Rep[D], Rep[E], Rep[F]) => Rep[G]): Rep[(A, B, C, D, E, F) => G] =
-    Wrap[(A,B,C,D,E,F)=>G](__fun(f, 6, xn => Unwrap(f(Wrap[A](xn(0)), Wrap[B](xn(1)), Wrap[C](xn(2)), Wrap[D](xn(3)), Wrap[E](xn(4)), Wrap[F](xn(5)))), capture.map(unwrap): _*))
+  def fun[A: Manifest, B: Manifest, C: Manifest, D: Manifest, E: Manifest, F: Manifest, G: Manifest](
+      capture: Seq[Capture],
+      f: (Rep[A], Rep[B], Rep[C], Rep[D], Rep[E], Rep[F]) => Rep[G]
+  ): Rep[(A, B, C, D, E, F) => G] =
+    Wrap[(A, B, C, D, E, F) => G](
+      __fun(
+        f,
+        6,
+        xn => Unwrap(f(Wrap[A](xn(0)), Wrap[B](xn(1)), Wrap[C](xn(2)), Wrap[D](xn(3)), Wrap[E](xn(4)), Wrap[F](xn(5)))),
+        capture.map(unwrap): _*
+      )
+    )
 
-  def fun[A:Manifest,B:Manifest,C:Manifest,D:Manifest,E:Manifest,F:Manifest,G:Manifest,H:Manifest]
-    (capture: Seq[Capture], f:(Rep[A], Rep[B], Rep[C], Rep[D], Rep[E], Rep[F], Rep[G]) => Rep[H]): Rep[(A, B, C, D, E, F, G) => H] =
-    Wrap[(A,B,C,D,E,F,G)=>H](__fun(f, 7, xn => Unwrap(f(Wrap[A](xn(0)), Wrap[B](xn(1)), Wrap[C](xn(2)), Wrap[D](xn(3)), Wrap[E](xn(4)), Wrap[F](xn(5)), Wrap[G](xn(6)))),
-                                   capture.map(unwrap): _*))
+  def fun[A: Manifest, B: Manifest, C: Manifest, D: Manifest, E: Manifest, F: Manifest, G: Manifest, H: Manifest](
+      capture: Seq[Capture],
+      f: (Rep[A], Rep[B], Rep[C], Rep[D], Rep[E], Rep[F], Rep[G]) => Rep[H]
+  ): Rep[(A, B, C, D, E, F, G) => H] =
+    Wrap[(A, B, C, D, E, F, G) => H](
+      __fun(
+        f,
+        7,
+        xn =>
+          Unwrap(
+            f(
+              Wrap[A](xn(0)),
+              Wrap[B](xn(1)),
+              Wrap[C](xn(2)),
+              Wrap[D](xn(3)),
+              Wrap[E](xn(4)),
+              Wrap[F](xn(5)),
+              Wrap[G](xn(6))
+            )
+          ),
+        capture.map(unwrap): _*
+      )
+    )
 
-  def fun[A:Manifest,B:Manifest,C:Manifest,D:Manifest,E:Manifest,F:Manifest,G:Manifest,H:Manifest,I:Manifest]
-    (capture: Seq[Capture], f:(Rep[A], Rep[B], Rep[C], Rep[D], Rep[E], Rep[F], Rep[G], Rep[H]) => Rep[I]): Rep[(A, B, C, D, E, F, G, H) => I] =
-    Wrap[(A,B,C,D,E,F,G,H)=>I](__fun(f, 8, xn => Unwrap(f(Wrap[A](xn(0)), Wrap[B](xn(1)), Wrap[C](xn(2)), Wrap[D](xn(3)), Wrap[E](xn(4)), Wrap[F](xn(5)), Wrap[G](xn(6)), Wrap[H](xn(7)))),
-                                   capture.map(unwrap): _*))
+  def fun[
+      A: Manifest,
+      B: Manifest,
+      C: Manifest,
+      D: Manifest,
+      E: Manifest,
+      F: Manifest,
+      G: Manifest,
+      H: Manifest,
+      I: Manifest
+  ](
+      capture: Seq[Capture],
+      f: (Rep[A], Rep[B], Rep[C], Rep[D], Rep[E], Rep[F], Rep[G], Rep[H]) => Rep[I]
+  ): Rep[(A, B, C, D, E, F, G, H) => I] =
+    Wrap[(A, B, C, D, E, F, G, H) => I](
+      __fun(
+        f,
+        8,
+        xn =>
+          Unwrap(
+            f(
+              Wrap[A](xn(0)),
+              Wrap[B](xn(1)),
+              Wrap[C](xn(2)),
+              Wrap[D](xn(3)),
+              Wrap[E](xn(4)),
+              Wrap[F](xn(5)),
+              Wrap[G](xn(6)),
+              Wrap[H](xn(7))
+            )
+          ),
+        capture.map(unwrap): _*
+      )
+    )
 
-  def fun[A:Manifest,B:Manifest,C:Manifest,D:Manifest,E:Manifest,F:Manifest,G:Manifest,H:Manifest,I:Manifest,J:Manifest]
-    (capture: Seq[Capture], f:(Rep[A], Rep[B], Rep[C], Rep[D], Rep[E], Rep[F], Rep[G], Rep[H], Rep[I]) => Rep[J]): Rep[(A, B, C, D, E, F, G, H, I) => J] =
-    Wrap[(A,B,C,D,E,F,G,H,I)=>J](__fun(f, 9, xn => Unwrap(f(Wrap[A](xn(0)), Wrap[B](xn(1)), Wrap[C](xn(2)), Wrap[D](xn(3)), Wrap[E](xn(4)), Wrap[F](xn(5)), Wrap[G](xn(6)), Wrap[H](xn(7)), Wrap[I](xn(8)))),
-                                   capture.map(unwrap): _*))
+  def fun[
+      A: Manifest,
+      B: Manifest,
+      C: Manifest,
+      D: Manifest,
+      E: Manifest,
+      F: Manifest,
+      G: Manifest,
+      H: Manifest,
+      I: Manifest,
+      J: Manifest
+  ](
+      capture: Seq[Capture],
+      f: (Rep[A], Rep[B], Rep[C], Rep[D], Rep[E], Rep[F], Rep[G], Rep[H], Rep[I]) => Rep[J]
+  ): Rep[(A, B, C, D, E, F, G, H, I) => J] =
+    Wrap[(A, B, C, D, E, F, G, H, I) => J](
+      __fun(
+        f,
+        9,
+        xn =>
+          Unwrap(
+            f(
+              Wrap[A](xn(0)),
+              Wrap[B](xn(1)),
+              Wrap[C](xn(2)),
+              Wrap[D](xn(3)),
+              Wrap[E](xn(4)),
+              Wrap[F](xn(5)),
+              Wrap[G](xn(6)),
+              Wrap[H](xn(7)),
+              Wrap[I](xn(8))
+            )
+          ),
+        capture.map(unwrap): _*
+      )
+    )
 
-  def fun[A:Manifest,B:Manifest,C:Manifest,D:Manifest,E:Manifest,F:Manifest,G:Manifest,H:Manifest,I:Manifest,J:Manifest,K:Manifest]
-    (capture: Seq[Capture], f:(Rep[A], Rep[B], Rep[C], Rep[D], Rep[E], Rep[F], Rep[G], Rep[H], Rep[I], Rep[J]) => Rep[K]): Rep[(A, B, C, D, E, F, G, H, I, J) => K] =
-    Wrap[(A,B,C,D,E,F,G,H,I,J)=>K](__fun(f, 9, xn => Unwrap(f(Wrap[A](xn(0)), Wrap[B](xn(1)), Wrap[C](xn(2)), Wrap[D](xn(3)), Wrap[E](xn(4)), Wrap[F](xn(5)), Wrap[G](xn(6)), Wrap[H](xn(7)), Wrap[I](xn(8)), Wrap[J](xn(9)))),
-                                   capture.map(unwrap): _*))
+  def fun[
+      A: Manifest,
+      B: Manifest,
+      C: Manifest,
+      D: Manifest,
+      E: Manifest,
+      F: Manifest,
+      G: Manifest,
+      H: Manifest,
+      I: Manifest,
+      J: Manifest,
+      K: Manifest
+  ](
+      capture: Seq[Capture],
+      f: (Rep[A], Rep[B], Rep[C], Rep[D], Rep[E], Rep[F], Rep[G], Rep[H], Rep[I], Rep[J]) => Rep[K]
+  ): Rep[(A, B, C, D, E, F, G, H, I, J) => K] =
+    Wrap[(A, B, C, D, E, F, G, H, I, J) => K](
+      __fun(
+        f,
+        9,
+        xn =>
+          Unwrap(
+            f(
+              Wrap[A](xn(0)),
+              Wrap[B](xn(1)),
+              Wrap[C](xn(2)),
+              Wrap[D](xn(3)),
+              Wrap[E](xn(4)),
+              Wrap[F](xn(5)),
+              Wrap[G](xn(6)),
+              Wrap[H](xn(7)),
+              Wrap[I](xn(8)),
+              Wrap[J](xn(9))
+            )
+          ),
+        capture.map(unwrap): _*
+      )
+    )
 }
 
 trait ExtendedCPPCodeGen extends ExtendedCCodeGen {
 
   // remap for function types
   override def function(sig: List[Manifest[_]]): String = {
-      registerHeader("<functional>")
-      val ret = remap(sig.last)
-      val params = sig.init.map(remap(_)).mkString(", ")
-      s"std::function<$ret($params)>"
+    registerHeader("<functional>")
+    val ret = remap(sig.last)
+    val params = sig.init.map(remap(_)).mkString(", ")
+    s"std::function<$ret($params)>"
   }
 
   // inlining closure sometimes have trouble
   // for details, check test `returned_lambda_0`
-  override def mayInline(n: Node): Boolean = n match {
-    case Node(s, "λ", _, _) => false
-    case _ => super.mayInline(n)
-  }
+  override def mayInline(n: Node): Boolean =
+    n match {
+      case Node(s, "λ", _, _) => false
+      case _ => super.mayInline(n)
+    }
 
   // emit closures with explicit argument types and return type
   // `argMod`/`retMod` specifies pass by copy or reference
-  def quoteTypedBlock(b: Block, autoArgType: Boolean, retType: Boolean,
-                      capture: String = "&", argMod: Option[List[String]] = None, retMod: Option[String] = None): Unit = {
+  def quoteTypedBlock(
+      b: Block,
+      autoArgType: Boolean,
+      retType: Boolean,
+      capture: String = "&",
+      argMod: Option[List[String]] = None,
+      retMod: Option[String] = None
+  ): Unit = {
     val eff = quoteEff(b.ein)
     val args = argMod match {
       case Some(mods) =>
-        assert(mods.length == b.in.length, s"argMod should have same length as block inputs ${mods.length} ${b.in.length}")
-        b.in.zipWithIndex.map{
-          case (s, i) =>
-            val mod = mods(i)
-            if (autoArgType) s"auto$mod ${quote(s)}"
-            else s"${remap(typeMap(s))}$mod ${quote(s)}"
-        }.mkString(", ")
-      case None => b.in.map{s =>
-          if (autoArgType) s"auto ${quote(s)}"
-          else s"${remap(typeMap(s))} ${quote(s)}"
-      }.mkString(", ")
+        assert(
+          mods.length == b.in.length,
+          s"argMod should have same length as block inputs ${mods.length} ${b.in.length}"
+        )
+        b.in.zipWithIndex
+          .map {
+            case (s, i) =>
+              val mod = mods(i)
+              if (autoArgType) s"auto$mod ${quote(s)}"
+              else s"${remap(typeMap(s))}$mod ${quote(s)}"
+          }
+          .mkString(", ")
+      case None =>
+        b.in
+          .map { s =>
+            if (autoArgType) s"auto ${quote(s)}"
+            else s"${remap(typeMap(s))} ${quote(s)}"
+          }
+          .mkString(", ")
     }
     val mod = retMod.getOrElse("")
-    val ret: String = if (retType) "->"+remap(typeBlockRes(b.res))+mod else ""
+    val ret: String = if (retType) "->" + remap(typeBlockRes(b.res)) + mod else ""
 
     // special case if capture is "mutable"
     if (capture == "mutable") emit(s"[=](${args}) mutable $ret $eff")
@@ -114,17 +281,18 @@ trait ExtendedCPPCodeGen extends ExtendedCCodeGen {
     quoteBlockPReturn(traverse(b))
   }
 
-  override def shallow(n: Node): Unit = n match {
-    case n @ Node(s, "λ", (block: Block)::Nil, _) =>
-      quoteTypedBlock(block, false, false, capture = "")
-    case n @ Node(s, "λ", (block: Block)::Backend.Const(m:String)::rest, _) =>
-      val cap = m match {
-        case "=" => ("=" +: rest.map(r => s"&${quote(r)}")).mkString(", ")
-        case "&" => ("&" +: rest.map(quote(_))).mkString(", ")
-        case _ => ???
-      }
-      quoteTypedBlock(block, false, false, capture = cap)
-    case _ => super.shallow(n)
-  }
+  override def shallow(n: Node): Unit =
+    n match {
+      case n @ Node(s, "λ", (block: Block) :: Nil, _) =>
+        quoteTypedBlock(block, false, false, capture = "")
+      case n @ Node(s, "λ", (block: Block) :: Backend.Const(m: String) :: rest, _) =>
+        val cap = m match {
+          case "=" => ("=" +: rest.map(r => s"&${quote(r)}")).mkString(", ")
+          case "&" => ("&" +: rest.map(quote(_))).mkString(", ")
+          case _ => ???
+        }
+        quoteTypedBlock(block, false, false, capture = cap)
+      case _ => super.shallow(n)
+    }
 
 }

--- a/src/main/scala/lms/core/codegen/cps_codegen.scala
+++ b/src/main/scala/lms/core/codegen/cps_codegen.scala
@@ -9,30 +9,33 @@ import java.io.{ByteArrayOutputStream, PrintStream}
 import Backend._
 
 /**
- * On top of the CPSTraverser, we can build code generators that run in CPS.
- * Here we show a CPSScalaCodeGen. However, the CPSScalaCodeGen isn't just generating
- * normal code with CPS traverser. It is generated code that can manipulate continuations:
- * i.e., support `shift1` and `reset1` in the LMS IR.
- *
- * However, note that this code gen is quite rudimentary (no inlining, types are simple).
- * This is just a show case of CPS code gen, not the one actually used in production.
- */
+  * On top of the CPSTraverser, we can build code generators that run in CPS.
+  * Here we show a CPSScalaCodeGen. However, the CPSScalaCodeGen isn't just generating
+  * normal code with CPS traverser. It is generated code that can manipulate continuations:
+  * i.e., support `shift1` and `reset1` in the LMS IR.
+  *
+  * However, note that this code gen is quite rudimentary (no inlining, types are simple).
+  * This is just a show case of CPS code gen, not the one actually used in production.
+  */
 class CPSScalaCodeGen extends CPSTraverser {
 
   var trace = 0
-  def fresh = try { trace } finally { trace += 1 }
+  def fresh =
+    try { trace }
+    finally { trace += 1 }
   def emit(s: String) = print(s)
   def emitln(s: String) = println(s)
 
   // Although the paramete `s` is of type `Def`
   // this function is only handling `Exp`
-  def quote(s: Def): String = s match {
-    case Sym(n) => s"x$n"
-    case Const(x: String) => "\""+x+"\""
-    case Const(x: Char) => "'"+x+"'"
-    case Const(x) => x.toString
-    case _ => System.out.println("Block not supported"); ???
-  }
+  def quote(s: Def): String =
+    s match {
+      case Sym(n) => s"x$n"
+      case Const(x: String) => "\"" + x + "\""
+      case Const(x: Char) => "'" + x + "'"
+      case Const(x) => x.toString
+      case _ => System.out.println("Block not supported"); ???
+    }
 
   // this function tracks the set of continuations, because
   // application of continutations do not generate another continuation
@@ -40,135 +43,134 @@ class CPSScalaCodeGen extends CPSTraverser {
 
   // In this simple case, the main difference between a codegen pass and
   // a generic traverser is that each node has to generate some code.
-  override def traverse(n: Node)(k: => Unit): Unit = n match {
+  override def traverse(n: Node)(k: => Unit): Unit =
+    n match {
 
-    // `shift` captures the current continutation (generate a def)
-    // and then generates the `shift` body.
-    case n @ Node(s,"shift1",List(y:Block),_) =>
-      contSet += y.in.head
-      emitln(s"def ${quote(y.in.head)}($s: Int) = {"); k; emitln("\n}")
-      traverse(y)(v => emitln(quote(v)))
+      // `shift` captures the current continutation (generate a def)
+      // and then generates the `shift` body.
+      case n @ Node(s, "shift1", List(y: Block), _) =>
+        contSet += y.in.head
+        emitln(s"def ${quote(y.in.head)}($s: Int) = {"); k; emitln("\n}")
+        traverse(y)(v => emitln(quote(v)))
 
-    // `reset` needs to deliminate the continuation, thus the continuation `k` is
-    // not supplied to the traverse of the reset block.
-    case n @ Node(s,"reset1",List(y:Block),_) =>
-      emitln(s"val ${quote(s)} = {")
-      traverse(y){ v => emit(quote(v)) }
-      emitln("\n}")
-      k
+      // `reset` needs to deliminate the continuation, thus the continuation `k` is
+      // not supplied to the traverse of the reset block.
+      case n @ Node(s, "reset1", List(y: Block), _) =>
+        emitln(s"val ${quote(s)} = {")
+        traverse(y) { v => emit(quote(v)) }
+        emitln("\n}")
+        k
 
-    // In CPS code, all functions should have additional parameter, the continuation
-    case n @ Node(f,"λ",List(y:Block),_) =>
-      val x = y.in.head
-      emitln(s"def ${quote(f)}(c: Int => Int, ${quote(x)}: Int): Int = {")
-      traverse(y, f){ v => emit("c("); emit(quote(v)); emit(")") }
-      emitln("\n}")
-      k
+      // In CPS code, all functions should have additional parameter, the continuation
+      case n @ Node(f, "λ", List(y: Block), _) =>
+        val x = y.in.head
+        emitln(s"def ${quote(f)}(c: Int => Int, ${quote(x)}: Int): Int = {")
+        traverse(y, f) { v => emit("c("); emit(quote(v)); emit(")") }
+        emitln("\n}")
+        k
 
-    // "λforward" is the used for recursive functions (as a function name declaration)
-    case n @ Node(s,"λforward",List(x, arity), _) =>
-      emitln(s"lazy val $s = ${quote(x)} _"); k
+      // "λforward" is the used for recursive functions (as a function name declaration)
+      case n @ Node(s, "λforward", List(x, arity), _) =>
+        emitln(s"lazy val $s = ${quote(x)} _"); k
 
-    // application needs to be split into 2 cases: function appliation and continuation application
-    // Continuation Application (the true case) is simple (just apply and continue)
-    // Function Application (the false case) should capture the continuation
-    //    and use it as the first argument of the generated function.
-    case n @ Node(s,"@",x::y::_,_) =>
-      if (x.isInstanceOf[Sym] && contSet.contains(x.asInstanceOf[Sym])) {
-        emitln(s"val ${quote(s)} = ${quote(x)}(${quote(y)})"); k
-      } else {
+      // application needs to be split into 2 cases: function appliation and continuation application
+      // Continuation Application (the true case) is simple (just apply and continue)
+      // Function Application (the false case) should capture the continuation
+      //    and use it as the first argument of the generated function.
+      case n @ Node(s, "@", x :: y :: _, _) =>
+        if (x.isInstanceOf[Sym] && contSet.contains(x.asInstanceOf[Sym])) {
+          emitln(s"val ${quote(s)} = ${quote(x)}(${quote(y)})"); k
+        } else {
+          val index = fresh
+          emitln(s"def cApp$index($s: Int) = {"); k; emitln("\n}")
+          emitln(s"${quote(x)}(cApp$index, ${quote(y)})")
+        }
+
+      // In CPS conditional, there should be a continuation `cIf`, and then
+      // each branch should call the continuation at the end.
+      // Note that the 2 traverse(block) cannot be code in tandem
+      // like `traverse(a){ v => emit ... ; traverse(b) { v => emit ...}}`
+      // because we are doing code generation (the generated code are static, and
+      // both branches are generated). For instance, if the true branch has a
+      // `shift1`, the code for the false branch should not be captured as part of
+      // the shift continuation!
+      case n @ Node(f, "?", c :: (a: Block) :: (b: Block) :: _, _) =>
         val index = fresh
-        emitln(s"def cApp$index($s: Int) = {"); k; emitln("\n}")
-        emitln(s"${quote(x)}(cApp$index, ${quote(y)})")
-      }
+        emitln(s"def cIf$index($f: Int) = {"); k; emitln("\n}")
+        emitln(s"if (${quote(c)}) {")
+        traverse(a) { v => emit(s"cIf$index("); emit(quote(v)); emit(")") }
+        emitln("\n} else {")
+        traverse(b) { v => emit(s"cIf$index("); emit(quote(v)); emit(")") }
+        emitln("\n}")
 
-    // In CPS conditional, there should be a continuation `cIf`, and then
-    // each branch should call the continuation at the end.
-    // Note that the 2 traverse(block) cannot be code in tandem
-    // like `traverse(a){ v => emit ... ; traverse(b) { v => emit ...}}`
-    // because we are doing code generation (the generated code are static, and
-    // both branches are generated). For instance, if the true branch has a
-    // `shift1`, the code for the false branch should not be captured as part of
-    // the shift continuation!
-    case n @ Node(f,"?",c::(a:Block)::(b:Block)::_,_) =>
-      val index = fresh
-      emitln(s"def cIf$index($f: Int) = {"); k; emitln("\n}")
-      emitln(s"if (${quote(c)}) {")
-      traverse(a){ v => emit(s"cIf$index("); emit(quote(v)); emit(")") }
-      emitln("\n} else {")
-      traverse(b){ v => emit(s"cIf$index("); emit(quote(v)); emit(")") }
-      emitln("\n}")
+      // CPS loop is generated as recursive function `def loop`
+      // In the recursive function, the true branch recurses on `loop`, while
+      // the false branch runs the code after the loop (the continuation).
+      case n @ Node(f, "W", List(c: Block, b: Block), _) =>
+        val index = fresh
+        emitln(s"def loop$index(): Int = {")
+        traverse(c) { v => emit("if ("); emit(quote(v)); emit(") ") }
+        emitln("{")
+        traverse(b) { v => emit(s"loop$index()") }
+        emitln("\n} else {")
+        k
+        emitln("\n}\n}")
+        emit(s"loop$index()")
 
-    // CPS loop is generated as recursive function `def loop`
-    // In the recursive function, the true branch recurses on `loop`, while
-    // the false branch runs the code after the loop (the continuation).
-    case n @ Node(f,"W", List(c:Block, b:Block),_) =>
-      val index = fresh
-      emitln(s"def loop$index(): Int = {")
-      traverse(c){ v => emit("if ("); emit(quote(v)); emit(") ") }
-      emitln("{")
-      traverse(b) { v => emit(s"loop$index()") }
-      emitln("\n} else {")
-      k
-      emitln("\n}\n}")
-      emit(s"loop$index()")
-
-    // Simple computations are generated in direct style.
-    case n @ Node(s,"+",List(x,y),_) =>
-      emitln(s"val $s = ${quote(x)} + ${quote(y)}"); k
-    case n @ Node(s,"-",List(x,y),_) =>
-      emitln(s"val $s = ${quote(x)} - ${quote(y)}"); k
-    case n @ Node(s,"*",List(x,y),_) =>
-      emitln(s"val $s = ${quote(x)} * ${quote(y)}"); k
-    case n @ Node(s,"/",List(x,y),_) =>
-      emitln(s"val $s = ${quote(x)} / ${quote(y)}"); k
-    case n @ Node(s,"%",List(x,y),_) =>
-      emitln(s"val $s = ${quote(x)} % ${quote(y)}"); k
-    case n @ Node(s,"==",List(x,y),_) =>
-      emitln(s"val $s = ${quote(x)} == ${quote(y)}"); k
-    case n @ Node(s,"!=",List(x,y),_) =>
-      emitln(s"val $s = ${quote(x)} != ${quote(y)}"); k
-    case n @ Node(s,">",List(x,y), _) =>
-      emitln(s"val $s = ${quote(x)} > ${quote(y)}"); k
-    case n @ Node(s,"<",List(x,y), _) =>
-      emitln(s"val $s = ${quote(x)} < ${quote(y)}"); k
-    case n @ Node(s,">=",List(x,y), _) =>
-      emitln(s"val $s = ${quote(x)} >= ${quote(y)}"); k
-    case n @ Node(s,"<=",List(x,y), _) =>
-      emitln(s"val $s = ${quote(x)} <= ${quote(y)}"); k
-    case n @ Node(s,"var_new",List(x),_) =>
-      emitln(s"var $s = ${quote(x)}"); k
-    case n @ Node(s,"var_get",List(x),_) =>
-      emitln(s"val $s = ${quote(x)}"); k
-    case n @ Node(s,"var_set",List(x,y),_) =>
-      emitln(s"${quote(x)} = ${quote(y)}"); k
-    case n @ Node(s,"array_new",List(x),_) =>
-      emitln(s"var $s = new Array[Int](${quote(x)})"); k
-    case n @ Node(s,"array_get",List(x,i),_) =>
-      emitln(s"val $s = ${quote(x)}(${quote(i)})"); k
-    case n @ Node(s,"array_set",List(x,i,y),_) =>
-      emitln(s"${quote(x)}(${quote(i)}) = ${quote(y)}"); k
-    case n @ Node(s,"P",List(x),_) =>
-      emitln(s"val $s = println(${quote(x)})"); k
-    case n @ Node(_,_,_,_) =>
-      emitln(s"??? " + n.toString); k
-  }
+      // Simple computations are generated in direct style.
+      case n @ Node(s, "+", List(x, y), _) =>
+        emitln(s"val $s = ${quote(x)} + ${quote(y)}"); k
+      case n @ Node(s, "-", List(x, y), _) =>
+        emitln(s"val $s = ${quote(x)} - ${quote(y)}"); k
+      case n @ Node(s, "*", List(x, y), _) =>
+        emitln(s"val $s = ${quote(x)} * ${quote(y)}"); k
+      case n @ Node(s, "/", List(x, y), _) =>
+        emitln(s"val $s = ${quote(x)} / ${quote(y)}"); k
+      case n @ Node(s, "%", List(x, y), _) =>
+        emitln(s"val $s = ${quote(x)} % ${quote(y)}"); k
+      case n @ Node(s, "==", List(x, y), _) =>
+        emitln(s"val $s = ${quote(x)} == ${quote(y)}"); k
+      case n @ Node(s, "!=", List(x, y), _) =>
+        emitln(s"val $s = ${quote(x)} != ${quote(y)}"); k
+      case n @ Node(s, ">", List(x, y), _) =>
+        emitln(s"val $s = ${quote(x)} > ${quote(y)}"); k
+      case n @ Node(s, "<", List(x, y), _) =>
+        emitln(s"val $s = ${quote(x)} < ${quote(y)}"); k
+      case n @ Node(s, ">=", List(x, y), _) =>
+        emitln(s"val $s = ${quote(x)} >= ${quote(y)}"); k
+      case n @ Node(s, "<=", List(x, y), _) =>
+        emitln(s"val $s = ${quote(x)} <= ${quote(y)}"); k
+      case n @ Node(s, "var_new", List(x), _) =>
+        emitln(s"var $s = ${quote(x)}"); k
+      case n @ Node(s, "var_get", List(x), _) =>
+        emitln(s"val $s = ${quote(x)}"); k
+      case n @ Node(s, "var_set", List(x, y), _) =>
+        emitln(s"${quote(x)} = ${quote(y)}"); k
+      case n @ Node(s, "array_new", List(x), _) =>
+        emitln(s"var $s = new Array[Int](${quote(x)})"); k
+      case n @ Node(s, "array_get", List(x, i), _) =>
+        emitln(s"val $s = ${quote(x)}(${quote(i)})"); k
+      case n @ Node(s, "array_set", List(x, i, y), _) =>
+        emitln(s"${quote(x)}(${quote(i)}) = ${quote(y)}"); k
+      case n @ Node(s, "P", List(x), _) =>
+        emitln(s"val $s = println(${quote(x)})"); k
+      case n @ Node(_, _, _, _) =>
+        emitln(s"??? " + n.toString); k
+    }
 
   override def apply(g: Graph): Unit = {
     bound(g)
     path = Nil; inner = g.nodes
-    traverse(g.block){ e => emit(s"${quote(e)} /*exit ${quote(e)}*/") }
+    traverse(g.block) { e => emit(s"${quote(e)} /*exit ${quote(e)}*/") }
   }
 
-  def emitAll(g: Graph)(m1:Manifest[_],m2:Manifest[_]): Unit = {
+  def emitAll(g: Graph)(m1: Manifest[_], m2: Manifest[_]): Unit = {
     val arg = quote(g.block.in.head)
-    emitln(
-      s"""
-        |class Snippet extends (${m1.toString} => ${m2.toString}) {
-        |  def apply($arg: ${m1.toString}): ${m2.toString} = {
+    emitln(s"""
+              |class Snippet extends (${m1.toString} => ${m2.toString}) {
+              |  def apply($arg: ${m1.toString}): ${m2.toString} = {
        """.stripMargin)
     apply(g)
     emitln("\n}\n}")
   }
 }
-

--- a/src/main/scala/lms/core/codegen/scala_codegen.scala
+++ b/src/main/scala/lms/core/codegen/scala_codegen.scala
@@ -9,19 +9,20 @@ import java.io.{ByteArrayOutputStream, PrintStream}
 import Backend._
 
 /**
- * The `ScalaCodeGen` is a simple code generation class built on Traverser.
- * It is not used in production.
- */
+  * The `ScalaCodeGen` is a simple code generation class built on Traverser.
+  * It is not used in production.
+  */
 class ScalaCodeGen extends Traverser {
 
   def emit(s: String) = println(s)
 
-  def quote(s: Def): String = s match {
-    case Sym(n) => s"x$n"
-    case Const(x: String) => "\""+x+"\""
-    case Const(x: Char) => "'"+x+"'"
-    case Const(x) => x.toString
-  }
+  def quote(s: Def): String =
+    s match {
+      case Sym(n) => s"x$n"
+      case Const(x: String) => "\"" + x + "\""
+      case Const(x: Char) => "'" + x + "'"
+      case Const(x) => x.toString
+    }
 
   var printRes = true
   override def traverse(ns: Seq[Node], y: Block): Unit = {
@@ -30,91 +31,91 @@ class ScalaCodeGen extends Traverser {
     else printRes = true
   }
 
-  override def traverse(n: Node): Unit = n match {
-    case n @ Node(f, "λ", (y:Block)::_, _) =>
-      val para = y.in.length match {
-        case 0 => ""
-        case 1 => s"${quote(y.in.head)}: Int"
-        case 2 => s"${quote(y.in.head)}: Int => Int, ${quote(y.in.tail.head)}: Int"
-      }
-      emit(s"def ${quote(f)}($para): Int = {")
-      // see what becomes available given new bound vars
-      traverse(y, f)
-      emit(s"}")
-    case n @ Node(f,"?",c::(a:Block)::(b:Block)::_,_) =>
-      emit(s"val $f = if (${quote(c)}) {")
-      traverse(a)
-      emit(s"} else {")
-      traverse(b)
-      emit(s"}")
-    case n @ Node(f,"W",List(c:Block,b:Block),_) =>
-      emit(s"while ({")
-      traverse(c)
-      emit(s"}) {")
-      traverse(b)
-      emit(s"}")
-    case n @ Node(s,"+",List(x,y),_) =>
-      emit(s"val $s = ${quote(x)} + ${quote(y)}")
-    case n @ Node(s,"-",List(x,y),_) =>
-      emit(s"val $s = ${quote(x)} - ${quote(y)}")
-    case n @ Node(s,"*",List(x,y),_) =>
-      emit(s"val $s = ${quote(x)} * ${quote(y)}")
-    case n @ Node(s,"/",List(x,y),_) =>
-      emit(s"val $s = ${quote(x)} / ${quote(y)}")
-    case n @ Node(s,"%",List(x,y),_) =>
-      emit(s"val $s = ${quote(x)} % ${quote(y)}")
-    case n @ Node(s,"==",List(x,y),_) =>
-      emit(s"val $s = ${quote(x)} == ${quote(y)}")
-    case n @ Node(s,"!=",List(x,y),_) =>
-      emit(s"val $s = ${quote(x)} != ${quote(y)}")
-    case n @ Node(s,"var_new",List(x),_) =>
-      emit(s"var $s = ${quote(x)}")
-    case n @ Node(s,"var_get",List(x),_) =>
-      emit(s"val $s = ${quote(x)}")
-    case n @ Node(s,"var_set",List(x,y),_) =>
-      emit(s"${quote(x)} = ${quote(y)}")
-    case n @ Node(s,"array_new",List(x),_) =>
-      emit(s"var $s = new Array[Int](${quote(x)})")
-    case n @ Node(s,"array_get",List(x,i),_) =>
-      emit(s"val $s = ${quote(x)}(${quote(i)})")
-    case n @ Node(s,"array_set",List(x,i,y),_) =>
-      emit(s"${quote(x)}(${quote(i)}) = ${quote(y)}")
-    case n @ Node(s,"@",x::y,_) =>
-      emit(s"val $s = ${quote(x)}(${y.map(quote).mkString(", ")})")
-    case n @ Node(s,"P",List(x),_) =>
-      emit(s"val $s = println(${quote(x)})")
-    case n @ Node(s,">",List(x,y), _) =>
-      emit(s"val $s = ${quote(x)} > ${quote(y)}")
-    case n @ Node(s,"<",List(x,y), _) =>
-      emit(s"val $s = ${quote(x)} < ${quote(y)}")
-    case n @ Node(s,">=",List(x,y), _) =>
-      emit(s"val $s = ${quote(x)} >= ${quote(y)}")
-    case n @ Node(s,"<=",List(x,y), _) =>
-      emit(s"val $s = ${quote(x)} <= ${quote(y)}")
-    case n @ Node(s,"λforward",List(x, arity), _) =>
-      emit(s"lazy val $s = ${quote(x)} _")
-    case n @ Node(s, "define_exit", _, _) =>
-      emit(s"def exit(res: Int): Int = res")
-    case n @ Node(s, "exit", List(x), _) =>
-      emit(s"${quote(x)} /*exit: ${quote(x)} */")
-      printRes = false
-    case n @ Node(s, "reset0", List(x:Block), _) =>
-      emit(s"val $s = {"); traverse(x); emit("\n}")
-    case n @ Node(_,_,_,_) =>
-      emit(s"??? " + n.toString)
-  }
+  override def traverse(n: Node): Unit =
+    n match {
+      case n @ Node(f, "λ", (y: Block) :: _, _) =>
+        val para = y.in.length match {
+          case 0 => ""
+          case 1 => s"${quote(y.in.head)}: Int"
+          case 2 => s"${quote(y.in.head)}: Int => Int, ${quote(y.in.tail.head)}: Int"
+        }
+        emit(s"def ${quote(f)}($para): Int = {")
+        // see what becomes available given new bound vars
+        traverse(y, f)
+        emit(s"}")
+      case n @ Node(f, "?", c :: (a: Block) :: (b: Block) :: _, _) =>
+        emit(s"val $f = if (${quote(c)}) {")
+        traverse(a)
+        emit(s"} else {")
+        traverse(b)
+        emit(s"}")
+      case n @ Node(f, "W", List(c: Block, b: Block), _) =>
+        emit(s"while ({")
+        traverse(c)
+        emit(s"}) {")
+        traverse(b)
+        emit(s"}")
+      case n @ Node(s, "+", List(x, y), _) =>
+        emit(s"val $s = ${quote(x)} + ${quote(y)}")
+      case n @ Node(s, "-", List(x, y), _) =>
+        emit(s"val $s = ${quote(x)} - ${quote(y)}")
+      case n @ Node(s, "*", List(x, y), _) =>
+        emit(s"val $s = ${quote(x)} * ${quote(y)}")
+      case n @ Node(s, "/", List(x, y), _) =>
+        emit(s"val $s = ${quote(x)} / ${quote(y)}")
+      case n @ Node(s, "%", List(x, y), _) =>
+        emit(s"val $s = ${quote(x)} % ${quote(y)}")
+      case n @ Node(s, "==", List(x, y), _) =>
+        emit(s"val $s = ${quote(x)} == ${quote(y)}")
+      case n @ Node(s, "!=", List(x, y), _) =>
+        emit(s"val $s = ${quote(x)} != ${quote(y)}")
+      case n @ Node(s, "var_new", List(x), _) =>
+        emit(s"var $s = ${quote(x)}")
+      case n @ Node(s, "var_get", List(x), _) =>
+        emit(s"val $s = ${quote(x)}")
+      case n @ Node(s, "var_set", List(x, y), _) =>
+        emit(s"${quote(x)} = ${quote(y)}")
+      case n @ Node(s, "array_new", List(x), _) =>
+        emit(s"var $s = new Array[Int](${quote(x)})")
+      case n @ Node(s, "array_get", List(x, i), _) =>
+        emit(s"val $s = ${quote(x)}(${quote(i)})")
+      case n @ Node(s, "array_set", List(x, i, y), _) =>
+        emit(s"${quote(x)}(${quote(i)}) = ${quote(y)}")
+      case n @ Node(s, "@", x :: y, _) =>
+        emit(s"val $s = ${quote(x)}(${y.map(quote).mkString(", ")})")
+      case n @ Node(s, "P", List(x), _) =>
+        emit(s"val $s = println(${quote(x)})")
+      case n @ Node(s, ">", List(x, y), _) =>
+        emit(s"val $s = ${quote(x)} > ${quote(y)}")
+      case n @ Node(s, "<", List(x, y), _) =>
+        emit(s"val $s = ${quote(x)} < ${quote(y)}")
+      case n @ Node(s, ">=", List(x, y), _) =>
+        emit(s"val $s = ${quote(x)} >= ${quote(y)}")
+      case n @ Node(s, "<=", List(x, y), _) =>
+        emit(s"val $s = ${quote(x)} <= ${quote(y)}")
+      case n @ Node(s, "λforward", List(x, arity), _) =>
+        emit(s"lazy val $s = ${quote(x)} _")
+      case n @ Node(s, "define_exit", _, _) =>
+        emit(s"def exit(res: Int): Int = res")
+      case n @ Node(s, "exit", List(x), _) =>
+        emit(s"${quote(x)} /*exit: ${quote(x)} */")
+        printRes = false
+      case n @ Node(s, "reset0", List(x: Block), _) =>
+        emit(s"val $s = {"); traverse(x); emit("\n}")
+      case n @ Node(_, _, _, _) =>
+        emit(s"??? " + n.toString)
+    }
 
   override def apply(g: Graph): Unit = {
     bound(g)
     withScope(Nil, g.nodes) { traverse(g.block) }
   }
 
-  def emitAll(g: Graph)(m1:Manifest[_],m2:Manifest[_]): Unit = {
+  def emitAll(g: Graph)(m1: Manifest[_], m2: Manifest[_]): Unit = {
     val arg = quote(g.block.in.head)
-    emit(
-      s"""
-        |class Snippet extends (${m1.toString} => ${m2.toString}) {
-        |  def apply($arg: ${m1.toString}): ${m2.toString} = {
+    emit(s"""
+            |class Snippet extends (${m1.toString} => ${m2.toString}) {
+            |  def apply($arg: ${m1.toString}): ${m2.toString} = {
        """.stripMargin)
     apply(g)
     emit("\n}\n}")
@@ -122,21 +123,22 @@ class ScalaCodeGen extends Traverser {
 }
 
 /**
- * The `CompactScalaCodeGen` is only used for some legacy tests in the repo that
- * do not start from the stub.scala frontend. As a result, the IR generated do not have
- * typeMap, thus cannot use the ExtendedCodeGen trait.
- * FIXME(feiw) Maybe rewrite those legacy tests with the stub.scala frontend, and update
- *   the tests to use ExtendedScalaCodeGen. Then this CompactScalaCodeGen can be merged
- *   into ExtendedScalaCodeGen.
- */
+  * The `CompactScalaCodeGen` is only used for some legacy tests in the repo that
+  * do not start from the stub.scala frontend. As a result, the IR generated do not have
+  * typeMap, thus cannot use the ExtendedCodeGen trait.
+  * FIXME(feiw) Maybe rewrite those legacy tests with the stub.scala frontend, and update
+  *   the tests to use ExtendedScalaCodeGen. Then this CompactScalaCodeGen can be merged
+  *   into ExtendedScalaCodeGen.
+  */
 class CompactScalaCodeGen extends CompactCodeGen {
   def emit(s: String): Unit = print(s)
   def emitln(s: String = ""): Unit = println(s)
 
-  override def quote(s: Def) = s match {
-    case Const(null) => "null"
-    case _ => super.quote(s)
-  }
+  override def quote(s: Def) =
+    s match {
+      case Const(null) => "null"
+      case _ => super.quote(s)
+    }
 
   def quoteBlock(header: String)(f: => Unit): Unit = {
     def wraper(numStms: Int, l: Option[Node], y: Block)(f: => Unit) = {
@@ -156,82 +158,87 @@ class CompactScalaCodeGen extends CompactCodeGen {
       val tp = if (argType) (": Int") else "" //FIXME(GW): get the type annotation, add a typeMap?
       quote(arg) + tp
     })
-    val argsStr = if (args.length == 1 && !argType) s"${args.head}$eff => "
-                  else args.mkString("(", ", ", s")$eff => ")
+    val argsStr =
+      if (args.length == 1 && !argType) s"${args.head}$eff => "
+      else args.mkString("(", ", ", s")$eff => ")
     quoteBlock(argsStr)(traverse(b))
   }
 
-  def precedence(op: String): Int = op match {
-    case "?" => 1
-    case "||" => 2
-    case "&&" => 3
-    case "|" => 4
-    case "^" => 5
-    case "&" => 6
-    case "==" | "!=" => 7
-    case "<" | ">" | "<=" | ">=" => 8
-    case "<<" | ">>" | ">>>" => 9
-    case "+" | "-" => 10
-    case "*" | "/" | "%" => 11
-    case "cast" => 12
-    case _ if op.startsWith("unchecked") => 0 // force parenthesis if nested: 3 * unchecked(5 + 4)
-    case "λ" => 19 // less than 20?
-    case _ => 20
-  }
+  def precedence(op: String): Int =
+    op match {
+      case "?" => 1
+      case "||" => 2
+      case "&&" => 3
+      case "|" => 4
+      case "^" => 5
+      case "&" => 6
+      case "==" | "!=" => 7
+      case "<" | ">" | "<=" | ">=" => 8
+      case "<<" | ">>" | ">>>" => 9
+      case "+" | "-" => 10
+      case "*" | "/" | "%" => 11
+      case "cast" => 12
+      case _ if op.startsWith("unchecked") => 0 // force parenthesis if nested: 3 * unchecked(5 + 4)
+      case "λ" => 19 // less than 20?
+      case _ => 20
+    }
 
-  override def shallow(n: Node): Unit = { n match {
-    case n @ Node(f, "λ", (y:Block)::_, _) =>
-      // XXX what should we do for functions?
-      // proper inlining will likely work better
-      // as a separate phase b/c it may trigger
-      // further optimizations
-      // Note: if argument types have to be emitted, ExtendedScalaCodeGen has overrided this case
-      quoteBlock(y, true)
+  override def shallow(n: Node): Unit = {
+    n match {
+      case n @ Node(f, "λ", (y: Block) :: _, _) =>
+        // XXX what should we do for functions?
+        // proper inlining will likely work better
+        // as a separate phase b/c it may trigger
+        // further optimizations
+        // Note: if argument types have to be emitted, ExtendedScalaCodeGen has overrided this case
+        quoteBlock(y, true)
 
-    case n @ Node(s,op,List(x),_) if math(op) =>
-      emit(s"scala.math.$op("); shallowP(x); emit(")")
+      case n @ Node(s, op, List(x), _) if math(op) =>
+        emit(s"scala.math.$op("); shallowP(x); emit(")")
 
-    case n @ Node(s,"array_get",List(x,i),_) =>
-      shallow(x); emit("("); shallow(i); emit(")")
+      case n @ Node(s, "array_get", List(x, i), _) =>
+        shallow(x); emit("("); shallow(i); emit(")")
 
-    case n @ Node(s,"P",List(x),_) =>
-      emit("println("); shallow(x); emit(")")
+      case n @ Node(s, "P", List(x), _) =>
+        emit("println("); shallow(x); emit(")")
 
-    case n @ Node(s,"comment",Const(str: String)::Const(verbose: Boolean)::(b:Block)::_,_) =>
-      quoteBlock {
-        emitln("//#" + str)
-        if (verbose) {
-          emitln("// generated code for " + str.replace('_', ' '))
-        } else {
-          emitln("// generated code")
+      case n @ Node(s, "comment", Const(str: String) :: Const(verbose: Boolean) :: (b: Block) :: _, _) =>
+        quoteBlock {
+          emitln("//#" + str)
+          if (verbose) {
+            emitln("// generated code for " + str.replace('_', ' '))
+          } else {
+            emitln("// generated code")
+          }
+          traverse(b)
+          emitln("//#" + str)
         }
-        traverse(b)
-        emitln("//#" + str)
-      }
 
-    case _ => super.shallow(n)
+      case _ => super.shallow(n)
 
-  }; emit(quoteEff(n)) }
-
-  override def traverse(n: Node): Unit = n match {
-    case n @ Node(f, "λ", (y:Block)::_, _) =>
-      val x = y.in.head
-      emit(s"def ${quote(f)}(${quote(x)}: Int): Int${quoteEff(y.ein)} = "); quoteBlockP(traverse(y,f)); emitln("")
-    // XXX: should not need these below!
-    case n @ Node(s,"P",_,_) => // Unit result
-      shallow(n); emitln("")
-    case n @ Node(s,"W",_,_) => // Unit result
-      shallow(n); emitln("")
-    case n @ Node(s,"var_new",List(x),_) =>
-      emit(s"var ${quote(s)} = "); shallow(x); emitln("")
-    case n @ Node(s,"var_set",List(x,y),_) =>
-      emit(s"${quote(x)} = "); shallow(y); emitln("")
-    case n @ Node(s,"array_new",List(x),_) =>
-      emit(s"val ${quote(s)} = new Array[Int]("); shallow(x); emitln(")")
-    case n @ Node(s,"array_set",List(x,i,y),_) =>
-      shallow(x); emit("("); shallow(i); emit(") = "); shallow(y); emitln("")
-    case _ => emitValDef(n)
+    }; emit(quoteEff(n))
   }
+
+  override def traverse(n: Node): Unit =
+    n match {
+      case n @ Node(f, "λ", (y: Block) :: _, _) =>
+        val x = y.in.head
+        emit(s"def ${quote(f)}(${quote(x)}: Int): Int${quoteEff(y.ein)} = "); quoteBlockP(traverse(y, f)); emitln("")
+      // XXX: should not need these below!
+      case n @ Node(s, "P", _, _) => // Unit result
+        shallow(n); emitln("")
+      case n @ Node(s, "W", _, _) => // Unit result
+        shallow(n); emitln("")
+      case n @ Node(s, "var_new", List(x), _) =>
+        emit(s"var ${quote(s)} = "); shallow(x); emitln("")
+      case n @ Node(s, "var_set", List(x, y), _) =>
+        emit(s"${quote(x)} = "); shallow(y); emitln("")
+      case n @ Node(s, "array_new", List(x), _) =>
+        emit(s"val ${quote(s)} = new Array[Int]("); shallow(x); emitln(")")
+      case n @ Node(s, "array_set", List(x, i, y), _) =>
+        shallow(x); emit("("); shallow(i); emit(") = "); shallow(y); emitln("")
+      case _ => emitValDef(n)
+    }
 
   def emitValDef(n: Node): Unit = {
     emit(s"val ${quote(n.n)} = "); shallow(n); emitln("")
@@ -242,7 +249,6 @@ class CompactScalaCodeGen extends CompactCodeGen {
     emitln()
   }
 }
-
 
 trait Pattern
 case class PVar(x: Sym) extends Pattern
@@ -285,12 +291,12 @@ class ExtendedScalaCodeGen extends CompactScalaCodeGen with ExtendedCodeGen {
   // this following nameMap is specific to a tutorial, and should be moved
   // to that tutorial. FIXME(feiw)
   val nameMap: Map[String, String] = Map(
-    "ScannerNew"     -> "new scala.lms.tutorial.Scanner",
+    "ScannerNew" -> "new scala.lms.tutorial.Scanner",
     "ScannerHasNext" -> "Scanner.hasNext",
-    "ScannerNext"    -> "Scanner.next",
-    "ScannerClose"   -> "Scanner.close",
-    "ObjHashCode"    -> "Object.hashCode",
-    "DFAState"       -> "new scala.lms.tutorial.Automaton[Char,Boolean]"
+    "ScannerNext" -> "Scanner.next",
+    "ScannerClose" -> "Scanner.close",
+    "ObjHashCode" -> "Object.hashCode",
+    "DFAState" -> "new scala.lms.tutorial.Automaton[Char,Boolean]"
   )
 
   var recursive = false
@@ -327,20 +333,23 @@ class ExtendedScalaCodeGen extends CompactScalaCodeGen with ExtendedCodeGen {
     if (b.in.length == 0) {
       quoteBlock(traverse(b))
     } else {
-      val argsStr = b.in.map({ arg =>
-        val tp = if (emitType) s": ${remap(typeMap.getOrElse(arg, manifest[Unknown]))}" else ""
-        quote(arg) + tp
-      }).mkString("(", ", ", s")$eff => ")
+      val argsStr = b.in
+        .map({ arg =>
+          val tp = if (emitType) s": ${remap(typeMap.getOrElse(arg, manifest[Unknown]))}" else ""
+          quote(arg) + tp
+        })
+        .mkString("(", ", ", s")$eff => ")
       quoteBlock(argsStr)(traverse(b))
     }
   }
 
-  def patternToString(p: Pattern, emitType: Boolean = false): String = p match {
-    case PVar(x) =>
-      val tp = if (emitType) s": ${remap(typeMap.getOrElse(x, manifest[Unknown]))}" else ""
-      quote(x) + tp
-    case PTuple(xs) => "(" + xs.map(patternToString(_)).mkString(", ") + ")"
-  }
+  def patternToString(p: Pattern, emitType: Boolean = false): String =
+    p match {
+      case PVar(x) =>
+        val tp = if (emitType) s": ${remap(typeMap.getOrElse(x, manifest[Unknown]))}" else ""
+        quote(x) + tp
+      case PTuple(xs) => "(" + xs.map(patternToString(_)).mkString(", ") + ")"
+    }
 
   //TODO(GW): merge this code into exisitng quoteBlock or reify?
   // The current block.in is a special case of a tuple of arguments, can be generalized.
@@ -350,111 +359,119 @@ class ExtendedScalaCodeGen extends CompactScalaCodeGen with ExtendedCodeGen {
     quoteBlock("case " + patStr + " =>")(traverse(b))
   }
 
-  def shallow(n: Def, emitType: Boolean = false): Unit = n match {
-    case b:Block => quoteBlock(b, emitType)
-    case _ => super.shallow(n)
-  }
+  def shallow(n: Def, emitType: Boolean = false): Unit =
+    n match {
+      case b: Block => quoteBlock(b, emitType)
+      case _ => super.shallow(n)
+    }
 
   // generate string for node's right-hand-size
   // (either inline or as part of val def)
   // XXX TODO: precedence of nested expressions!!
-  override def shallow(n: Node): Unit = n match {
-    case n @ Node(f,"λforward",List(y, arity),_) => emit(quote(y))
-    case n @ Node(f, "λ", (y:Block)::_, _) =>
-      // XXX what should we do for functions?
-      // proper inlining will likely work better
-      // as a separate phase b/c it may trigger
-      // further optimizations
-      /*
+  override def shallow(n: Node): Unit =
+    n match {
+      case n @ Node(f, "λforward", List(y, arity), _) => emit(quote(y))
+      case n @ Node(f, "λ", (y: Block) :: _, _) =>
+        // XXX what should we do for functions?
+        // proper inlining will likely work better
+        // as a separate phase b/c it may trigger
+        // further optimizations
+        /*
       val argsTyped = y.in map { arg => s"${quote(arg)}: ${remap(typeMap.getOrElse(arg, manifest[Unknown]))}" }
       val argsTypedStr = argsTyped.mkString("(", ",", ") => ")
       quoteBlock(argsTypedStr)(traverse(y))
-      */
-      quoteBlock(y, true)
-    case n @ Node(s,"?",List(c, a: Block, b: Block),_) if b.isPure && b.res == Const(false) =>
-      shallowP(c, precedence("&&")); emit(" && "); quoteBlockP(precedence("&&") + 1)(traverse(a))
-    case n @ Node(s,"?",List(c, a: Block, b: Block),_) if a.isPure && a.res == Const(true) =>
-      shallowP(c, precedence("||")); emit(" || "); quoteBlockP(precedence("||") + 1)(traverse(b))
-    case n @ Node(f,"?",c::(a:Block)::(b:Block)::_,_) =>
-      emit(s"if ("); shallow(c); emit(") ")
-      quoteBlockP(traverse(a))
-      quoteElseBlock(traverse(b))
-    case n @ Node(f,"W",List(c:Block,b:Block),_) =>
-      emit(s"while (")
-      quoteBlockP(traverse(c))
-      emit(s") ")
-      quoteBlock(traverse(b))
-    case n @ Node(s,"var_get",List(x),_) =>
-      shallow(x)
-    case n @ Node(s,"array_get",List(x,i),_) =>
-      shallowP(x); emit("("); shallow(i); emit(")")
-    case n @ Node(s,"array_length",List(x), _) =>
-      shallow(x); emit(".length")
-    case n @ Node(s,"array_free", List(arr), _) => ()
-    case n @ Node(s, "NewArray" ,List(x), _) =>
-      val tpe = remap(typeMap.get(s).map(_.typeArguments.head).getOrElse(manifest[Unknown]))
-      emit("new Array["); emit(tpe); emit("]("); shallow(x); emit(")")
-    case n @ Node(s,"@",x::y,_) => {
-      def emitArgs(y: List[Def]): Unit = y match {
-        case t::Nil => shallow(t)
-        case t::ys  => shallow(t); emit(","); emitArgs(ys)
+         */
+        quoteBlock(y, true)
+      case n @ Node(s, "?", List(c, a: Block, b: Block), _) if b.isPure && b.res == Const(false) =>
+        shallowP(c, precedence("&&")); emit(" && "); quoteBlockP(precedence("&&") + 1)(traverse(a))
+      case n @ Node(s, "?", List(c, a: Block, b: Block), _) if a.isPure && a.res == Const(true) =>
+        shallowP(c, precedence("||")); emit(" || "); quoteBlockP(precedence("||") + 1)(traverse(b))
+      case n @ Node(f, "?", c :: (a: Block) :: (b: Block) :: _, _) =>
+        emit(s"if ("); shallow(c); emit(") ")
+        quoteBlockP(traverse(a))
+        quoteElseBlock(traverse(b))
+      case n @ Node(f, "W", List(c: Block, b: Block), _) =>
+        emit(s"while (")
+        quoteBlockP(traverse(c))
+        emit(s") ")
+        quoteBlock(traverse(b))
+      case n @ Node(s, "var_get", List(x), _) =>
+        shallow(x)
+      case n @ Node(s, "array_get", List(x, i), _) =>
+        shallowP(x); emit("("); shallow(i); emit(")")
+      case n @ Node(s, "array_length", List(x), _) =>
+        shallow(x); emit(".length")
+      case n @ Node(s, "array_free", List(arr), _) => ()
+      case n @ Node(s, "NewArray", List(x), _) =>
+        val tpe = remap(typeMap.get(s).map(_.typeArguments.head).getOrElse(manifest[Unknown]))
+        emit("new Array["); emit(tpe); emit("]("); shallow(x); emit(")")
+      case n @ Node(s, "@", x :: y, _) => {
+        def emitArgs(y: List[Def]): Unit =
+          y match {
+            case t :: Nil => shallow(t)
+            case t :: ys => shallow(t); emit(","); emitArgs(ys)
+          }
+        shallowP(x); emit("("); emitArgs(y); emit(")")
       }
-      shallowP(x); emit("("); emitArgs(y); emit(")")
-    }
-    case n @ Node(s,"P",List(x),_) =>
-      emit("println"); emit("("); shallow(x); emit(")")
-    case n @ Node(s,"comment",Const(str: String)::Const(verbose: Boolean)::(b:Block)::_,_) => ??? // Comment shouldn't be inlined
-      emitln("//# " + str)
-      if (verbose) {
-        emitln("// generated code for " + str.replace('_', ' '))
-      } else {
-        emitln("// generated code")
-      }
-      quoteBlockP {
-        traverse(b)
-      }
-      emitln("\n//# " + str)
-
-    case n @ Node(s,"staticData",List(Const(a)),_) =>
-      val q = a match { case x: Array[_] => "Array("+x.mkString(",")+")" case _ => a }
-      emit("p"+quote(s)); emit(s" /* staticData $q */")
-
-    case n @ Node(s,op,args,_) if nameMap contains op =>
-      shallow(n.copy(op = nameMap(n.op)))
-
-    // case n @ Node(s,op,List(x),_) if numTypeConv(op) =>
-    //   shallowP(x); emit(s".$op")
-    case n @ Node(s, "cast", a::_, _) =>
-      val tpe = remap(typeMap.getOrElse(s, manifest[Unknown]))
-      shallowP(a); emit(s".to$tpe")
-
-    case n @ Node(s,op,args,_) if op.startsWith("unchecked") => // unchecked
-      var next = 9 // skip unchecked
-      for (a <- args) {
-        val i = op.indexOf("[ ]", next)
-        assert(i >= next)
-        emit(op.substring(next,i))
-        shallow(a)
-        next = i + 3
-      }
-      emit(op.substring(next))
-
-    case n @ Node(s,op,args,_) if op.contains('.') && !op.contains(' ') => // method call
-      val (recv::args1) = args
-      shallowP(recv); emit("."); emit(op.drop(op.lastIndexOf('.')+1))
-      if (args1.nonEmpty) {
-        emit("(")
-        shallow(args1.head)
-        args1.tail.foreach { a =>
-          emit(", "); shallow(a)
+      case n @ Node(s, "P", List(x), _) =>
+        emit("println"); emit("("); shallow(x); emit(")")
+      case n @ Node(s, "comment", Const(str: String) :: Const(verbose: Boolean) :: (b: Block) :: _, _) =>
+        ??? // Comment shouldn't be inlined
+        emitln("//# " + str)
+        if (verbose) {
+          emitln("// generated code for " + str.replace('_', ' '))
+        } else {
+          emitln("// generated code")
         }
-        emit(")")
-      }
-    case n @ Node(s, "timestamp", _, _) => emitln(s"System.nanoTime / 1000L")
-    case n @ Node(s, "array_sort_scala", List(arr, l), _) => shallowP(arr); emit(".slice(0, "); shallowP(l); emitln(").sorted")
+        quoteBlockP {
+          traverse(b)
+        }
+        emitln("\n//# " + str)
 
-    case _ => super.shallow(n)
-  }
+      case n @ Node(s, "staticData", List(Const(a)), _) =>
+        val q = a match {
+          case x: Array[_] => "Array(" + x.mkString(",") + ")"
+          case _ => a
+        }
+        emit("p" + quote(s)); emit(s" /* staticData $q */")
+
+      case n @ Node(s, op, args, _) if nameMap contains op =>
+        shallow(n.copy(op = nameMap(n.op)))
+
+      // case n @ Node(s,op,List(x),_) if numTypeConv(op) =>
+      //   shallowP(x); emit(s".$op")
+      case n @ Node(s, "cast", a :: _, _) =>
+        val tpe = remap(typeMap.getOrElse(s, manifest[Unknown]))
+        shallowP(a); emit(s".to$tpe")
+
+      case n @ Node(s, op, args, _) if op.startsWith("unchecked") => // unchecked
+        var next = 9 // skip unchecked
+        for (a <- args) {
+          val i = op.indexOf("[ ]", next)
+          assert(i >= next)
+          emit(op.substring(next, i))
+          shallow(a)
+          next = i + 3
+        }
+        emit(op.substring(next))
+
+      case n @ Node(s, op, args, _) if op.contains('.') && !op.contains(' ') => // method call
+        val (recv :: args1) = args
+        shallowP(recv); emit("."); emit(op.drop(op.lastIndexOf('.') + 1))
+        if (args1.nonEmpty) {
+          emit("(")
+          shallow(args1.head)
+          args1.tail.foreach { a =>
+            emit(", "); shallow(a)
+          }
+          emit(")")
+        }
+      case n @ Node(s, "timestamp", _, _) => emitln(s"System.nanoTime / 1000L")
+      case n @ Node(s, "array_sort_scala", List(arr, l), _) =>
+        shallowP(arr); emit(".slice(0, "); shallowP(l); emitln(").sorted")
+
+      case _ => super.shallow(n)
+    }
 
   override def emitValDef(n: Node): Unit = {
     if (!recursive) {
@@ -466,70 +483,72 @@ class ExtendedScalaCodeGen extends CompactScalaCodeGen with ExtendedCodeGen {
     }
   }
 
-  override def traverse(n: Node): Unit = n match {
-    case n @ Node(s, "exit", List(x), _) =>
-      emit("System.exit("); shallow(x); emitln(")")
-    case n @ Node(f, "λ", (y: Block)::_, _) =>
-      val args = y.in
-      val types = args.map { a => remap(typeMap.getOrElse(a, manifest[Unknown])) }
-      val retType = remap(typeMap.getOrElse(y.res, manifest[Unit]))
-      val eff = quoteEff(y.ein)
+  override def traverse(n: Node): Unit =
+    n match {
+      case n @ Node(s, "exit", List(x), _) =>
+        emit("System.exit("); shallow(x); emitln(")")
+      case n @ Node(f, "λ", (y: Block) :: _, _) =>
+        val args = y.in
+        val types = args.map { a => remap(typeMap.getOrElse(a, manifest[Unknown])) }
+        val retType = remap(typeMap.getOrElse(y.res, manifest[Unit]))
+        val eff = quoteEff(y.ein)
 
-      val argsStr = (args zip types).map { case (x, a) => s"${quote(x)}: $a" }.mkString(", ")
-      emit(s"def ${quote(f)}($argsStr): $retType$eff = ")
-      quoteBlockP(traverse(y,f))
-      emitln()
+        val argsStr = (args zip types).map { case (x, a) => s"${quote(x)}: $a" }.mkString(", ")
+        emit(s"def ${quote(f)}($argsStr): $retType$eff = ")
+        quoteBlockP(traverse(y, f))
+        emitln()
 
-    case n @ Node(s,"generate-comment",List(Const(x)),_) =>
-      emit("// "); emitln(x.toString)
+      case n @ Node(s, "generate-comment", List(Const(x)), _) =>
+        emit("// "); emitln(x.toString)
 
-    case n @ Node(s,"comment",Const(str: String)::Const(verbose: Boolean)::(b:Block)::_,_) =>
-      emitln("//# " + str)
-      if (verbose) {
-        emitln("// generated code for " + str.replace('_', ' '))
-      } else {
-        emitln("// generated code")
-      }
-      if (dce.live(s)) {
-        emit("val "); emit(quote(s)); emit(" = "); quoteBlockP(traverse(b))
-      } else {
-        noquoteBlock(traverse(b))
-      }
-      emitln("\n//# " + str)
-    case n @ Node(_, "switch", guard::default::others, _) =>
-      shallowP(guard); emitln(" match {");
-      others.grouped(2).foreach {
-        case List(Const(cases: Seq[Const]), block: Block) =>
-          emit("case "); emit(quote(cases.head)); cases.tail.foreach(x => emit(s" | ${quote(x)}")); emitln(" =>")
-          noquoteBlock(traverse(block))
-      }
-      default match {
-        case block: Block =>
-          emitln("case _ =>")
-          noquoteBlock(traverse(block))
-        case _ =>
-      }
-      emitln("}")
-    case n @ Node(s,"var_new",List(x),_) =>
-      /*if (dce.live(s))*/
-      if (!recursive) {
-        emit(s"var ${quote(s)} = "); shallow(x); emitln()
-      } else {
-        emit(s"${quote(s)} = "); shallow(x); emitln()
-      }
-    case n @ Node(s,"var_set",List(x,y),_) =>
-      emit(s"${quote(x)} = "); shallow(y); emitln()
-    case n @ Node(s,"array_new",List(x),_) =>
-      /*if (dce.live(s))*/ emit(s"val ${quote(s)} = new Array[Int]("); shallow(x); emit(")"); emitln()
-    case n @ Node(s,"array_set",List(x,i,y),_) =>
-      shallow(x); emit("("); shallow(i); emit(") = "); shallow(y); emitln()
+      case n @ Node(s, "comment", Const(str: String) :: Const(verbose: Boolean) :: (b: Block) :: _, _) =>
+        emitln("//# " + str)
+        if (verbose) {
+          emitln("// generated code for " + str.replace('_', ' '))
+        } else {
+          emitln("// generated code")
+        }
+        if (dce.live(s)) {
+          emit("val "); emit(quote(s)); emit(" = "); quoteBlockP(traverse(b))
+        } else {
+          noquoteBlock(traverse(b))
+        }
+        emitln("\n//# " + str)
+      case n @ Node(_, "switch", guard :: default :: others, _) =>
+        shallowP(guard); emitln(" match {");
+        others.grouped(2).foreach {
+          case List(Const(cases: Seq[Const]), block: Block) =>
+            emit("case "); emit(quote(cases.head)); cases.tail.foreach(x => emit(s" | ${quote(x)}")); emitln(" =>")
+            noquoteBlock(traverse(block))
+        }
+        default match {
+          case block: Block =>
+            emitln("case _ =>")
+            noquoteBlock(traverse(block))
+          case _ =>
+        }
+        emitln("}")
+      case n @ Node(s, "var_new", List(x), _) =>
+        /*if (dce.live(s))*/
+        if (!recursive) {
+          emit(s"var ${quote(s)} = "); shallow(x); emitln()
+        } else {
+          emit(s"${quote(s)} = "); shallow(x); emitln()
+        }
+      case n @ Node(s, "var_set", List(x, y), _) =>
+        emit(s"${quote(x)} = "); shallow(y); emitln()
+      case n @ Node(s, "array_new", List(x), _) =>
+        /*if (dce.live(s))*/
+        emit(s"val ${quote(s)} = new Array[Int]("); shallow(x); emit(")"); emitln()
+      case n @ Node(s, "array_set", List(x, i, y), _) =>
+        shallow(x); emit("("); shallow(i); emit(") = "); shallow(y); emitln()
 
-    case n @ Node(s,"var_get",_,_) if !dce.live(s) => ??? // no-op
-    case n @ Node(s,"array_get",_,_) if !dce.live(s) => ??? // no-op
+      case n @ Node(s, "var_get", _, _) if !dce.live(s) => ??? // no-op
+      case n @ Node(s, "array_get", _, _) if !dce.live(s) => ??? // no-op
 
-    case n =>
-      emitValDef(n)
-  }
+      case n =>
+        emitValDef(n)
+    }
 
   override def apply(g: Graph): Unit = {
     bound(g)

--- a/src/main/scala/lms/core/frontend.scala
+++ b/src/main/scala/lms/core/frontend.scala
@@ -13,19 +13,19 @@ class FrontEnd {
   case class BOOL(x: Exp) {
     //def &&(y: => BOOL): BOOL = BOOL(g.reflect("&",x,y.x)) // should call if?
     //def ||(y: => BOOL): BOOL = BOOL(g.reflect("|",x,y.x))
-    def unary_! = BOOL(g.reflect("!",x))
+    def unary_! = BOOL(g.reflect("!", x))
   }
 
   case class UNIT(x: Exp)
 
   case class INT(x: Exp) {
-    def +(y: INT): INT = INT(g.reflect("+",x,y.x))
-    def -(y: INT): INT = INT(g.reflect("-",x,y.x))
-    def *(y: INT): INT = INT(g.reflect("*",x,y.x))
-    def /(y: INT): INT = INT(g.reflect("/",x,y.x))
-    def %(y: INT): INT = INT(g.reflect("%",x,y.x))
-    def ===(y: INT): BOOL = BOOL(g.reflect("==",x,y.x))
-    def !==(y: INT): BOOL = BOOL(g.reflect("!=",x,y.x))
+    def +(y: INT): INT = INT(g.reflect("+", x, y.x))
+    def -(y: INT): INT = INT(g.reflect("-", x, y.x))
+    def *(y: INT): INT = INT(g.reflect("*", x, y.x))
+    def /(y: INT): INT = INT(g.reflect("/", x, y.x))
+    def %(y: INT): INT = INT(g.reflect("%", x, y.x))
+    def ===(y: INT): BOOL = BOOL(g.reflect("==", x, y.x))
+    def !==(y: INT): BOOL = BOOL(g.reflect("!=", x, y.x))
     def sin(): INT = INT(g.reflect("sin", x))
     def cos(): INT = INT(g.reflect("cos", x))
     def abs(): INT = INT(g.reflect("abs", x))
@@ -35,23 +35,22 @@ class FrontEnd {
     def sqrt(): INT = INT(g.reflect("sqrt", x))
   }
 
-  case class STRING(x: Exp) {
-  }
+  case class STRING(x: Exp) {}
 
   case class ARRAY(x: Exp) {
-    def apply(i: INT): INT = INT(g.reflectRead("array_get",x,i.x)(x))
-    def update(i: INT, y: INT): Unit = g.reflectWrite("array_set",x,i.x,y.x)(x)
+    def apply(i: INT): INT = INT(g.reflectRead("array_get", x, i.x)(x))
+    def update(i: INT, y: INT): Unit = g.reflectWrite("array_set", x, i.x, y.x)(x)
   }
   object ARRAY {
-    def apply(n: INT): ARRAY = ARRAY(g.reflectMutable("array_new",n.x))
+    def apply(n: INT): ARRAY = ARRAY(g.reflectMutable("array_new", n.x))
   }
 
   case class VAR(x: Exp) {
-    def apply(): INT = INT(g.reflectRead("var_get",x)(x))
-    def update(y: INT): Unit = g.reflectWrite("var_set",x,y.x)(x)
+    def apply(): INT = INT(g.reflectRead("var_get", x)(x))
+    def update(y: INT): Unit = g.reflectWrite("var_set", x, y.x)(x)
   }
   object VAR {
-    def apply(x: INT): VAR = VAR(g.reflectMutable("var_new",x.x))
+    def apply(x: INT): VAR = VAR(g.reflectMutable("var_new", x.x))
   }
 
   def IF(c: BOOL)(a: => INT)(b: => INT): INT = {
@@ -60,37 +59,36 @@ class FrontEnd {
     // compute effect (aBlock || bBlock)
     val pure = aBlock.isPure && bBlock.isPure
     if (pure)
-      INT(g.reflect("?",c.x,aBlock,bBlock))
+      INT(g.reflect("?", c.x, aBlock, bBlock))
     else
-      INT(g.reflectEffectSummaryHere("?",c.x,aBlock,bBlock)(g.mergeEffKeys(aBlock, bBlock)))
+      INT(g.reflectEffectSummaryHere("?", c.x, aBlock, bBlock)(g.mergeEffKeys(aBlock, bBlock)))
   }
 
   def WHILE(c: => BOOL)(b: => Unit): Unit = {
     val cBlock = g.reify(c.x)
-    val bBlock = g.reify({b;Const(())})
+    val bBlock = g.reify({ b; Const(()) })
     // compute effect (cBlock bBlock)* cBlock
-    g.reflectEffectSummary("W",cBlock,bBlock)(g.mergeEffKeys(cBlock, bBlock))
+    g.reflectEffectSummary("W", cBlock, bBlock)(g.mergeEffKeys(cBlock, bBlock))
   }
-
 
   def APP(f: Exp, x: INT): INT = INT(g.reflect("@", f, x.x))
 
   def PRINT(x: INT): Unit =
-    g.reflectWrite("P",x.x)(CTRL)
+    g.reflectWrite("P", x.x)(CTRL)
 
   def PRINT(x: STRING): Unit =
-    g.reflectWrite("P",x.x)(CTRL)
+    g.reflectWrite("P", x.x)(CTRL)
 
-  def FUN(f: INT => INT): INT => INT = FUN((_,x) => f(x))
+  def FUN(f: INT => INT): INT => INT = FUN((_, x) => f(x))
 
-  def FUN(f: ((INT=>INT),INT) => INT): INT => INT = {
+  def FUN(f: ((INT => INT), INT) => INT): INT => INT = {
     val fn = Sym(g.fresh)
     //val xn = Sym(g.fresh)
-    val f1 = (x: INT) => APP(fn,x)
+    val f1 = (x: INT) => APP(fn, x)
     // NOTE: lambda expression itself does not have
     // an effect, so body block should not count as
     // latent effect of the lambda
-    g.reflect(fn,"λ",g.reify(xn => f(f1,INT(xn)).x))()
+    g.reflect(fn, "λ", g.reify(xn => f(f1, INT(xn)).x))()
     f1
   }
 
@@ -108,8 +106,7 @@ class FrontEnd {
     try {
       val block = body
       Graph(g.globalDefs, block, g.globalDefsCache.toMap)
-    } finally {g = null}
+    } finally { g = null }
   }
-
 
 }

--- a/src/main/scala/lms/core/macros.scala
+++ b/src/main/scala/lms/core/macros.scala
@@ -4,7 +4,6 @@ package core
 import language.experimental.{macros => m}
 import scala.annotation.StaticAnnotation
 
-
 class ir extends StaticAnnotation {
   def macroTransform(annottees: Any*): Any = macro macros.ir.impl
 }

--- a/src/main/scala/lms/core/utils.scala
+++ b/src/main/scala/lms/core/utils.scala
@@ -15,9 +15,10 @@ object utils {
   def time[A](key: String)(a: => A) = {
     val start = System.nanoTime
     val saveTime = timeInSub
-    scope = key::scope
+    scope = key :: scope
     timeInSub = 0
-    try a finally {
+    try a
+    finally {
       val timeElapsed = (System.nanoTime - start) / 1000
       val timeHere = timeElapsed - timeInSub
 
@@ -54,11 +55,12 @@ object utils {
   def devnull(f: => Unit): Unit = {
     withOutput(nullout)(f)
   }
-  def nullout = new PrintStream(new OutputStream() {
-    override def write(b: Int) = {}
-    override def write(b: Array[Byte]) = {}
-    override def write(b: Array[Byte], off: Int, len: Int) = {}
-  })
+  def nullout =
+    new PrintStream(new OutputStream() {
+      override def write(b: Int) = {}
+      override def write(b: Array[Byte]) = {}
+      override def write(b: Array[Byte], off: Int, len: Int) = {}
+    })
   def withOutputFull(out: PrintStream)(func: => Unit): Unit = {
     val oldStdOut = System.out
     val oldStdErr = System.err

--- a/src/main/scala/lms/experimental/base.scala
+++ b/src/main/scala/lms/experimental/base.scala
@@ -2,7 +2,6 @@ package lms.experimental
 
 import scala.annotation.implicitNotFound
 
-
 trait CodeBuilder {
   // mutable state goes here ...
 
@@ -10,10 +9,11 @@ trait CodeBuilder {
   var mode = 0 // 0 anf, 1 normal
 
   case class Exp(s: String) { override def toString = s }
-  def reflect(s: Any*) = mode match {
-    case 0 => numVars += 1; println("val x"+numVars+" = "+s.mkString); Exp("x"+numVars)
-    case 1 => Exp(s.mkString)
-  }
+  def reflect(s: Any*) =
+    mode match {
+      case 0 => numVars += 1; println("val x" + numVars + " = " + s.mkString); Exp("x" + numVars)
+      case 1 => Exp(s.mkString)
+    }
 
   def reifyBlock(f: => Exp) = {
     val source = new java.io.ByteArrayOutputStream()
@@ -21,11 +21,11 @@ trait CodeBuilder {
     val str = source.toString + res.s
     if (str.contains("\n"))
       Exp("{\n" + str + "\n}")
-    else 
+    else
       Exp(str)
   }
 
-  def reifyPattern[T](f: => T):T = {
+  def reifyPattern[T](f: => T): T = {
     var save = mode
     mode = 1
     try {
@@ -35,23 +35,21 @@ trait CodeBuilder {
       res
     } finally mode = save
   }
-  
+
 }
-
-
 
 trait Base {
   // preliminaries
   @implicitNotFound("${T} is not a DSL type")
   type Typ[T]
   @implicitNotFound("${A} cannot be implicitly lifted to ${B}")
-  type Lift[A,B]
-  implicit def identLift[T:Typ]: Lift[T,T]
-  implicit def lift[T,U](x:T)(implicit e: Lift[T,U]): U
+  type Lift[A, B]
+  implicit def identLift[T: Typ]: Lift[T, T]
+  implicit def lift[T, U](x: T)(implicit e: Lift[T, U]): U
 
-  case class Rewrite[T:Typ](a:T, b:T)
+  case class Rewrite[T: Typ](a: T, b: T)
 
-  def lower[A:Typ,B:Typ,C:Typ](f: (A,B) => Rewrite[C]): Unit
+  def lower[A: Typ, B: Typ, C: Typ](f: (A, B) => Rewrite[C]): Unit
 }
 
 trait BaseExp extends Base {
@@ -60,32 +58,31 @@ trait BaseExp extends Base {
   import codeBuilder.Exp
 
   trait Typ[T] {
-    def from(e:Exp): T
-    def to(x:T):Exp
+    def from(e: Exp): T
+    def to(x: T): Exp
   }
-  trait Lift[A,B] {
-    def to(x:A):B
+  trait Lift[A, B] {
+    def to(x: A): B
   }
-  implicit def identLift[T:Typ]: Lift[T,T] = new Lift[T,T] { def to(x:T) = x }
-  implicit def lift[T,U](x:T)(implicit e: Lift[T,U]): U = e.to(x)
+  implicit def identLift[T: Typ]: Lift[T, T] = new Lift[T, T] { def to(x: T) = x }
+  implicit def lift[T, U](x: T)(implicit e: Lift[T, U]): U = e.to(x)
 
-  def typ[T:Typ] = implicitly[Typ[T]]
+  def typ[T: Typ] = implicitly[Typ[T]]
 
-  def reflect[T:Typ](s:Any*):T = typ[T].from(codeBuilder.reflect(s:_*))
-  def ref[T:Typ](f: => T): Exp = codeBuilder.reifyBlock(typ[T].to(f))
+  def reflect[T: Typ](s: Any*): T = typ[T].from(codeBuilder.reflect(s: _*))
+  def ref[T: Typ](f: => T): Exp = codeBuilder.reifyBlock(typ[T].to(f))
 
   //case class Rewrite[T:Typ](a:T, b:T)
 
-  def lower[A:Typ,B:Typ,C:Typ](f: (A,B) => Rewrite[C]): Unit = {
+  def lower[A: Typ, B: Typ, C: Typ](f: (A, B) => Rewrite[C]): Unit = {
     val a = typ[A].from(Exp("?A"))
     val b = typ[B].from(Exp("?B"))
-    val rw = codeBuilder.reifyPattern(f(a,b))
+    val rw = codeBuilder.reifyPattern(f(a, b))
     val u = typ[C].to(rw.a)
     val v = typ[C].to(rw.b)
     println("lower: " + u + "===>" + v)
   }
 }
-
 
 trait DSL extends Base {
   trait IntOps {
@@ -103,9 +100,9 @@ trait DSL extends Base {
   type Int <: IntOps
   type Boolean <: BooleanOps
   implicit def intTyp: Typ[Int]
-  implicit def intLift: Lift[scala.Int,Int]
+  implicit def intLift: Lift[scala.Int, Int]
   implicit def booleanTyp: Typ[Boolean]
-  implicit def booleanLift: Lift[scala.Boolean,Boolean]
+  implicit def booleanLift: Lift[scala.Boolean, Boolean]
 
   trait ArrayOps[T] {
     def length: Int
@@ -113,10 +110,10 @@ trait DSL extends Base {
     def update(x: Int, y: T): Unit
   }
   type Array[T] <: ArrayOps[T]
-  def NewArray[T:Typ](x: Int): Array[T]
-  implicit def arrayTyp[T:Typ]: Typ[Array[T]]
+  def NewArray[T: Typ](x: Int): Array[T]
+  implicit def arrayTyp[T: Typ]: Typ[Array[T]]
 
-  def __ifThenElse[C,A,B](c:Boolean, a: =>A, b: =>B)(implicit mA: Lift[A,C], mB: Lift[B,C], mC: Typ[C]): C
+  def __ifThenElse[C, A, B](c: Boolean, a: => A, b: => B)(implicit mA: Lift[A, C], mB: Lift[B, C], mC: Typ[C]): C
 
   // tuples, variables (for c: are variables just 0-elem arrays?), functions
 
@@ -126,36 +123,45 @@ trait Impl extends BaseExp with DSL {
   val codeBuilder = new CodeBuilder {}
   import codeBuilder.Exp
   case class Int(e: Exp) extends IntOps {
-    def +(y: Int) = reflect[Int](e,"+",y.e)
-    def -(y: Int) = reflect[Int](e,"-",y.e)
-    def *(y: Int) = reflect[Int](e,"*",y.e)
-    def /(y: Int) = reflect[Int](e,"/",y.e)
-    def %(y: Int) = reflect[Int](e,"%",y.e)
+    def +(y: Int) = reflect[Int](e, "+", y.e)
+    def -(y: Int) = reflect[Int](e, "-", y.e)
+    def *(y: Int) = reflect[Int](e, "*", y.e)
+    def /(y: Int) = reflect[Int](e, "/", y.e)
+    def %(y: Int) = reflect[Int](e, "%", y.e)
   }
   case class Boolean(e: Exp) extends BooleanOps {
-    def &&(y: => Boolean) = reflect[Boolean](e,"&&",y.e)
-    def ||(y: => Boolean) = reflect[Boolean](e,"||",y.e)
-    def unary_! = reflect[Boolean]("!",e)
+    def &&(y: => Boolean) = reflect[Boolean](e, "&&", y.e)
+    def ||(y: => Boolean) = reflect[Boolean](e, "||", y.e)
+    def unary_! = reflect[Boolean]("!", e)
   }
 
-  implicit val unitTyp: Typ[Unit] = new Typ[Unit] { def from(e:Exp) = (); def to(x:Unit) = Exp("()"); override def toString = "Unit" }
-  implicit val intTyp: Typ[Int] = new Typ[Int] { def from(e:Exp) = Int(e); def to(x:Int) = x.e; override def toString = "Int" }
-  implicit val booleanTyp: Typ[Boolean] = new Typ[Boolean] { def from(e:Exp) = Boolean(e); def to(x:Boolean) = x.e; override def toString = "Boolean" }
-
-  implicit val intLift: Lift[scala.Int,Int] = new Lift[scala.Int,Int] { def to(x:scala.Int) = Int(Exp(x.toString)) }
-  implicit val booleanLift: Lift[scala.Boolean,Boolean] = new Lift[scala.Boolean,Boolean] { def to(x:scala.Boolean) = Boolean(Exp(x.toString)) }
-  
-  case class Array[T:Typ](e: Exp) extends ArrayOps[T] {
-    def length = reflect[Int](e,".length")
-    def apply(x: Int) = reflect[T](e,"(",ref(x),")")
-    def update(x: Int, y: T): Unit = reflect[Unit](e,"(",ref(x),") = ",ref(y))
+  implicit val unitTyp: Typ[Unit] = new Typ[Unit] {
+    def from(e: Exp) = (); def to(x: Unit) = Exp("()"); override def toString = "Unit"
   }
-  def NewArray[T:Typ](x: Int): Array[T] = reflect[Array[T]]("new Array[",typ[T],"](",ref(x),")")
-  implicit def arrayTyp[T:Typ]: Typ[Array[T]] = new Typ[Array[T]] { def from(e:Exp) = Array(e); def to(x:Array[T]) = x.e; override def toString = "Array["+typ[T]+"]" }
+  implicit val intTyp: Typ[Int] = new Typ[Int] {
+    def from(e: Exp) = Int(e); def to(x: Int) = x.e; override def toString = "Int"
+  }
+  implicit val booleanTyp: Typ[Boolean] = new Typ[Boolean] {
+    def from(e: Exp) = Boolean(e); def to(x: Boolean) = x.e; override def toString = "Boolean"
+  }
 
-  def __ifThenElse[C,A,B](c:Boolean, a: =>A, b: =>B)(implicit mA: Lift[A,C], mB: Lift[B,C], mC: Typ[C]): C = {
-    reflect[C]("if (",ref(c),") ",ref(mA.to(a))," else ",ref(mB.to(b)))
+  implicit val intLift: Lift[scala.Int, Int] = new Lift[scala.Int, Int] { def to(x: scala.Int) = Int(Exp(x.toString)) }
+  implicit val booleanLift: Lift[scala.Boolean, Boolean] = new Lift[scala.Boolean, Boolean] {
+    def to(x: scala.Boolean) = Boolean(Exp(x.toString))
+  }
+
+  case class Array[T: Typ](e: Exp) extends ArrayOps[T] {
+    def length = reflect[Int](e, ".length")
+    def apply(x: Int) = reflect[T](e, "(", ref(x), ")")
+    def update(x: Int, y: T): Unit = reflect[Unit](e, "(", ref(x), ") = ", ref(y))
+  }
+  def NewArray[T: Typ](x: Int): Array[T] = reflect[Array[T]]("new Array[", typ[T], "](", ref(x), ")")
+  implicit def arrayTyp[T: Typ]: Typ[Array[T]] =
+    new Typ[Array[T]] {
+      def from(e: Exp) = Array(e); def to(x: Array[T]) = x.e; override def toString = "Array[" + typ[T] + "]"
+    }
+
+  def __ifThenElse[C, A, B](c: Boolean, a: => A, b: => B)(implicit mA: Lift[A, C], mB: Lift[B, C], mC: Typ[C]): C = {
+    reflect[C]("if (", ref(c), ") ", ref(mA.to(a)), " else ", ref(mB.to(b)))
   }
 }
-
-

--- a/src/main/scala/lms/experimental/c.scala
+++ b/src/main/scala/lms/experimental/c.scala
@@ -5,14 +5,14 @@ import scala.annotation.implicitNotFound
 trait CBase {
 
   case class Thunk[T](eval: () => T)
-  implicit def thunk(x: =>Exp) = Thunk(() => x)
+  implicit def thunk(x: => Exp) = Thunk(() => x)
 
   case class Exp(s: String)
 
   def quote(e: Exp) = e.s
 
   var numVars = 0
-  def fresh = { numVars += 1; Exp("x"+(numVars-1)) }
+  def fresh = { numVars += 1; Exp("x" + (numVars - 1)) }
 
   implicit class StringHelper(sc: StringContext) {
     def gen(args: Thunk[Exp]*): Exp = {
@@ -27,7 +27,7 @@ trait CBase {
       Exp("")
     }
 
-/*
+    /*
     def cg(args: Thunk[Rep[Any]]*) = new {
       def as[T:Manifest]: Rep[T] = {
         //reflect(c.s(args map (a => reify(a.eval())):_*))
@@ -38,7 +38,7 @@ trait CBase {
         unchecked[T](merge(c.parts.toList, args.toList.map(_.eval())):_*)
       }
     }
-*/
+     */
   }
 }
 
@@ -46,79 +46,80 @@ object c extends CBase {
 
   @implicitNotFound("${T} is not a DSL type")
   trait Typ[T] {
-    def from(e:Exp): T
-    def to(x:T):Exp
+    def from(e: Exp): T
+    def to(x: T): Exp
   }
   @implicitNotFound("${A} cannot be implicitly lifted to ${B}")
-  trait Lift[A,B] {
-    def to(x:A):B
+  trait Lift[A, B] {
+    def to(x: A): B
   }
 
-  implicit def identLift[T:Typ]: Lift[T,T] = new Lift[T,T] { def to(x:T) = x }
-  implicit def lift[T,U](x:T)(implicit e: Lift[T,U]): U = e.to(x)
+  implicit def identLift[T: Typ]: Lift[T, T] = new Lift[T, T] { def to(x: T) = x }
+  implicit def lift[T, U](x: T)(implicit e: Lift[T, U]): U = e.to(x)
 
-  def typ[T:Typ] = implicitly[Typ[T]]
+  def typ[T: Typ] = implicitly[Typ[T]]
 
-  def cbreflect[T:Typ](s:Exp):T = {
+  def cbreflect[T: Typ](s: Exp): T = {
     val tpe = typ[T]
     val x = fresh
     gen"""${Exp(tpe.toString)} $x = $s}"""
     tpe from x
   }
 
-  def reflect[T:Typ](s:Any*):T = cbreflect[T](Exp(s.mkString))
-  def ref[T:Typ](f: => T): Exp = (typ[T].to(f))
+  def reflect[T: Typ](s: Any*): T = cbreflect[T](Exp(s.mkString))
+  def ref[T: Typ](f: => T): Exp = (typ[T].to(f))
 
   case class Int(e: Exp) {
-    def +(y: Int) = reflect[Int](e,"+",y.e)
-    def -(y: Int) = reflect[Int](e,"-",y.e)
-    def *(y: Int) = reflect[Int](e,"*",y.e)
-    def /(y: Int) = reflect[Int](e,"/",y.e)
-    def %(y: Int) = reflect[Int](e,"%",y.e)
+    def +(y: Int) = reflect[Int](e, "+", y.e)
+    def -(y: Int) = reflect[Int](e, "-", y.e)
+    def *(y: Int) = reflect[Int](e, "*", y.e)
+    def /(y: Int) = reflect[Int](e, "/", y.e)
+    def %(y: Int) = reflect[Int](e, "%", y.e)
   }
   case class Boolean(e: Exp) {
-    def &&(y: => Boolean) = reflect[Boolean](e,"&&",y.e)
-    def ||(y: => Boolean) = reflect[Boolean](e,"+",y.e)
-    def unary_! = reflect[Boolean]("!",e)
+    def &&(y: => Boolean) = reflect[Boolean](e, "&&", y.e)
+    def ||(y: => Boolean) = reflect[Boolean](e, "+", y.e)
+    def unary_! = reflect[Boolean]("!", e)
   }
 
-  implicit val unitTyp: Typ[Unit] = new Typ[Unit] { 
-    def from(e:Exp) = (); 
-    def to(x:Unit) = Exp("()"); 
-    override def toString = "Unit" 
+  implicit val unitTyp: Typ[Unit] = new Typ[Unit] {
+    def from(e: Exp) = ();
+    def to(x: Unit) = Exp("()");
+    override def toString = "Unit"
   }
-  implicit val intTyp: Typ[Int] = new Typ[Int] { 
-    def from(e:Exp) = Int(e); 
-    def to(x:Int) = x.e; 
-    override def toString = "Int" 
+  implicit val intTyp: Typ[Int] = new Typ[Int] {
+    def from(e: Exp) = Int(e);
+    def to(x: Int) = x.e;
+    override def toString = "Int"
   }
-  implicit val booleanTyp: Typ[Boolean] = new Typ[Boolean] { 
-    def from(e:Exp) = Boolean(e); 
-    def to(x:Boolean) = x.e; 
-    override def toString = "Boolean" 
-  }
-
-  implicit val intLift: Lift[scala.Int,Int] = new Lift[scala.Int,Int] { 
-    def to(x:scala.Int) = Int(Exp(x.toString)) 
-  }
-  implicit val booleanLift: Lift[scala.Boolean,Boolean] = new Lift[scala.Boolean,Boolean] { 
-    def to(x:scala.Boolean) = Boolean(Exp(x.toString)) 
-  }
-  
-  case class Array[T:Typ](e: Exp) {
-    def length = reflect[Int](e,".length")
-    def apply(x: Int) = reflect[T](e,"(",ref(x),")")
-    def update(x: Int, y: T): Unit = reflect[Unit](e,"(",ref(x),") = ",ref(y))
-  }
-  def NewArray[T:Typ](x: Int): Array[T] = reflect[Array[T]]("new Array[",typ[T],"](",ref(x),")")
-  implicit def arrayTyp[T:Typ]: Typ[Array[T]] = new Typ[Array[T]] { 
-    def from(e:Exp) = Array(e); 
-    def to(x:Array[T]) = x.e; 
-    override def toString = "Array["+typ[T]+"]" 
+  implicit val booleanTyp: Typ[Boolean] = new Typ[Boolean] {
+    def from(e: Exp) = Boolean(e);
+    def to(x: Boolean) = x.e;
+    override def toString = "Boolean"
   }
 
-  def __ifThenElse[C,A,B](c:Boolean, a: =>A, b: =>B)(implicit mA: Lift[A,C], mB: Lift[B,C], mC: Typ[C]): C = {
-    reflect[C]("if (",ref(c),") ",ref(mA.to(a))," else ",ref(mB.to(b)))
+  implicit val intLift: Lift[scala.Int, Int] = new Lift[scala.Int, Int] {
+    def to(x: scala.Int) = Int(Exp(x.toString))
+  }
+  implicit val booleanLift: Lift[scala.Boolean, Boolean] = new Lift[scala.Boolean, Boolean] {
+    def to(x: scala.Boolean) = Boolean(Exp(x.toString))
+  }
+
+  case class Array[T: Typ](e: Exp) {
+    def length = reflect[Int](e, ".length")
+    def apply(x: Int) = reflect[T](e, "(", ref(x), ")")
+    def update(x: Int, y: T): Unit = reflect[Unit](e, "(", ref(x), ") = ", ref(y))
+  }
+  def NewArray[T: Typ](x: Int): Array[T] = reflect[Array[T]]("new Array[", typ[T], "](", ref(x), ")")
+  implicit def arrayTyp[T: Typ]: Typ[Array[T]] =
+    new Typ[Array[T]] {
+      def from(e: Exp) = Array(e);
+      def to(x: Array[T]) = x.e;
+      override def toString = "Array[" + typ[T] + "]"
+    }
+
+  def __ifThenElse[C, A, B](c: Boolean, a: => A, b: => B)(implicit mA: Lift[A, C], mB: Lift[B, C], mC: Typ[C]): C = {
+    reflect[C]("if (", ref(c), ") ", ref(mA.to(a)), " else ", ref(mB.to(b)))
   }
 
 }

--- a/src/main/scala/lms/experimental/macro_impl.scala
+++ b/src/main/scala/lms/experimental/macro_impl.scala
@@ -20,8 +20,7 @@ This macro implements the following translations:
   def foo(x1: T1, x2: T2): Tn = reflect[Tn]("foo",ref(x1),ref(x2))
   def foo_next(x1: T1, x2: T2): Tn = body
   lower((x1:T1,x2:T2) => Rewrite(foo(x1,x2), foo_next(x1,x2)))
-*/
-
+ */
 
 object ir_impl {
   def impl(c: Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
@@ -33,12 +32,12 @@ object ir_impl {
     println(a)
     a.tree match {
       case q"def $name[..$t](..$args): $tpe" =>
-        val args1 = args map { case ValDef(_,x,_,_) => q"ref($x)" }
+        val args1 = args map { case ValDef(_, x, _, _) => q"ref($x)" }
         return c.Expr(q"def $name[..$t](..$args): $tpe = reflect[$tpe](${name.toString},..$args1)")
       case q"def $name[..$t](..$args): $tpe = $body" =>
         // TODO: strip by-name type
-        val args0 = args map { case ValDef(_,x,_,_) => q"$x" }
-        val args1 = args map { case ValDef(_,x,_,_) => q"ref($x)" }
+        val args0 = args map { case ValDef(_, x, _, _) => q"$x" }
+        val args1 = args map { case ValDef(_, x, _, _) => q"ref($x)" }
         val name_next = TermName(name.toString + "_next")
         // TODO: what if we have type parameters? just disallow?
         return c.Expr(q"""
@@ -47,7 +46,7 @@ object ir_impl {
           def $name[..$t](..$args): $tpe = reflect[$tpe](${name.toString},..$args1)
           def $name_next[..$t](..$args): $tpe = $body
         """)
-     // TODO class def
+      // TODO class def
       //case t@ClassDef(_,_,_,_) =>
     }
   }

--- a/src/main/scala/lms/experimental/macros.scala
+++ b/src/main/scala/lms/experimental/macros.scala
@@ -3,7 +3,6 @@ package lms.experimental
 import language.experimental.macros
 import scala.annotation.StaticAnnotation
 
-
 class ir extends StaticAnnotation {
   def macroTransform(annottees: Any*): Any = macro ir_impl.impl
 }

--- a/src/main/scala/lms/macros/EmbeddedControls.scala
+++ b/src/main/scala/lms/macros/EmbeddedControls.scala
@@ -4,31 +4,31 @@ import language.experimental.macros
 import scala.reflect.macros.whitebox.Context
 
 /**
- * Default implementation of virtualized Scala control structures.
- *
- * This trait is adapted from the `EmbeddedControls` trait in
- * Scala Virtualized.  See also
- * [[https://raw.github.com/namin/scala/topic-virt/src/library/scala/EmbeddedControls.scala]]
- *
- * The `EmbeddedControls` trait provides method definitions where
- * calls to the methods are treated by the compiler in a special way.
- * The reason to express these calls as methods is to give embedded
- * DSLs a chance to provide their own definitions and thereby override
- * the standard interpretation of the compiler.
- *
- * Example: When faced with an `if` construct, the `@virtualized`
- * macro annotation will generate a method call:
- * `__ifThenElse(cond, thenp, elsep)`
- *
- * This method call will be bound to an implementation based on normal
- * rules of scoping.  If it binds to the standard one in this trait,
- * the corresponding macro will replace it by an `If` tree node. If
- * not, the call will be left as it is and a staging or interpreting
- * DSL can take over.
- *
- * @note This is feature experimental.
- * @note None of the above will happen unless you annotate your code with `@virtualize`.
- */
+  * Default implementation of virtualized Scala control structures.
+  *
+  * This trait is adapted from the `EmbeddedControls` trait in
+  * Scala Virtualized.  See also
+  * [[https://raw.github.com/namin/scala/topic-virt/src/library/scala/EmbeddedControls.scala]]
+  *
+  * The `EmbeddedControls` trait provides method definitions where
+  * calls to the methods are treated by the compiler in a special way.
+  * The reason to express these calls as methods is to give embedded
+  * DSLs a chance to provide their own definitions and thereby override
+  * the standard interpretation of the compiler.
+  *
+  * Example: When faced with an `if` construct, the `@virtualized`
+  * macro annotation will generate a method call:
+  * `__ifThenElse(cond, thenp, elsep)`
+  *
+  * This method call will be bound to an implementation based on normal
+  * rules of scoping.  If it binds to the standard one in this trait,
+  * the corresponding macro will replace it by an `If` tree node. If
+  * not, the call will be left as it is and a staging or interpreting
+  * DSL can take over.
+  *
+  * @note This is feature experimental.
+  * @note None of the above will happen unless you annotate your code with `@virtualize`.
+  */
 trait EmbeddedControls {
 
   import EmbeddedControls._
@@ -56,10 +56,10 @@ trait EmbeddedControls {
 //  def __lazyValDef[T](init: T): T = macro lazyValDefImpl[T]
 //  def __valDef[T](init: T): T = macro valDefImpl[T]
 
-
   // Poor man's infix methods for `Any` methods
   def infix_+(x1: String, x2: Any): String = macro string_+
-  def infix_+(x1: Any, x2: Any): Any = macro any_+ // don't know the return type => should actually never be produced by LanguageVirtualization
+  def infix_+(x1: Any, x2: Any): Any =
+    macro any_+ // don't know the return type => should actually never be produced by LanguageVirtualization
   def infix_==(x1: Any, x2: Any): Boolean = macro any_==
   def infix_!=(x1: Any, x2: Any): Boolean = macro any_!=
   def infix_##(x: Any): Int = macro any_##
@@ -83,19 +83,18 @@ trait EmbeddedControls {
   def infix_finalize(x: AnyRef): Unit = macro anyRef_finalize
 
   // Define universal arithmetic for all primitive types
-  def infix_+[A<:AnyVal, B<:AnyVal](lhs: A, rhs: B): AnyVal = macro anyVal_+[A,B]
+  def infix_+[A <: AnyVal, B <: AnyVal](lhs: A, rhs: B): AnyVal = macro anyVal_+[A, B]
 
 }
 
 /**
- * EmbeddedControls companion object containing macro implementations.
- */
+  * EmbeddedControls companion object containing macro implementations.
+  */
 private object EmbeddedControls {
 
   // Control structures
 
-  def ifThenElseImpl[T](c: Context)(
-    cond: c.Expr[Boolean], thenBr: c.Expr[T], elseBr: c.Expr[T]): c.Expr[T] = {
+  def ifThenElseImpl[T](c: Context)(cond: c.Expr[Boolean], thenBr: c.Expr[T], elseBr: c.Expr[T]): c.Expr[T] = {
 
     import c.universe._
     c.Expr(q"if ($cond) $thenBr else $elseBr")
@@ -131,16 +130,13 @@ private object EmbeddedControls {
     c.Expr(q"$lhs /= $rhs")
   }
 
-
-  def whileDoImpl(c: Context)(
-    cond: c.Expr[Boolean], body: c.Expr[Unit]): c.Expr[Unit] = {
+  def whileDoImpl(c: Context)(cond: c.Expr[Boolean], body: c.Expr[Unit]): c.Expr[Unit] = {
 
     import c.universe._
     c.Expr(q"while ($cond) $body")
   }
 
-  def doWhileImpl(c: Context)(
-    body: c.Expr[Unit], cond: c.Expr[Boolean]): c.Expr[Unit] = {
+  def doWhileImpl(c: Context)(body: c.Expr[Unit], cond: c.Expr[Boolean]): c.Expr[Unit] = {
 
     import c.universe._
     c.Expr(q"do $body while ($cond)")
@@ -156,29 +152,25 @@ private object EmbeddedControls {
 
   // Poor man's infix methods for `Any` methods
 
-  def string_+(c: Context)(
-    x1: c.Expr[String], x2: c.Expr[Any]): c.Expr[String] = {
+  def string_+(c: Context)(x1: c.Expr[String], x2: c.Expr[Any]): c.Expr[String] = {
 
     import c.universe._
     c.Expr(q"$x1.+($x2)")
   }
 
-  def any_+(c: Context)(
-    x1: c.Expr[Any], x2: c.Expr[Any]): c.Expr[Any] = {
+  def any_+(c: Context)(x1: c.Expr[Any], x2: c.Expr[Any]): c.Expr[Any] = {
 
     import c.universe._
     c.Expr(q"$x1.+($x2)")
   }
 
-  def any_==(c: Context)(
-    x1: c.Expr[Any], x2: c.Expr[Any]): c.Expr[Boolean] = {
+  def any_==(c: Context)(x1: c.Expr[Any], x2: c.Expr[Any]): c.Expr[Boolean] = {
 
     import c.universe._
     c.Expr(q"$x1.==($x2)")
   }
 
-  def any_!=(c: Context)(
-    x1: c.Expr[Any], x2: c.Expr[Any]): c.Expr[Boolean] = {
+  def any_!=(c: Context)(x1: c.Expr[Any], x2: c.Expr[Any]): c.Expr[Boolean] = {
 
     import c.universe._
     c.Expr(q"$x1.!=($x2)")
@@ -190,8 +182,7 @@ private object EmbeddedControls {
     c.Expr(q"$x.##()")
   }
 
-  def any_equals(c: Context)(
-    x1: c.Expr[Any], x2: c.Expr[Any]): c.Expr[Boolean] = {
+  def any_equals(c: Context)(x1: c.Expr[Any], x2: c.Expr[Any]): c.Expr[Boolean] = {
 
     import c.universe._
     c.Expr(q"$x1.equals($x2)")
@@ -203,15 +194,13 @@ private object EmbeddedControls {
     c.Expr(q"$x.hashCode()")
   }
 
-  def any_asInstanceOf[T](c: Context)(x: c.Expr[Any])(
-    implicit tt: c.WeakTypeTag[T]): c.Expr[T] = {
+  def any_asInstanceOf[T](c: Context)(x: c.Expr[Any])(implicit tt: c.WeakTypeTag[T]): c.Expr[T] = {
 
     import c.universe._
     c.Expr(q"$x.asInstanceOf[${tt.tpe}]")
   }
 
-  def any_isInstanceOf[T](c: Context)(x: c.Expr[Any])(
-    implicit tt: c.WeakTypeTag[T]): c.Expr[Boolean] = {
+  def any_isInstanceOf[T](c: Context)(x: c.Expr[Any])(implicit tt: c.WeakTypeTag[T]): c.Expr[Boolean] = {
 
     import c.universe._
     c.Expr[Boolean](q"$x.isInstanceOf[${tt.tpe}]")
@@ -232,15 +221,13 @@ private object EmbeddedControls {
 
   // Poor man's infix methods for `AnyRef` methods
 
-  def anyRef_eq(c: Context)(
-    x1: c.Expr[AnyRef], x2: c.Expr[AnyRef]): c.Expr[Boolean] = {
+  def anyRef_eq(c: Context)(x1: c.Expr[AnyRef], x2: c.Expr[AnyRef]): c.Expr[Boolean] = {
 
     import c.universe._
     c.Expr(q"$x1.eq($x2)")
   }
 
-  def anyRef_ne(c: Context)(
-    x1: c.Expr[AnyRef], x2: c.Expr[AnyRef]): c.Expr[Boolean] = {
+  def anyRef_ne(c: Context)(x1: c.Expr[AnyRef], x2: c.Expr[AnyRef]): c.Expr[Boolean] = {
 
     import c.universe._
     c.Expr(q"$x1.ne($x2)")
@@ -258,8 +245,7 @@ private object EmbeddedControls {
     c.Expr(q"$x.notifyAll()")
   }
 
-  def anyRef_synchronized[T](c: Context)(
-    x: c.Expr[AnyRef], body: c.Expr[T]): c.Expr[T] = {
+  def anyRef_synchronized[T](c: Context)(x: c.Expr[AnyRef], body: c.Expr[T]): c.Expr[T] = {
 
     import c.universe._
     c.Expr(q"$x.synchronized($body)")
@@ -271,16 +257,13 @@ private object EmbeddedControls {
     c.Expr(q"$x.wait()")
   }
 
-  def anyRef_wait1(c: Context)(
-    x: c.Expr[AnyRef], timeout: c.Expr[Long]): c.Expr[Unit] = {
+  def anyRef_wait1(c: Context)(x: c.Expr[AnyRef], timeout: c.Expr[Long]): c.Expr[Unit] = {
 
     import c.universe._
     c.Expr(q"$x.wait($timeout)")
   }
 
-  def anyRef_wait2(c: Context)(
-    x: c.Expr[AnyRef], timeout: c.Expr[Long],
-    nanos: c.Expr[Int]): c.Expr[Unit] = {
+  def anyRef_wait2(c: Context)(x: c.Expr[AnyRef], timeout: c.Expr[Long], nanos: c.Expr[Int]): c.Expr[Unit] = {
 
     import c.universe._
     c.Expr(q"$x.wait($timeout, $nanos)")
@@ -298,17 +281,21 @@ private object EmbeddedControls {
     c.Expr(q"$x.finalize()")
   }
 
-
   // TODO: move me and add hook for lms
   // TODO: revert import statement to blackbox macros when this is moved
-  def anyVal_+[A<:AnyVal, B<:AnyVal](c: Context)(lhs: c.Expr[A], rhs: c.Expr[B])(implicit ta: c.WeakTypeTag[A], tb: c.WeakTypeTag[B]): c.Expr[AnyVal] = {
+  def anyVal_+[A <: AnyVal, B <: AnyVal](
+      c: Context
+  )(lhs: c.Expr[A], rhs: c.Expr[B])(implicit ta: c.WeakTypeTag[A], tb: c.WeakTypeTag[B]): c.Expr[AnyVal] = {
     import c.universe._
 
     val resultType =
       if (weakTypeOf[A] weak_<:< weakTypeOf[B]) weakTypeOf[B]
       else if (weakTypeOf[B] weak_<:< weakTypeOf[A]) weakTypeOf[A]
       else {
-        c.error(c.enclosingPosition, s"Cannot add ${weakTypeOf[A]} and ${weakTypeOf[B]}") // panic (byte/short + char ???)
+        c.error(
+          c.enclosingPosition,
+          s"Cannot add ${weakTypeOf[A]} and ${weakTypeOf[B]}"
+        ) // panic (byte/short + char ???)
         weakTypeOf[AnyVal]
       }
 

--- a/src/main/scala/lms/macros/ir.scala
+++ b/src/main/scala/lms/macros/ir.scala
@@ -26,8 +26,7 @@ This macro implements the following translations:
   def foo(x1: T1, x2: T2): Tn = ...
   def foo_next(x1: T1, x2: T2): Tn = body
   object Mfoo { ... }
-*/
-
+ */
 
 object ir {
   def impl(c: Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
@@ -43,21 +42,24 @@ object ir {
 
     val List(a) = annottees
     println(a)
-    def transform(a: c.Expr[Any]): c.Expr[Any] = a.tree match {
+    def transform(a: c.Expr[Any]): c.Expr[Any] =
+      a.tree match {
 
-      // TODO
-      // + 1. Proper reflectEffect call
-      // + 2. Method annotation for allocation (e.g. TensorBuilder1)
-      // - 3. Extract meaningful arg annotation symbol?
+        // TODO
+        // + 1. Proper reflectEffect call
+        // + 2. Method annotation for allocation (e.g. TensorBuilder1)
+        // - 3. Extract meaningful arg annotation symbol?
 
-      case q"def $name[..$t](..$args): $tpe" =>
-        val effects = args collect { case v@ValDef(_,x,t,y) if v.toString contains("@") => q"ref($x)" } //XXX FIXME: currently any ann counts as effect!
-        val args1 = args map { case ValDef(_,x,_,_) => q"ref($x)" }
-        val tpes = args map { case ValDef(_,x,t,_) => q"$t" }
-        val name_extract = TermName("M"+name.toString)
-        val args3 = args map { case ValDef(_,x,_,_) => pq"$x" }
-        val args2 = args map { case ValDef(_,x,t,_) => q"unref[$t]($x)" }
-        return c.Expr(q"""
+        case q"def $name[..$t](..$args): $tpe" =>
+          val effects = args collect {
+            case v @ ValDef(_, x, t, y) if v.toString contains ("@") => q"ref($x)"
+          } //XXX FIXME: currently any ann counts as effect!
+          val args1 = args map { case ValDef(_, x, _, _) => q"ref($x)" }
+          val tpes = args map { case ValDef(_, x, t, _) => q"$t" }
+          val name_extract = TermName("M" + name.toString)
+          val args3 = args map { case ValDef(_, x, _, _) => pq"$x" }
+          val args2 = args map { case ValDef(_, x, t, _) => q"unref[$t]($x)" }
+          return c.Expr(q"""
           def $name[..$t](..$args): $tpe = reflect[$tpe](${name.toString},..$args1)()(..$effects)
           object $name_extract {
             def unapply(xx_x: Any): Option[(..$tpes)] = xx_x match {
@@ -66,33 +68,38 @@ object ir {
             }
           }
         """)
-      case q"def $name[..$t](..$args): $tpe = $body" =>
-        // TODO: strip by-name type (?)
-        var effects = args collect { case v@ValDef(_,x,t,y) if v.toString contains("@") => q"ref($x)" } //XXX FIXME: any ann counts as effect!
-        var effects2 = args collect { case v@ValDef(m,x,t,y) if m.annotations.nonEmpty => q"ref($x)" }
-        assert(effects.toString == effects2.toString, s"$effects != $effects2")
-        var reffects = List[c.universe.Tree]()
-        if (tpe.toString.contains("@")) {
-          println(tpe.getClass)
-          tpe match {
-            case tq"$t @..$foo" => println(s"YAY $t $foo")
-            case _ => println("NAY")
+        case q"def $name[..$t](..$args): $tpe = $body" =>
+          // TODO: strip by-name type (?)
+          var effects = args collect {
+            case v @ ValDef(_, x, t, y) if v.toString contains ("@") => q"ref($x)"
+          } //XXX FIXME: any ann counts as effect!
+          var effects2 = args collect { case v @ ValDef(m, x, t, y) if m.annotations.nonEmpty => q"ref($x)" }
+          assert(effects.toString == effects2.toString, s"$effects != $effects2")
+          var reffects = List[c.universe.Tree]()
+          if (tpe.toString.contains("@")) {
+            println(tpe.getClass)
+            tpe match {
+              case tq"$t @..$foo" => println(s"YAY $t $foo")
+              case _ => println("NAY")
+            }
+            //XXX TODO cleanup!!
+            // println(tpe.asInstanceOf[scala.reflect.internal.Trees$Tree].annotations)
+            println("XXXXXXXXXXXXX " + tpe)
+            reffects :+= q"STORE"
           }
-          //XXX TODO cleanup!!
-          // println(tpe.asInstanceOf[scala.reflect.internal.Trees$Tree].annotations)
-          println("XXXXXXXXXXXXX "+tpe)
-          reffects :+= q"STORE"
-        }
 
-        val args0 = args map { case ValDef(_,x,_,_) => q"$x" }
-        val args1 = args map { case ValDef(_,x,_,_) => q"ref($x)" }
-        val tpes = args map { case ValDef(_,x,t,_) => q"$t" }
-        val name_extract = TermName("M"+name.toString)
-        val name_next = TermName(name.toString + "_next")
-        val args3 = args map { case ValDef(_,x,_,_) => pq"$x" }
-        val args2 = args map { case ValDef(_,x,t,_) => q"unref[$t]($x)" }
-        val lower = target match { case Some(t) => q"rewriteAt($t)" case _ => q"rewrite"}
-        return c.Expr(q"""
+          val args0 = args map { case ValDef(_, x, _, _) => q"$x" }
+          val args1 = args map { case ValDef(_, x, _, _) => q"ref($x)" }
+          val tpes = args map { case ValDef(_, x, t, _) => q"$t" }
+          val name_extract = TermName("M" + name.toString)
+          val name_next = TermName(name.toString + "_next")
+          val args3 = args map { case ValDef(_, x, _, _) => pq"$x" }
+          val args2 = args map { case ValDef(_, x, t, _) => q"unref[$t]($x)" }
+          val lower = target match {
+            case Some(t) => q"rewriteAt($t)"
+            case _ => q"rewrite"
+          }
+          return c.Expr(q"""
           $lower { case $name_extract(..$args3) => $name_next(..$args0) }
           def $name[..$t](..$args): $tpe = reflect[$tpe](${name.toString},..$args1)(..$reffects)(..$effects)
           def $name_next[..$t](..$args): $tpe = $body
@@ -103,9 +110,9 @@ object ir {
             }
           }
         """)
-     // TODO class def
-      //case t@ClassDef(_,_,_,_) =>
-    }
+        // TODO class def
+        //case t@ClassDef(_,_,_,_) =>
+      }
     transform(a)
   }
 }

--- a/src/main/scala/lms/macros/virtualize.scala
+++ b/src/main/scala/lms/macros/virtualize.scala
@@ -8,7 +8,6 @@ import scala.util.matching.Regex
 
 import scala.collection.mutable
 
-
 object virtualize {
   def impl(c: Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
     import c.universe._
@@ -26,35 +25,31 @@ object virtualize {
     val inputs = annottees.map(_.tree).toList
     val (annottee, rest) = inputs match {
       case (a: ValDef) :: as => {
-        c.warning(c.enclosingPosition,
-          "virtualization of parameters is not supported.")
+        c.warning(c.enclosingPosition, "virtualization of parameters is not supported.")
         (None, inputs)
       }
       case (a: TypeDef) :: as => {
-        c.warning(c.enclosingPosition,
-          "virtualization of type parameters is not supported.")
+        c.warning(c.enclosingPosition, "virtualization of type parameters is not supported.")
         (None, inputs)
       }
       case a :: as => (Some(a), as)
-      case Nil     => (None, Nil)
+      case Nil => (None, Nil)
     }
 
     /* Virtualize the annottee. */
     val expandees = annottee match {
       case Some(a) => transformer.virtualize(a)._1 :: rest
-      case None    => rest
+      case None => rest
     }
 
     c.Expr(Block(expandees, Literal(Constant(()))))
   }
 
-  private final class Virtualizer[C <: Context](val c: C)
-    extends LanguageVirtualization {
+  private final class Virtualizer[C <: Context](val c: C) extends LanguageVirtualization {
     type Ctx = C
     val debugLevel = 0
   }
 }
-
 
 trait MacroModule {
   type Ctx <: Context
@@ -67,8 +62,8 @@ trait DataDefs extends MacroModule {
 }
 
 /**
- * Common utilities for the Yin-Yang project.
- */
+  * Common utilities for the Yin-Yang project.
+  */
 trait TransformationUtils extends MacroModule {
   import c.universe._
   import internal.decorators._
@@ -78,7 +73,7 @@ trait TransformationUtils extends MacroModule {
     val calleeName = TermName(methName)
     val callee = recOpt match {
       case Some(rec) => Select(rec, calleeName)
-      case None      => Ident(calleeName)
+      case None => Ident(calleeName)
     }
     val calleeAndTargs: Tree = typeApply(targs)(callee)
     args.foldLeft(calleeAndTargs) { Apply(_, _) }
@@ -89,10 +84,11 @@ trait TransformationUtils extends MacroModule {
 
   def symbolId(tree: Tree): Int = symbolId(tree.symbol)
 
-  def typeApply(targs: List[Tree])(select: Tree) = if (targs.nonEmpty)
-    TypeApply(select, targs)
-  else
-    select
+  def typeApply(targs: List[Tree])(select: Tree) =
+    if (targs.nonEmpty)
+      TypeApply(select, targs)
+    else
+      select
 
   def makeConstructor(classname: String, arguments: List[Tree]): Tree =
     Apply(Select(newClass(classname), termNames.CONSTRUCTOR), arguments)
@@ -132,7 +128,6 @@ trait TransformationUtils extends MacroModule {
   }
 }
 
-
 trait LanguageVirtualization extends MacroModule with TransformationUtils with DataDefs {
   import c.universe._
 
@@ -155,125 +150,125 @@ trait LanguageVirtualization extends MacroModule with TransformationUtils with D
       method(receiver.map(transform), nme, List(args.map(transform)), targs)
     }
 
-    override def transform(tree: Tree): Tree = atPos(tree.pos) {
-      tree match {
-        // sstucki: It seems necessary to keep the MUTABLE flag in the
-        // new ValDef set, otherwise it becomes tricky to
-        // "un-virtualize" a variable definition, if necessary
-        // (e.g. if the DSL does not handle variable definitions in a
-        // special way).
-        case ValDef(mods, sym, tpt, rhs) if mods.hasFlag(Flag.MUTABLE) =>
-          ValDef(mods, sym, tpt, liftFeature(None, "__newVar", List(rhs)))
+    override def transform(tree: Tree): Tree =
+      atPos(tree.pos) {
+        tree match {
+          // sstucki: It seems necessary to keep the MUTABLE flag in the
+          // new ValDef set, otherwise it becomes tricky to
+          // "un-virtualize" a variable definition, if necessary
+          // (e.g. if the DSL does not handle variable definitions in a
+          // special way).
+          case ValDef(mods, sym, tpt, rhs) if mods.hasFlag(Flag.MUTABLE) =>
+            ValDef(mods, sym, tpt, liftFeature(None, "__newVar", List(rhs)))
 
-        // TODO: what about variable reads?
+          // TODO: what about variable reads?
 
-        case t @ If(cond, thenBr, elseBr) =>
-          liftFeature(None, "__ifThenElse", List(cond, thenBr, elseBr))
+          case t @ If(cond, thenBr, elseBr) =>
+            liftFeature(None, "__ifThenElse", List(cond, thenBr, elseBr))
 
-        case Return(e) =>
-          liftFeature(None, "__return", List(e))
+          case Return(e) =>
+            liftFeature(None, "__return", List(e))
 
-        case Assign(lhs, rhs) =>
-          liftFeature(None, "__assign", List(lhs, rhs))
+          case Assign(lhs, rhs) =>
+            liftFeature(None, "__assign", List(lhs, rhs))
 
-        case LabelDef(sym, List(), If(cond, Block(body :: Nil, Apply(Ident(label),
-          List())), Literal(Constant(())))) if label == sym => // while(){}
-          liftFeature(None, "__whileDo", List(cond, body))
+          case LabelDef(sym, List(), If(cond, Block(body :: Nil, Apply(Ident(label), List())), Literal(Constant(()))))
+              if label == sym => // while(){}
+            liftFeature(None, "__whileDo", List(cond, body))
 
-        case LabelDef(sym, List(), Block(body :: Nil, If(cond, Apply(Ident(label),
-          List()), Literal(Constant(()))))) if label == sym => // do while(){}
-          liftFeature(None, "__doWhile", List(cond, body))
+          case LabelDef(sym, List(), Block(body :: Nil, If(cond, Apply(Ident(label), List()), Literal(Constant(())))))
+              if label == sym => // do while(){}
+            liftFeature(None, "__doWhile", List(cond, body))
 
-        // only rewrite + to infix_+ if lhs is a String *literal* (we can't look at types!)
-        // TODO: note that this is not sufficient to handle "foo: " + x + "," + y
-        case Apply(Select(qual @ Literal(Constant(s: String)), TermName("$plus")), List(arg)) =>
-          liftFeature(None, "infix_$plus", List(qual, arg))
+          // only rewrite + to infix_+ if lhs is a String *literal* (we can't look at types!)
+          // TODO: note that this is not sufficient to handle "foo: " + x + "," + y
+          case Apply(Select(qual @ Literal(Constant(s: String)), TermName("$plus")), List(arg)) =>
+            liftFeature(None, "infix_$plus", List(qual, arg))
 
 //        case Apply(Select(qualifier, TermName("$plus")), List(arg)) =>
 //          liftFeature(None, "infix_$plus", List(qualifier, arg))
 
-        case Apply(Select(qualifier, TermName("$eq$eq")), List(arg)) =>
-          liftFeature(None, "infix_$eq$eq", List(qualifier, arg))
+          case Apply(Select(qualifier, TermName("$eq$eq")), List(arg)) =>
+            liftFeature(None, "infix_$eq$eq", List(qualifier, arg))
 
-        case Apply(Select(qualifier, TermName("$bang$eq")), List(arg)) =>
-          liftFeature(None, "infix_$bang$eq", List(qualifier, arg))
+          case Apply(Select(qualifier, TermName("$bang$eq")), List(arg)) =>
+            liftFeature(None, "infix_$bang$eq", List(qualifier, arg))
 
-        case Apply(lhs @ Select(qualifier, TermName("$hash$hash")), List()) =>
-          liftFeature(None, "infix_$hash$hash", List(qualifier))
+          case Apply(lhs @ Select(qualifier, TermName("$hash$hash")), List()) =>
+            liftFeature(None, "infix_$hash$hash", List(qualifier))
 
-        case Apply(lhs @ Select(qualifier, TermName("equals")), List(arg)) =>
-          liftFeature(None, "infix_equals", List(qualifier, arg))
+          case Apply(lhs @ Select(qualifier, TermName("equals")), List(arg)) =>
+            liftFeature(None, "infix_equals", List(qualifier, arg))
 
-        case Apply(lhs @ Select(qualifier, TermName("hashCode")), List()) =>
-          liftFeature(None, "infix_hashCode", List(qualifier))
+          case Apply(lhs @ Select(qualifier, TermName("hashCode")), List()) =>
+            liftFeature(None, "infix_hashCode", List(qualifier))
 
-        case TypeApply(Select(qualifier, TermName("asInstanceOf")), targs) =>
-          liftFeature(None, "infix_asInstanceOf", List(qualifier), targs)
+          case TypeApply(Select(qualifier, TermName("asInstanceOf")), targs) =>
+            liftFeature(None, "infix_asInstanceOf", List(qualifier), targs)
 
-        case TypeApply(Select(qualifier, TermName("isInstanceOf")), targs) =>
-          liftFeature(None, "infix_isInstanceOf", List(qualifier), targs)
+          case TypeApply(Select(qualifier, TermName("isInstanceOf")), targs) =>
+            liftFeature(None, "infix_isInstanceOf", List(qualifier), targs)
 
-        case Apply(lhs @ Select(qualifier, TermName("toString")), List()) =>
-          liftFeature(None, "infix_toString", List(qualifier))
+          case Apply(lhs @ Select(qualifier, TermName("toString")), List()) =>
+            liftFeature(None, "infix_toString", List(qualifier))
 
-        case Apply(lhs @ Select(qualifier, TermName("eq")), List(arg)) =>
-          liftFeature(None, "infix_eq", List(qualifier, arg))
+          case Apply(lhs @ Select(qualifier, TermName("eq")), List(arg)) =>
+            liftFeature(None, "infix_eq", List(qualifier, arg))
 
-        case Apply(lhs @ Select(qualifier, TermName("ne")), List(arg)) =>
-          liftFeature(None, "infix_ne", List(qualifier, arg))
+          case Apply(lhs @ Select(qualifier, TermName("ne")), List(arg)) =>
+            liftFeature(None, "infix_ne", List(qualifier, arg))
 
-        case Apply(Select(qualifier, TermName("notify")), List()) =>
-          liftFeature(None, "infix_notify", List(qualifier))
+          case Apply(Select(qualifier, TermName("notify")), List()) =>
+            liftFeature(None, "infix_notify", List(qualifier))
 
-        case Apply(Select(qualifier, TermName("notifyAll")), List()) =>
-          liftFeature(None, "infix_notifyAll", List(qualifier))
+          case Apply(Select(qualifier, TermName("notifyAll")), List()) =>
+            liftFeature(None, "infix_notifyAll", List(qualifier))
 
-        case Apply(Select(qualifier, TermName("synchronized")), List(arg)) =>
-          liftFeature(None, "infix_synchronized", List(qualifier, arg))
+          case Apply(Select(qualifier, TermName("synchronized")), List(arg)) =>
+            liftFeature(None, "infix_synchronized", List(qualifier, arg))
 
-        case Apply(TypeApply(Select(qualifier, TermName("synchronized")), targs), List(arg)) =>
-          liftFeature(None, "infix_synchronized", List(qualifier, arg), targs)
+          case Apply(TypeApply(Select(qualifier, TermName("synchronized")), targs), List(arg)) =>
+            liftFeature(None, "infix_synchronized", List(qualifier, arg), targs)
 
-        case Apply(Select(qualifier, TermName("wait")), List()) =>
-          liftFeature(None, "infix_wait", List(qualifier))
+          case Apply(Select(qualifier, TermName("wait")), List()) =>
+            liftFeature(None, "infix_wait", List(qualifier))
 
-        case Apply(Select(qualifier, TermName("wait")), List(arg)
-          ) if arg.tpe =:= typeOf[Long] =>
-          liftFeature(None, "infix_wait", List(qualifier, arg))
+          case Apply(Select(qualifier, TermName("wait")), List(arg)) if arg.tpe =:= typeOf[Long] =>
+            liftFeature(None, "infix_wait", List(qualifier, arg))
 
-        case Apply(Select(qualifier, TermName("wait")), List(arg0, arg1)
-          ) if arg0.tpe =:= typeOf[Long] && arg1.tpe =:= typeOf[Int] =>
-          liftFeature(None, "infix_wait", List(qualifier, arg0, arg1))
+          case Apply(Select(qualifier, TermName("wait")), List(arg0, arg1))
+              if arg0.tpe =:= typeOf[Long] && arg1.tpe =:= typeOf[Int] =>
+            liftFeature(None, "infix_wait", List(qualifier, arg0, arg1))
 
-        case Try(block, catches, finalizer) => {
-          c.warning(tree.pos, "virtualization of try/catch expressions is not supported.")
-          super.transform(tree)
+          case Try(block, catches, finalizer) => {
+            c.warning(tree.pos, "virtualization of try/catch expressions is not supported.")
+            super.transform(tree)
+          }
+
+          case Throw(expr) => {
+            c.warning(tree.pos, "virtualization of throw expressions is not supported.")
+            super.transform(tree)
+          }
+
+          case ClassDef(mods, n, _, _) if mods.hasFlag(Flag.CASE) =>
+            // sstucki: there are issues with the ordering of
+            // virtualization and expansion of case classes (i.e. some
+            // of the expanded code might be virtualized even though it
+            // should not be and vice-versa).  So until we have decided
+            // how proper virtualization of case classes should be done,
+            // any attempt to do so should fail.
+            // TR: not 100% sure what the issue is (although i vaguely
+            // remember that we had issues in Scala-Virtualized with
+            // auto-generated case class equality methods using virtualized
+            // equality where it shouldn't). For the moment it seems like
+            // just treating case classes as regular classes works fine.
+            //println(tree)
+            // c.warning(tree.pos, "virtualization of case classes is not fully supported.")
+            super.transform(tree)
+          case _ =>
+            super.transform(tree)
         }
-
-        case Throw(expr) => {
-          c.warning(tree.pos, "virtualization of throw expressions is not supported.")
-          super.transform(tree)
-        }
-
-        case ClassDef(mods, n, _, _) if mods.hasFlag(Flag.CASE) =>
-          // sstucki: there are issues with the ordering of
-          // virtualization and expansion of case classes (i.e. some
-          // of the expanded code might be virtualized even though it
-          // should not be and vice-versa).  So until we have decided
-          // how proper virtualization of case classes should be done,
-          // any attempt to do so should fail.
-          // TR: not 100% sure what the issue is (although i vaguely
-          // remember that we had issues in Scala-Virtualized with 
-          // auto-generated case class equality methods using virtualized
-          // equality where it shouldn't). For the moment it seems like 
-          // just treating case classes as regular classes works fine.
-          //println(tree)
-          // c.warning(tree.pos, "virtualization of case classes is not fully supported.")
-          super.transform(tree) 
-        case _ =>
-          super.transform(tree)
       }
-    }
     def apply(tree: c.universe.Tree): (Tree, Seq[DSLFeature]) =
       (transform(tree), lifted.toSeq)
   }

--- a/src/main/scala/lms/thirdparty/c_lib_utils.scala
+++ b/src/main/scala/lms/thirdparty/c_lib_utils.scala
@@ -11,22 +11,22 @@ import lms.collection.mutable.ArrayOps
 
 import lms.collection._
 
-
 trait CMacro { b: Base =>
-  def cmacro[T:Manifest](m:String): Rep[T] = {
+  def cmacro[T: Manifest](m: String): Rep[T] = {
     Wrap[T](Adapter.g.reflectUnsafe("macro", lms.core.Backend.Const(m)))
   }
 }
 
 trait CCodeGenCMacro extends ExtendedCCodeGen {
-  override def shallow(n: Node): Unit = n match {
-    case Node(_, "macro", List(Const(m:String)), _) =>
-      emit(m)
-    case _ => super.shallow(n)
-  }
+  override def shallow(n: Node): Unit =
+    n match {
+      case Node(_, "macro", List(Const(m: String)), _) =>
+        emit(m)
+      case _ => super.shallow(n)
+    }
 }
 
-trait LibStruct { b : Base =>
+trait LibStruct { b: Base =>
   def newStruct[T: Manifest]: Rep[T] = {
     Wrap[T](Adapter.g.reflectUnsafe("lib-struct", Backend.Const(manifest[T])))
   }
@@ -38,54 +38,62 @@ trait LibStruct { b : Base =>
 }
 
 trait CCodeGenLibStruct extends ExtendedCCodeGen {
-  override def mayInline(n: Node): Boolean = n match {
-    case Node(_, "lib-struct", _, _) => false
-    case _ => super.mayInline(n)
-  }
+  override def mayInline(n: Node): Boolean =
+    n match {
+      case Node(_, "lib-struct", _, _) => false
+      case _ => super.mayInline(n)
+    }
 
-  override def shallow(n: Node): Unit = n match {
-    case Node(s, "read-field", List(x: Sym, Const(m: String)), _) =>
-      shallow(x); emit(s".$m")
-    case _ => super.shallow(n)
-  }
+  override def shallow(n: Node): Unit =
+    n match {
+      case Node(s, "read-field", List(x: Sym, Const(m: String)), _) =>
+        shallow(x); emit(s".$m")
+      case _ => super.shallow(n)
+    }
 
-  override def traverse(n: Node): Unit = n match {
-    case Node(s, "lib-struct", List(Const(m: Manifest[_])), _) =>
-      emit(s"${remap(m)} ")
-      shallow(s)
-      emitln(";")
-    // allow "lib-struct" to take parameters
-    case Node(s, "lib-struct", Const(m: Manifest[_])::args, _) =>
-      emit(s"${remap(m)} "); shallow(s);
-      emit("("); shallow(args.head);
-      args.tail.foreach(a => {emit(", "); shallow(a)})
-      emitln(");")
-    case _ => super.traverse(n)
-  }
+  override def traverse(n: Node): Unit =
+    n match {
+      case Node(s, "lib-struct", List(Const(m: Manifest[_])), _) =>
+        emit(s"${remap(m)} ")
+        shallow(s)
+        emitln(";")
+      // allow "lib-struct" to take parameters
+      case Node(s, "lib-struct", Const(m: Manifest[_]) :: args, _) =>
+        emit(s"${remap(m)} "); shallow(s);
+        emit("("); shallow(args.head);
+        args.tail.foreach(a => { emit(", "); shallow(a) })
+        emitln(");")
+      case _ => super.traverse(n)
+    }
 }
 
 trait LibFunction { b: Base =>
-  def libFunction[T:Manifest](m:String, rhs:lms.core.Backend.Exp*)(rkeys:Seq[Int], wkeys:Seq[Int], pkeys:Set[Int], keys: lms.core.Backend.Exp*): Rep[T] = {
+  def libFunction[T: Manifest](
+      m: String,
+      rhs: lms.core.Backend.Exp*
+  )(rkeys: Seq[Int], wkeys: Seq[Int], pkeys: Set[Int], keys: lms.core.Backend.Exp*): Rep[T] = {
     val readKeys = rkeys.map(rhs(_))
     val writeKeys = wkeys.map(rhs(_)) ++ keys
     val defs = Seq(lms.core.Backend.Const(m), lms.core.Backend.Const(pkeys)) ++ rhs
-    Wrap[T](Adapter.g.reflectEffect("lib-function", defs:_*)(readKeys: _*)(writeKeys: _*))
+    Wrap[T](Adapter.g.reflectEffect("lib-function", defs: _*)(readKeys: _*)(writeKeys: _*))
   }
 }
 
 trait CCodeGenLibFunction extends ExtendedCCodeGen {
-  override def shallow(n: Node): Unit = n match {
-    case Node(s, "lib-function", Const(m:String) :: Const(pkeys: Set[Int]) :: rhs, _) =>
-      val last = rhs.length - 1
-      emit(s"$m(");
-      rhs.zipWithIndex.foreach { case(r, index) =>
-        if (pkeys.contains(index)) emit("&")
-        shallow(r)
-        if (index < last) emit(", ")
-      }
-      emit(")")
-    case _ => super.shallow(n)
-  }
+  override def shallow(n: Node): Unit =
+    n match {
+      case Node(s, "lib-function", Const(m: String) :: Const(pkeys: Set[Int]) :: rhs, _) =>
+        val last = rhs.length - 1
+        emit(s"$m(");
+        rhs.zipWithIndex.foreach {
+          case (r, index) =>
+            if (pkeys.contains(index)) emit("&")
+            shallow(r)
+            if (index < last) emit(", ")
+        }
+        emit(")")
+      case _ => super.shallow(n)
+    }
 }
 
 trait CLibs extends Base with CMacro with LibStruct with LibFunction

--- a/src/main/scala/lms/thirdparty/cblas.scala
+++ b/src/main/scala/lms/thirdparty/cblas.scala
@@ -24,13 +24,36 @@ trait CBLASOps extends Base with CLibs with SizeTOps {
                 const float alpha, const float  *A, const int lda,
                 const float  *X, const int incX, const float beta,
                 float  *Y, const int incY)
-  */
-  def cblas_sgemv(layout: Rep[CBLAS_LAYOUT], transA: Rep[CBLAS_TRANSPOSE], m: Rep[Int], n: Rep[Int],
-      alpha: Rep[Float], A: Rep[Array[Float]], lda: Rep[Int], X: Rep[Array[Float]], incX: Rep[Int],
-      beta: Rep[Float], Y: Rep[Array[Float]], incY: Rep[Int]) =
-    libFunction[Unit]("cblas_sgemv", Unwrap(layout), Unwrap(transA), Unwrap(m), Unwrap(n), Unwrap(alpha),
-      Unwrap(A), Unwrap(lda), Unwrap(X), Unwrap(incX), Unwrap(beta), Unwrap(Y),
-      Unwrap(incY))(Seq(0, 1, 5, 7), Seq(10), Set[Int]())
+   */
+  def cblas_sgemv(
+      layout: Rep[CBLAS_LAYOUT],
+      transA: Rep[CBLAS_TRANSPOSE],
+      m: Rep[Int],
+      n: Rep[Int],
+      alpha: Rep[Float],
+      A: Rep[Array[Float]],
+      lda: Rep[Int],
+      X: Rep[Array[Float]],
+      incX: Rep[Int],
+      beta: Rep[Float],
+      Y: Rep[Array[Float]],
+      incY: Rep[Int]
+  ) =
+    libFunction[Unit](
+      "cblas_sgemv",
+      Unwrap(layout),
+      Unwrap(transA),
+      Unwrap(m),
+      Unwrap(n),
+      Unwrap(alpha),
+      Unwrap(A),
+      Unwrap(lda),
+      Unwrap(X),
+      Unwrap(incX),
+      Unwrap(beta),
+      Unwrap(Y),
+      Unwrap(incY)
+    )(Seq(0, 1, 5, 7), Seq(10), Set[Int]())
 
   /*
     void cblas_sgemm(const CBLAS_LAYOUT layout, const CBLAS_TRANSPOSE TransA,
@@ -38,12 +61,39 @@ trait CBLASOps extends Base with CLibs with SizeTOps {
                 const int K, const float alpha, const float  *A,
                 const int lda, const float  *B, const int ldb,
                 const float beta, float  *C, const int ldc)
-  */
-  def cblas_sgemm(layout: Rep[CBLAS_LAYOUT], transA: Rep[CBLAS_TRANSPOSE], transB: Rep[CBLAS_TRANSPOSE],
-      m: Rep[Int], n: Rep[Int], k: Rep[Int], alpha: Rep[Float], A: Rep[Array[Float]], lda: Rep[Int],
-      B: Rep[Array[Float]], ldb: Rep[Int], beta: Rep[Float], C: Rep[Array[Float]], ldc: Rep[Int]) =
-    libFunction[Unit]("cblas_sgemm", Unwrap(layout), Unwrap(transA), Unwrap(transB), Unwrap(m), Unwrap(n),
-      Unwrap(k), Unwrap(alpha), Unwrap(A), Unwrap(lda), Unwrap(B), Unwrap(ldb), Unwrap(beta), Unwrap(C),
-      Unwrap(ldc))(Seq(0, 1, 2, 7, 9), Seq(12), Set[Int]())
+   */
+  def cblas_sgemm(
+      layout: Rep[CBLAS_LAYOUT],
+      transA: Rep[CBLAS_TRANSPOSE],
+      transB: Rep[CBLAS_TRANSPOSE],
+      m: Rep[Int],
+      n: Rep[Int],
+      k: Rep[Int],
+      alpha: Rep[Float],
+      A: Rep[Array[Float]],
+      lda: Rep[Int],
+      B: Rep[Array[Float]],
+      ldb: Rep[Int],
+      beta: Rep[Float],
+      C: Rep[Array[Float]],
+      ldc: Rep[Int]
+  ) =
+    libFunction[Unit](
+      "cblas_sgemm",
+      Unwrap(layout),
+      Unwrap(transA),
+      Unwrap(transB),
+      Unwrap(m),
+      Unwrap(n),
+      Unwrap(k),
+      Unwrap(alpha),
+      Unwrap(A),
+      Unwrap(lda),
+      Unwrap(B),
+      Unwrap(ldb),
+      Unwrap(beta),
+      Unwrap(C),
+      Unwrap(ldc)
+    )(Seq(0, 1, 2, 7, 9), Seq(12), Set[Int]())
 
 }

--- a/src/main/scala/lms/thirdparty/cuda/cuda.scala
+++ b/src/main/scala/lms/thirdparty/cuda/cuda.scala
@@ -22,16 +22,16 @@ trait CudaOps extends Base with SizeTOps with StackArrayOps with CLibs with Cuda
     libFunction[Unit]("CUDA_CALL", Unwrap(status))(Seq[Int](), Seq[Int](), Set[Int](), Adapter.CTRL)
 
   // cudaError_t cudaMalloc ( void** devPtr, size_t size )
-  def cudaMalloc[T:Manifest](devPtr: Rep[Array[T]], size: Rep[SizeT]) =
+  def cudaMalloc[T: Manifest](devPtr: Rep[Array[T]], size: Rep[SizeT]) =
     libFunction[CudaErrorT]("cudaMalloc", Unwrap(devPtr), Unwrap(size))(Seq(1), Seq(0), Set(0))
-  def cudaMalloc2[T:Manifest](count: Rep[Int])(implicit __pos: SourceContext) = {
+  def cudaMalloc2[T: Manifest](count: Rep[Int])(implicit __pos: SourceContext) = {
     val addr: Rep[Array[T]] = NewArray[T](0) // FIXME(feiw) just need an uninitialized pointer
     cudaCall(cudaMalloc(addr, SizeT(count * sizeOf[T])))
     addr
   }
 
   // cudaError_t cudaFree ( void* devPtr )
-  def cudaFree[T:Manifest](devPtr: Rep[Array[T]]) =
+  def cudaFree[T: Manifest](devPtr: Rep[Array[T]]) =
     libFunction[CudaErrorT]("cudaFree", Unwrap(devPtr))(Seq(0), Seq(0), Set[Int]())
 
   abstract class CudaMemcpyKind
@@ -43,9 +43,15 @@ trait CudaOps extends Base with SizeTOps with StackArrayOps with CLibs with Cuda
   def cpyDefault = cmacro[CudaMemcpyKind]("cudaMemcpyDefault")
 
   // ​cudaError_t cudaMemcpy ( void* dst, const void* src, size_t count, cudaMemcpyKind kind )
-  def cudaMemcpy[T:Manifest](dst: Rep[Array[T]], src: Rep[Array[T]], size: Rep[SizeT], kind: Rep[CudaMemcpyKind]) =
-    libFunction[CudaErrorT]("cudaMemcpy", Unwrap(dst), Unwrap(src), Unwrap(size), Unwrap(kind))(Seq(1,2,3), Seq(0), Set[Int]())
-  def cudaMemcpyOfT[T:Manifest](dst: Rep[Array[T]], src: Rep[Array[T]], count: Rep[Int], kind: Rep[CudaMemcpyKind])(implicit __pos: SourceContext) =
+  def cudaMemcpy[T: Manifest](dst: Rep[Array[T]], src: Rep[Array[T]], size: Rep[SizeT], kind: Rep[CudaMemcpyKind]) =
+    libFunction[CudaErrorT]("cudaMemcpy", Unwrap(dst), Unwrap(src), Unwrap(size), Unwrap(kind))(
+      Seq(1, 2, 3),
+      Seq(0),
+      Set[Int]()
+    )
+  def cudaMemcpyOfT[T: Manifest](dst: Rep[Array[T]], src: Rep[Array[T]], count: Rep[Int], kind: Rep[CudaMemcpyKind])(
+      implicit __pos: SourceContext
+  ) =
     cudaMemcpy(dst, src, SizeT(count * sizeOf[T]), kind)
 }
 

--- a/src/main/scala/lms/thirdparty/cuda/cuda_lib_utils.scala
+++ b/src/main/scala/lms/thirdparty/cuda/cuda_lib_utils.scala
@@ -12,30 +12,39 @@ import lms.collection.mutable.ArrayOps
 import lms.collection._
 
 trait CudaFunction extends Base {
-  def cudaFunction[T:Manifest](m: String, configs: Seq[lms.core.Backend.Exp],
-    rhs: lms.core.Backend.Exp*)(rkeys: Seq[Int], wkeys: Seq[Int], pkeys: Set[Int], keys: lms.core.Backend.Const*): Rep[T] = {
+  def cudaFunction[T: Manifest](
+      m: String,
+      configs: Seq[lms.core.Backend.Exp],
+      rhs: lms.core.Backend.Exp*
+  )(rkeys: Seq[Int], wkeys: Seq[Int], pkeys: Set[Int], keys: lms.core.Backend.Const*): Rep[T] = {
     val readKeys = rkeys.map(rhs(_))
     val writeKeys = wkeys.map(rhs(_)) ++ keys
-    val defs = Seq(lms.core.Backend.Const(m), lms.core.Backend.Const(configs.length), lms.core.Backend.Const(pkeys)) ++ configs ++ rhs
+    val defs = Seq(
+      lms.core.Backend.Const(m),
+      lms.core.Backend.Const(configs.length),
+      lms.core.Backend.Const(pkeys)
+    ) ++ configs ++ rhs
     Wrap[T](Adapter.g.reflectEffect("lib-function", defs: _*)(readKeys: _*)(writeKeys: _*))
   }
 }
 
 trait CudaCodeGenLibFunction extends ExtendedCCodeGen {
-  override def shallow(n: Node): Unit = n match {
-    case Node(s, "lib-function", Const(m:String)::Const(c:Int)::Const(pkeys:Set[Int])::defs, _) =>
-      val configs = defs.take(c)
-      val rhs = defs.drop(c)
-      val last = rhs.length - 1
-      emit(s"$m<<<"); shallow(configs.head);
-      configs.tail.foreach(a => {emit(", "); shallow(a)});
-      emit(">>>(");
-      rhs.zipWithIndex.foreach { case(r, index) =>
-        if (pkeys.contains(index)) emit("&")
-        shallow(r)
-        if (index < last) emit(", ")
-      }
-      emit(")")
-    case _ => super.shallow(n)
-  }
+  override def shallow(n: Node): Unit =
+    n match {
+      case Node(s, "lib-function", Const(m: String) :: Const(c: Int) :: Const(pkeys: Set[Int]) :: defs, _) =>
+        val configs = defs.take(c)
+        val rhs = defs.drop(c)
+        val last = rhs.length - 1
+        emit(s"$m<<<"); shallow(configs.head);
+        configs.tail.foreach(a => { emit(", "); shallow(a) });
+        emit(">>>(");
+        rhs.zipWithIndex.foreach {
+          case (r, index) =>
+            if (pkeys.contains(index)) emit("&")
+            shallow(r)
+            if (index < last) emit(", ")
+        }
+        emit(")")
+      case _ => super.shallow(n)
+    }
 }

--- a/src/main/scala/lms/thirdparty/mpi/mpi.scala
+++ b/src/main/scala/lms/thirdparty/mpi/mpi.scala
@@ -22,7 +22,8 @@ trait MPIOps extends CMacro with LibStruct with LibFunction { b: Base =>
   def cNull: Rep[CNull] = cmacro[CNull]("NULL")
 
   // this is how we deal with library functions (may need pointers)
-  def mpi_init() = libFunction[Unit]("MPI_INIT", Unwrap(cNull), Unwrap(cNull))(Seq[Int](), Seq[Int](), Set[Int](), Adapter.CTRL)
+  def mpi_init() =
+    libFunction[Unit]("MPI_INIT", Unwrap(cNull), Unwrap(cNull))(Seq[Int](), Seq[Int](), Set[Int](), Adapter.CTRL)
   def mpi_finalize() = libFunction[Unit]("MPI_FINALIZE")(Seq[Int](), Seq[Int](), Set[Int](), Adapter.CTRL)
 
   def mpi_comm_size(world: Rep[MPIWorld], size: Var[Int]): Rep[Unit] = {
@@ -70,16 +71,17 @@ trait CCodeGenMPI extends ExtendedCCodeGen {
     else super.remap(m)
   }
 
-  override def shallow(n: Node): Unit = n match {
-    case Node(s, "test-pointer", List(x:Sym), _) =>
-      emit("test_pointer(&"); shallow(x); emit(")");
-    case Node(s, "test-pointer-array", List(x:Sym), _) =>
-      emit("test_pointer("); shallow(x); emit(")");
-    case Node(s, "test-struct-pointer", List(x:Sym), _) =>
-      emit("test_struct_pointer(&"); shallow(x); emit(")")
-    case Node(s, "test-struct-ref", List(x:Sym), _) =>
-      emit("test_struct_pointer("); shallow(x); emit(")")
-    case _ => super.shallow(n)
-  }
+  override def shallow(n: Node): Unit =
+    n match {
+      case Node(s, "test-pointer", List(x: Sym), _) =>
+        emit("test_pointer(&"); shallow(x); emit(")");
+      case Node(s, "test-pointer-array", List(x: Sym), _) =>
+        emit("test_pointer("); shallow(x); emit(")");
+      case Node(s, "test-struct-pointer", List(x: Sym), _) =>
+        emit("test_struct_pointer(&"); shallow(x); emit(")")
+      case Node(s, "test-struct-ref", List(x: Sym), _) =>
+        emit("test_struct_pointer("); shallow(x); emit(")")
+      case _ => super.shallow(n)
+    }
 
 }

--- a/src/main/scala/lms/thirdparty/scanner.scala
+++ b/src/main/scala/lms/thirdparty/scanner.scala
@@ -16,36 +16,84 @@ trait ScannerOps extends Equal with ArrayOps with CLibs {
 
   // FIXME(feiw): should the open and close function have CTRL effects??
   // open function returns a file discriptor
-  def open(path: Rep[String]): Rep[Int] = libFunction[Int]("open", Unwrap(path), lms.core.Backend.Const(0))(Seq[Int](), Seq[Int](), Set[Int](), Adapter.CTRL)
+  def open(path: Rep[String]): Rep[Int] =
+    libFunction[Int]("open", Unwrap(path), lms.core.Backend.Const(0))(Seq[Int](), Seq[Int](), Set[Int](), Adapter.CTRL)
   // filelen function returns the file size
   def filelen(fd: Rep[Int]): Rep[Long] = libFunction[Long]("fsize", Unwrap(fd))(Seq[Int](), Seq[Int](), Set[Int]())
   // static_cast function cast types
-  def static_cast[X,Y:Manifest](x: Rep[X]): Rep[Y] =
+  def static_cast[X, Y: Manifest](x: Rep[X]): Rep[Y] =
     Wrap[Y](Adapter.g.reflect("cast", Unwrap(x), Backend.Const(manifest[Y])))
   // need a macro for mmap
   def prot = cmacro[Int]("PROT_READ | PROT_WRITE, MAP_FILE | MAP_PRIVATE")
   // mmap function maps a file to memory
-  def mmap[T:Manifest](fd: Rep[Int], len: Rep[Long]) = static_cast[Array[T], Array[T]](libFunction[Array[T]]("mmap",
-    lms.core.Backend.Const(0), Unwrap(len), Unwrap(prot), Unwrap(fd), lms.core.Backend.Const(0))(Seq[Int](), Seq[Int](), Set[Int]()))
+  def mmap[T: Manifest](fd: Rep[Int], len: Rep[Long]) =
+    static_cast[Array[T], Array[T]](
+      libFunction[Array[T]](
+        "mmap",
+        lms.core.Backend.Const(0),
+        Unwrap(len),
+        Unwrap(prot),
+        Unwrap(fd),
+        lms.core.Backend.Const(0)
+      )(Seq[Int](), Seq[Int](), Set[Int]())
+    )
   def close(fd: Rep[Int]) = libFunction[Unit]("close", Unwrap(fd))(Seq[Int](), Seq[Int](), Set[Int](), Adapter.CTRL)
-  def prints(s: Rep[String]): Rep[Int] = libFunction[Int]("printll", Unwrap(s))(Seq[Int](), Seq[Int](), Set[Int](), Adapter.CTRL)
+  def prints(s: Rep[String]): Rep[Int] =
+    libFunction[Int]("printll", Unwrap(s))(Seq[Int](), Seq[Int](), Set[Int](), Adapter.CTRL)
 
   // establish a File* type
   abstract class FilePointer
   // another API for opening a file
-  def fopen(name: Rep[String], mode: Rep[String]) = libFunction[FilePointer]("fopen", Unwrap(name), Unwrap(mode))(Seq[Int](), Seq[Int](), Set[Int](), Adapter.CTRL)
-  def fclose(fp: Rep[FilePointer]) = libFunction[Unit]("fclose", Unwrap(fp))(Seq[Int](0), Seq[Int](), Set[Int](), Adapter.CTRL)
-  def checkStatus(code: Rep[Int])(implicit pos: SourceContext): Rep[Unit] = __ifThenElse(notequals(code, unit(1)),
-    libFunction[Unit]("perror", lms.core.Backend.Const("Error reading file"))(Seq[Int](), Seq[Int](), Set[Int](), Adapter.CTRL), ())
+  def fopen(name: Rep[String], mode: Rep[String]) =
+    libFunction[FilePointer]("fopen", Unwrap(name), Unwrap(mode))(Seq[Int](), Seq[Int](), Set[Int](), Adapter.CTRL)
+  def fclose(fp: Rep[FilePointer]) =
+    libFunction[Unit]("fclose", Unwrap(fp))(Seq[Int](0), Seq[Int](), Set[Int](), Adapter.CTRL)
+  def checkStatus(code: Rep[Int])(implicit pos: SourceContext): Rep[Unit] =
+    __ifThenElse(
+      notequals(code, unit(1)),
+      libFunction[Unit]("perror", lms.core.Backend.Const("Error reading file"))(
+        Seq[Int](),
+        Seq[Int](),
+        Set[Int](),
+        Adapter.CTRL
+      ),
+      ()
+    )
 
   def getFloat(fp: Rep[FilePointer], target: Var[Float])(implicit pos: SourceContext) =
-    checkStatus(libFunction[Int]("fscanf", Unwrap(fp), lms.core.Backend.Const("%f"), UnwrapV(target))(Seq[Int](0), Seq[Int](2), Set[Int](2)))
+    checkStatus(
+      libFunction[Int]("fscanf", Unwrap(fp), lms.core.Backend.Const("%f"), UnwrapV(target))(
+        Seq[Int](0),
+        Seq[Int](2),
+        Set[Int](2)
+      )
+    )
   def getFloat(fp: Rep[FilePointer], target: Rep[Array[Float]], target_offset: Rep[Int])(implicit pos: SourceContext) =
-    checkStatus(libFunction[Int]("fscanf", Unwrap(fp), lms.core.Backend.Const("%f"), Unwrap(target(target_offset)))(Seq[Int](0), Seq[Int](), Set[Int](2), Unwrap(target)))
+    checkStatus(
+      libFunction[Int]("fscanf", Unwrap(fp), lms.core.Backend.Const("%f"), Unwrap(target(target_offset)))(
+        Seq[Int](0),
+        Seq[Int](),
+        Set[Int](2),
+        Unwrap(target)
+      )
+    )
   def getInt(fp: Rep[FilePointer], target: Var[Int])(implicit pos: SourceContext) =
-    checkStatus(libFunction[Int]("fscanf", Unwrap(fp), lms.core.Backend.Const("%d"), UnwrapV(target))(Seq[Int](0), Seq[Int](2), Set[Int](2)))
+    checkStatus(
+      libFunction[Int]("fscanf", Unwrap(fp), lms.core.Backend.Const("%d"), UnwrapV(target))(
+        Seq[Int](0),
+        Seq[Int](2),
+        Set[Int](2)
+      )
+    )
   def getInt(fp: Rep[FilePointer], target: Rep[Array[Int]], target_offset: Rep[Int])(implicit pos: SourceContext) =
-    checkStatus(libFunction[Int]("fscanf", Unwrap(fp), lms.core.Backend.Const("%d"), Unwrap(target(target_offset)))(Seq[Int](0), Seq[Int](), Set[Int](2), Unwrap(target)))
+    checkStatus(
+      libFunction[Int]("fscanf", Unwrap(fp), lms.core.Backend.Const("%d"), Unwrap(target(target_offset)))(
+        Seq[Int](0),
+        Seq[Int](),
+        Set[Int](2),
+        Unwrap(target)
+      )
+    )
 
   // writing to file in C
   def fprintf(fp: Rep[FilePointer], format: Rep[String], contents: Rep[Any]*) = {
@@ -60,8 +108,9 @@ trait CCodeGenScannerOps extends ExtendedCCodeGen with CCodeGenLibs {
   registerDefine("_GNU_SOURCE")
 
   // type remap
-  override def remap(m: Manifest[_]) = m.runtimeClass.getName match {
-    case s: String if s.endsWith("FilePointer") => "FILE*"
-    case _ => super.remap(m)
-  }
+  override def remap(m: Manifest[_]) =
+    m.runtimeClass.getName match {
+      case s: String if s.endsWith("FilePointer") => "FILE*"
+      case _ => super.remap(m)
+    }
 }

--- a/src/main/scala/lms/util/ClosureCompare.scala
+++ b/src/main/scala/lms/util/ClosureCompare.scala
@@ -6,7 +6,7 @@ trait ClosureCompare extends Externalizable {
 
   // the whole thing must be serializable, since embedded closures
   // might refer to the context.
-  
+
   def writeExternal(out: ObjectOutput) {
 //    println("in write object")
   }
@@ -20,14 +20,14 @@ trait ClosureCompare extends Externalizable {
     o.writeObject(f)
     s.toString("ASCII")
   }
-  
-  def sameFunction(f: Function[_,_], g: Function[_,_]): Boolean = {
 
-    def ser(f: Function[_,_]) = f.isInstanceOf[java.io.Serializable]
-    
+  def sameFunction(f: Function[_, _], g: Function[_, _]): Boolean = {
+
+    def ser(f: Function[_, _]) = f.isInstanceOf[java.io.Serializable]
+
     if (f.getClass != g.getClass)
       return false
-    
+
     if (ser(f) && ser(g)) {
       canonicalize(f) == canonicalize(g)
     } else {
@@ -36,6 +36,5 @@ trait ClosureCompare extends Externalizable {
       false
     }
   }
-
 
 }

--- a/src/main/scala/lms/util/GraphUtil.scala
+++ b/src/main/scala/lms/util/GraphUtil.scala
@@ -2,47 +2,51 @@ package lms.util
 
 import java.util.{ArrayDeque, HashMap}
 
-
 object GraphUtil {
-  
+
   class Ref[T](init: T) {
     var value: T = init
   }
-  
+
   /* test cases
 
      stronglyConnectedComponents[String](List("A"), { case "A" => List("B") case "B" => List("C") case "C" => List("A","D") case "D" => Nil})
      List(List(A, B, C), List(D))
 
      stronglyConnectedComponents[String](List("A","B","C"), { case "A" => List("B") case "B" => List("C") case "C" => List("A","D") case "D" => Nil})
-  */
-
-  /** 
-      Returns the strongly connected components
-      of the graph rooted at the first argument,
-      whose edges are given by the function argument.
-
-      The scc are returned in topological order.
-      Tarjan's algorithm (linear).
    */
-  def stronglyConnectedComponents[T](start: List[T], succ: T=>List[T]): List[List[T]] = {
+
+  /**
+    *      Returns the strongly connected components
+    *      of the graph rooted at the first argument,
+    *      whose edges are given by the function argument.
+    *
+    *      The scc are returned in topological order.
+    *      Tarjan's algorithm (linear).
+    */
+  def stronglyConnectedComponents[T](start: List[T], succ: T => List[T]): List[List[T]] = {
 
     val id: Ref[Int] = new Ref(0)
     val stack = new ArrayDeque[T]
-    val mark = new HashMap[T,Int]
+    val mark = new HashMap[T, Int]
 
     val res = new Ref[List[List[T]]](Nil)
     for (node <- start)
-      visit(node,succ,id,stack,mark,res)
+      visit(node, succ, id, stack, mark, res)
 
     res.value
   }
 
-  def visit[T](node: T, succ: T=>List[T], id: Ref[Int], stack: ArrayDeque[T], 
-            mark: HashMap[T,Int], res: Ref[List[List[T]]]): Int = {
+  def visit[T](
+      node: T,
+      succ: T => List[T],
+      id: Ref[Int],
+      stack: ArrayDeque[T],
+      mark: HashMap[T, Int],
+      res: Ref[List[List[T]]]
+  ): Int = {
 
-    
-    if (mark.containsKey(node)) 
+    if (mark.containsKey(node))
       mark.get(node)
     else {
       id.value = id.value + 1
@@ -55,7 +59,7 @@ object GraphUtil {
       for (child <- succ(node)) {
         val m = visit(child, succ, id, stack, mark, res)
 
-        if (m < min) 
+        if (m < min)
           min = m
       }
 
@@ -74,5 +78,5 @@ object GraphUtil {
       min
     }
   }
-  
+
 }

--- a/src/main/scala/lms/util/OverloadHack.scala
+++ b/src/main/scala/lms/util/OverloadHack.scala
@@ -25,7 +25,7 @@ trait OverloadHack {
   class Overloaded20
   class Overloaded21
   class Overloaded22
-  class Overloaded23  
+  class Overloaded23
   class Overloaded24
   class Overloaded25
   class Overloaded26
@@ -49,7 +49,7 @@ trait OverloadHack {
   class Overloaded44
   class Overloaded45
   class Overloaded46
-  class Overloaded47  
+  class Overloaded47
   class Overloaded48
   class Overloaded49
   class Overloaded50
@@ -75,7 +75,7 @@ trait OverloadHack {
   class Overloaded70
   class Overloaded71
   class Overloaded72
-  class Overloaded73  
+  class Overloaded73
   class Overloaded74
   class Overloaded75
   class Overloaded76
@@ -99,7 +99,7 @@ trait OverloadHack {
   class Overloaded94
   class Overloaded95
   class Overloaded96
-  class Overloaded97  
+  class Overloaded97
   class Overloaded98
   class Overloaded99
   class Overloaded100
@@ -125,7 +125,7 @@ trait OverloadHack {
   class Overloaded120
   class Overloaded121
   class Overloaded122
-  class Overloaded123  
+  class Overloaded123
   class Overloaded124
   class Overloaded125
   class Overloaded126
@@ -149,7 +149,7 @@ trait OverloadHack {
   class Overloaded144
   class Overloaded145
   class Overloaded146
-  class Overloaded147  
+  class Overloaded147
   class Overloaded148
   class Overloaded149
   class Overloaded150
@@ -175,7 +175,7 @@ trait OverloadHack {
   class Overloaded170
   class Overloaded171
   class Overloaded172
-  class Overloaded173  
+  class Overloaded173
   class Overloaded174
   class Overloaded175
   class Overloaded176
@@ -199,10 +199,10 @@ trait OverloadHack {
   class Overloaded194
   class Overloaded195
   class Overloaded196
-  class Overloaded197  
+  class Overloaded197
   class Overloaded198
   class Overloaded199
-  
+
   implicit val overloaded1 = new Overloaded1
   implicit val overloaded2 = new Overloaded2
   implicit val overloaded3 = new Overloaded3
@@ -221,10 +221,10 @@ trait OverloadHack {
   implicit val overloaded16 = new Overloaded16
   implicit val overloaded17 = new Overloaded17
   implicit val overloaded18 = new Overloaded18
-  implicit val overloaded19 = new Overloaded19  
+  implicit val overloaded19 = new Overloaded19
   implicit val overloaded20 = new Overloaded20
-  implicit val overloaded21 = new Overloaded21  
-  implicit val overloaded22 = new Overloaded22  
+  implicit val overloaded21 = new Overloaded21
+  implicit val overloaded22 = new Overloaded22
   implicit val overloaded23 = new Overloaded23
   implicit val overloaded24 = new Overloaded24
   implicit val overloaded25 = new Overloaded25
@@ -245,14 +245,14 @@ trait OverloadHack {
   implicit val overloaded40 = new Overloaded40
   implicit val overloaded41 = new Overloaded41
   implicit val overloaded42 = new Overloaded42
-  implicit val overloaded43 = new Overloaded43  
+  implicit val overloaded43 = new Overloaded43
   implicit val overloaded44 = new Overloaded44
-  implicit val overloaded45 = new Overloaded45  
-  implicit val overloaded46 = new Overloaded46  
+  implicit val overloaded45 = new Overloaded45
+  implicit val overloaded46 = new Overloaded46
   implicit val overloaded47 = new Overloaded47
   implicit val overloaded48 = new Overloaded48
   implicit val overloaded49 = new Overloaded49
-  implicit val overloaded50 = new Overloaded50  
+  implicit val overloaded50 = new Overloaded50
   implicit val overloaded51 = new Overloaded51
   implicit val overloaded52 = new Overloaded52
   implicit val overloaded53 = new Overloaded53
@@ -271,10 +271,10 @@ trait OverloadHack {
   implicit val overloaded66 = new Overloaded66
   implicit val overloaded67 = new Overloaded67
   implicit val overloaded68 = new Overloaded68
-  implicit val overloaded69 = new Overloaded69  
+  implicit val overloaded69 = new Overloaded69
   implicit val overloaded70 = new Overloaded70
-  implicit val overloaded71 = new Overloaded71  
-  implicit val overloaded72 = new Overloaded72  
+  implicit val overloaded71 = new Overloaded71
+  implicit val overloaded72 = new Overloaded72
   implicit val overloaded73 = new Overloaded73
   implicit val overloaded74 = new Overloaded74
   implicit val overloaded75 = new Overloaded75
@@ -295,14 +295,14 @@ trait OverloadHack {
   implicit val overloaded90 = new Overloaded90
   implicit val overloaded91 = new Overloaded91
   implicit val overloaded92 = new Overloaded92
-  implicit val overloaded93 = new Overloaded93  
+  implicit val overloaded93 = new Overloaded93
   implicit val overloaded94 = new Overloaded94
-  implicit val overloaded95 = new Overloaded95  
-  implicit val overloaded96 = new Overloaded96  
+  implicit val overloaded95 = new Overloaded95
+  implicit val overloaded96 = new Overloaded96
   implicit val overloaded97 = new Overloaded97
   implicit val overloaded98 = new Overloaded98
   implicit val overloaded99 = new Overloaded99
-  implicit val overloaded100 = new Overloaded100  
+  implicit val overloaded100 = new Overloaded100
   implicit val overloaded101 = new Overloaded101
   implicit val overloaded102 = new Overloaded102
   implicit val overloaded103 = new Overloaded103
@@ -321,10 +321,10 @@ trait OverloadHack {
   implicit val overloaded116 = new Overloaded116
   implicit val overloaded117 = new Overloaded117
   implicit val overloaded118 = new Overloaded118
-  implicit val overloaded119 = new Overloaded119  
+  implicit val overloaded119 = new Overloaded119
   implicit val overloaded120 = new Overloaded120
-  implicit val overloaded121 = new Overloaded121  
-  implicit val overloaded122 = new Overloaded122  
+  implicit val overloaded121 = new Overloaded121
+  implicit val overloaded122 = new Overloaded122
   implicit val overloaded123 = new Overloaded123
   implicit val overloaded124 = new Overloaded124
   implicit val overloaded125 = new Overloaded125
@@ -345,14 +345,14 @@ trait OverloadHack {
   implicit val overloaded140 = new Overloaded140
   implicit val overloaded141 = new Overloaded141
   implicit val overloaded142 = new Overloaded142
-  implicit val overloaded143 = new Overloaded143  
+  implicit val overloaded143 = new Overloaded143
   implicit val overloaded144 = new Overloaded144
-  implicit val overloaded145 = new Overloaded145  
-  implicit val overloaded146 = new Overloaded146  
+  implicit val overloaded145 = new Overloaded145
+  implicit val overloaded146 = new Overloaded146
   implicit val overloaded147 = new Overloaded147
   implicit val overloaded148 = new Overloaded148
   implicit val overloaded149 = new Overloaded149
-  implicit val overloaded150 = new Overloaded150  
+  implicit val overloaded150 = new Overloaded150
   implicit val overloaded151 = new Overloaded151
   implicit val overloaded152 = new Overloaded152
   implicit val overloaded153 = new Overloaded153
@@ -371,10 +371,10 @@ trait OverloadHack {
   implicit val overloaded166 = new Overloaded166
   implicit val overloaded167 = new Overloaded167
   implicit val overloaded168 = new Overloaded168
-  implicit val overloaded169 = new Overloaded169  
+  implicit val overloaded169 = new Overloaded169
   implicit val overloaded170 = new Overloaded170
-  implicit val overloaded171 = new Overloaded171  
-  implicit val overloaded172 = new Overloaded172  
+  implicit val overloaded171 = new Overloaded171
+  implicit val overloaded172 = new Overloaded172
   implicit val overloaded173 = new Overloaded173
   implicit val overloaded174 = new Overloaded174
   implicit val overloaded175 = new Overloaded175
@@ -395,11 +395,11 @@ trait OverloadHack {
   implicit val overloaded190 = new Overloaded190
   implicit val overloaded191 = new Overloaded191
   implicit val overloaded192 = new Overloaded192
-  implicit val overloaded193 = new Overloaded193  
+  implicit val overloaded193 = new Overloaded193
   implicit val overloaded194 = new Overloaded194
-  implicit val overloaded195 = new Overloaded195  
-  implicit val overloaded196 = new Overloaded196  
+  implicit val overloaded195 = new Overloaded195
+  implicit val overloaded196 = new Overloaded196
   implicit val overloaded197 = new Overloaded197
   implicit val overloaded198 = new Overloaded198
-  implicit val overloaded199 = new Overloaded199  
+  implicit val overloaded199 = new Overloaded199
 }

--- a/src/main/scala/lms/util/ScalaCompile.scala
+++ b/src/main/scala/lms/util/ScalaCompile.scala
@@ -15,13 +15,13 @@ trait ScalaCompile {
 
   var compiler: Global = _
   var reporter: ConsoleReporter = _
-  //var output: ByteArrayOutputStream = _ 
+  //var output: ByteArrayOutputStream = _
 
   def setupCompiler() = {
     /*
       output = new ByteArrayOutputStream()
       val writer = new PrintWriter(new OutputStreamWriter(output))
-    */
+     */
     val settings = new Settings()
     val pathSeparator = System.getProperty("path.separator")
 
@@ -39,25 +39,24 @@ trait ScalaCompile {
     //settings.verbose.value = true
     // -usejavacp needed on windows?
 
-    reporter = new ConsoleReporter(settings, null, new PrintWriter(System.out))//writer
+    reporter = new ConsoleReporter(settings, null, new PrintWriter(System.out)) //writer
     compiler = new Global(settings, reporter)
   }
 
   var compileCount = 0
-  
+
   var dumpGeneratedCode = false
 
   def nextClassName = "staged$" + compileCount
 
-
   // NOTE: class name must be unique (e.g. use nextClassName)
   //def compile[A,B](f: Exp[A] => Exp[B])(implicit mA: Typ[A], mB: Typ[B]): A=>B = {
-  def compile[A,B](className: String, source: String, staticData: List[(Class[_],Any)]): A=>B = {
+  def compile[A, B](className: String, source: String, staticData: List[(Class[_], Any)]): A => B = {
     if (this.compiler eq null)
       setupCompiler()
-    
+
     compileCount += 1
-    
+
     // val source = new StringWriter()
     // val writer = new PrintWriter(source)
     // val staticData = codegen.emitSource(f, className, writer)
@@ -90,9 +89,9 @@ trait ScalaCompile {
     val loader = new AbstractFileClassLoader(fileSystem, this.getClass.getClassLoader)
 
     val cls: Class[_] = loader.loadClass(className)
-    val cons = cls.getConstructor(staticData.map(_._1):_*)
-    
-    val obj: A=>B = cons.newInstance(staticData.map(_._2.asInstanceOf[AnyRef]):_*).asInstanceOf[A=>B]
+    val cons = cls.getConstructor(staticData.map(_._1): _*)
+
+    val obj: A => B = cons.newInstance(staticData.map(_._2.asInstanceOf[AnyRef]): _*).asInstanceOf[A => B]
     obj
   }
 }


### PR DESCRIPTION
This PR proposes to adopt a unified coding style and to use `scalafmt` to format the code. When running in `sbt`, you can use `lms-clean/scalafmt` to automatically reformat all source code files.

However, this PR is by no means enforcing a style we eventually should use, but just initiating such effort. There are tons of config options (https://scalameta.org/scalafmt/docs/configuration.html) we can tweak to find a style that everyone is comfortable with.