### PR TITLE
Refactor typeMap and funTable to immutable reference

### DIFF
--- a/src/test/scala/lms/core/test_cps.scala
+++ b/src/test/scala/lms/core/test_cps.scala
@@ -16,8 +16,8 @@ abstract class CPSDslDriver[A:Manifest,B:Manifest] extends DslSnippet[A,B] with 
     val IR: q.type = q
   }
 
-  Adapter.typeMap = new scala.collection.mutable.HashMap[lms.core.Backend.Exp, Manifest[_]]()
-  Adapter.funTable = Nil
+  Adapter.resetTypeMap
+  Adapter.resetFunTable
 
   def extra(x: A): Unit = {
     val source = new java.io.ByteArrayOutputStream()

--- a/src/test/scala/lms/thirdparty/test_cuda.scala
+++ b/src/test/scala/lms/thirdparty/test_cuda.scala
@@ -15,7 +15,7 @@ class CudaTest extends TutorialFunSuite {
     override val codegen = new DslGenC with CCodeGenCudaOps {
       val IR: q.type = q
     }
-    compilerCommand = "nvcc -std=c++11 -O3"
+    override val compilerCommand = "nvcc -std=c++11 -O3"
 
     val curPath = System.getProperty("user.dir")
     override val sourceFile = s"$curPath/snippet.cu"


### PR DESCRIPTION
The PR refactors `Adapter.typeMap` and `Adapter.funTable` to immutable reference (`val`) and adds several interfaces to effectully manipulate them. This should make latter refactor easier -- programming against interfaces instead of implementations.