### PR TITLE
Some sugar for emit and shallow

### DIFF
--- a/src/main/scala/lms/collection/ListOps.scala
+++ b/src/main/scala/lms/collection/ListOps.scala
@@ -122,54 +122,33 @@ trait ScalaCodeGen_List extends ExtendedScalaCodeGen {
   override def shallow(n: Node): Unit = n match {
     case Node(s, "list-new", Const(mA: Manifest[_])::xs, _) =>
       val ty = remap(mA)
-      emit("List[")
-      emit(ty)
-      emit("](")
+      es"List[$ty]("
       xs.zipWithIndex.map { case (x, i) =>
         shallow(x)
         if (i != xs.length-1) emit(", ")
       }
       emit(")")
-    case Node(s, "list-apply", List(xs, i), _) =>
-      shallow(xs); emit("("); shallow(i); emit(")")
-    case Node(s, "list-head", List(xs), _) =>
-      shallow(xs); emit(".head")
-    case Node(s, "list-tail", List(xs), _) =>
-      shallow(xs); emit(".tail")
-    case Node(s, "list-size", List(xs), _) =>
-      shallow(xs); emit(".size")
-    case Node(s, "list-isEmpty", List(xs), _) =>
-      shallow(xs); emit(".isEmpty")
-    case Node(s, "list-take", List(xs, i), _) =>
-      shallow(xs); emit(".take("); shallow(i); emit(")")
-    case Node(s, "list-prepend", List(xs, x), _) =>
-      shallow(x); emit(" :: "); shallow(xs)
-    case Node(s, "list-concat", List(xs, ys), _) =>
-      shallow(xs); emit(" ++ "); shallow(ys)
-    case Node(s, "list-mkString", List(xs, Const("")), _) =>
-      shallow(xs); emit(".mkString")
-    case Node(s, "list-mkString", List(xs, sep), _) =>
-      shallow(xs); emit(".mkString("); shallow(sep); emit(")")
-    case Node(s, "list-toArray", List(xs), _) =>
-      shallow(xs); emit(".toArray")
-    case Node(s, "list-toSeq", List(xs), _) =>
-      shallow(xs); emit(".toSeq")
-    case Node(s, "list-map", List(xs, b), _) =>
-      shallow(xs); emit(".map("); shallow(b); emit(")")
-    case Node(s, "list-flatMap", xs::(b: Block)::rest, _) =>
-      shallow(xs); emit(".flatMap("); shallow(b); emit(")")
+    case Node(s, "list-apply", List(xs, i), _) => es"$xs($i)"
+    case Node(s, "list-head", List(xs), _) => es"$xs.head"
+    case Node(s, "list-tail", List(xs), _) => es"$xs.tail"
+    case Node(s, "list-size", List(xs), _) => es"$xs.size"
+    case Node(s, "list-isEmpty", List(xs), _) => es"$xs.isEmpty"
+    case Node(s, "list-take", List(xs, i), _) => es"$xs.take($i)"
+    case Node(s, "list-prepend", List(xs, x), _) => es"$x :: $xs"
+    case Node(s, "list-concat", List(xs, ys), _) => es"$xs ++ $ys"
+    case Node(s, "list-mkString", List(xs, Const("")), _) => es"$xs.mkString"
+    case Node(s, "list-mkString", List(xs, sep), _) => es"$xs.mkString($sep)"
+    case Node(s, "list-toArray", List(xs), _) => es"$xs.toArray"
+    case Node(s, "list-toSeq", List(xs), _) => es"$xs.toSeq"
+    case Node(s, "list-map", List(xs, b), _) => es"$xs.map($b)"
+    case Node(s, "list-flatMap", xs::(b: Block)::rest, _) => es"$xs.flatMap($b)"
     case Node(s, "list-foldLeft", List(xs, z, b), _) =>
-      shallow(xs); emit(".foldLeft("); shallow(z); emit(")("); shallow(b, false); emit(")")
-    case Node(s, "list-zip", List(xs, ys), _) =>
-      shallow(xs); emit(".zip("); shallow(ys); emit(")")
-    case Node(s, "list-filter", List(xs, b), _) =>
-      shallow(xs); emit(".filter("); shallow(b); emit(")")
-    case Node(s, "list-sortBy", List(xs, b), _) =>
-      shallow(xs); emit(".sortBy("); shallow(b); emit(")")
-    case Node(s, "list-containsSlice", List(xs, ys), _) =>
-      shallow(xs); emit(".containsSlice("); shallow(ys); emit(")")
-    case Node(s, "list-intersect", List(xs, ys), _) =>
-      shallow(xs); emit(".intersect("); shallow(ys); emit(")")
+      es"$xs.foldLeft($z)("; shallow(b, false); emit(")")
+    case Node(s, "list-zip", List(xs, ys), _) => es"$xs.zip($ys)"
+    case Node(s, "list-filter", List(xs, b), _) => es"$xs.filter($b)"
+    case Node(s, "list-sortBy", List(xs, b), _) => es"$xs.sortBy($b)"
+    case Node(s, "list-containsSlice", List(xs, ys), _) => es"$xs.containsSlice($ys)"
+    case Node(s, "list-intersect", List(xs, ys), _) => es"$xs.intersect($ys)"
     case _ => super.shallow(n)
   }
 
@@ -210,59 +189,33 @@ trait CppCodeGen_List extends ExtendedCPPCodeGen {
 
   override def shallow(n: Node): Unit = n match {
     case Node(s, "list-new", Const(mA: Manifest[_])::xs, _) =>
-      emit("immer::flex_vector<")
-      emit(remap(mA))
-      emit(">")
-      emit("{")
+      emit(s"immer::flex_vector<${remap(mA)}>{")
       xs.zipWithIndex.map { case (x, i) =>
         shallow(x)
         if (i != xs.length-1) emit(", ")
       }
       emit("}")
-    case Node(s, "list-apply", List(xs, i), _) =>
-      shallow(xs); emit(".at("); shallow(i); emit(")")
-    case Node(s, "list-head", List(xs), _) =>
-      shallow(xs); emit(".front()")
-    case Node(s, "list-tail", List(xs), _) =>
-      shallow(xs); emit(".drop(1)")
-    case Node(s, "list-size", List(xs), _) =>
-      shallow(xs); emit(".size()")
-    case Node(s, "list-isEmpty", List(xs), _) =>
-      shallow(xs); emit(".size() == 0")
-    case Node(s, "list-take", List(xs, i), _) =>
-      shallow(xs); emit(".take("); shallow(i); emit(")")
-    case Node(s, "list-prepend", List(xs, x), _) =>
-      shallow(x); emit(".push_front("); shallow(xs); emit(")")
-    case Node(s, "list-concat", List(xs, ys), _) =>
-      shallow(xs); emit(" + "); shallow(ys)
+    case Node(s, "list-apply", List(xs, i), _) => es"$xs.at($i)"
+    case Node(s, "list-head", List(xs), _) => es"$xs.front()"
+    case Node(s, "list-tail", List(xs), _) => es"$xs.drop(1)"
+    case Node(s, "list-size", List(xs), _) => es"$xs.size()"
+    case Node(s, "list-isEmpty", List(xs), _) => es"$xs.size() == 0"
+    case Node(s, "list-take", List(xs, i), _) => es"$xs.take($i)"
+    case Node(s, "list-prepend", List(xs, x), _) => es"$x.push_front($xs)"
+    case Node(s, "list-concat", List(xs, ys), _) => es"$xs + $ys"
     case Node(s, "list-map", List(xs, b: Block), _) =>
       val retType = remap(typeBlockRes(b.res))
-      emit(s"ImmerContrib::vmap<$retType>(")
-      shallow(xs)
-      emit(", ")
-      shallow(b)
-      emit(")")
+      es"ImmerContrib::vmap<$retType>($xs, $b)"
     case Node(s, "list-flatMap", xs::(b: Block)::Const(mA: Manifest[_])::rest, _) =>
       // Note: b.res must return a List type, as required by flatMap
       val retType = remap(typeBlockRes(b.res).typeArguments(0))
-      emit(s"ImmerContrib::flatMap<$retType>(")
-      shallow(xs)
-      emit(", ")
-      shallow(b)
-      emit(")")
+      es"ImmerContrib::flatMap<$retType>($xs, $b)"
     case Node(s, "list-foldLeft", List(xs, z, b), _) =>
-      emit("ImmerContrib::foldLeft(")
-      shallow(xs); emit(", ")
-      shallow(z); emit(", ")
-      shallow(b); emit(")")
+      es"ImmerContrib::foldLeft($xs, $z, $b)"
     case Node(s, "list-zip", List(xs, ys), _) =>
-      emit("ImmerContrib::zip(")
-      shallow(xs); emit(", ")
-      shallow(ys); emit(")")
+      es"ImmerContrib::zip($xs, $ys)"
     case Node(s, "list-filter", List(xs, b), _) =>
-      emit("ImmerContrib::filter(")
-      shallow(xs); emit(", ")
-      shallow(b); emit(")")
+      es"ImmerContrib::filter($xs, $b)"
     // Unsupported operation for immer backend
     case Node(s, "list-mkString", List(xs, sep), _) =>
       ???

--- a/src/main/scala/lms/collection/MapOps.scala
+++ b/src/main/scala/lms/collection/MapOps.scala
@@ -130,49 +130,37 @@ trait ScalaCodeGen_Map extends ExtendedScalaCodeGen {
     case Node(s, "map-new", Const(mK: Manifest[_])::Const(mV: Manifest[_])::kvs, _) =>
       val kty = remap(mK)
       val vty = remap(mV)
-      emit("Map[")
-      emit(kty); emit(", "); emit(vty)
-      emit("](")
+      emit(s"Map[$kty, $vty](")
       kvs.zipWithIndex.map { case (kv, i) =>
         shallow(kv)
         if (i != kvs.length-1) emit(", ")
       }
       emit(")")
-    case Node(s, "map-apply", List(m, k), _) =>
-      shallow(m); emit("("); shallow(k); emit(")")
-    case Node(s, "map-contains", List(m, k), _) =>
-      shallow(m); emit(".contains("); shallow(k); emit(")")
-    case Node(s, "map-get", List(m, k), _) =>
-      shallow(m); emit(".get("); shallow(k); emit(")")
-    case Node(s, "map-getOrElse", List(m, k, d), _) =>
-      shallow(m); emit(".getOrElse("); shallow(k); emit(", "); shallow(d); emit(")")
-    case Node(s, "map-size", List(m), _) =>
-      shallow(m); emit(".size");
-    case Node(s, "map-+", List(m, kv), _) =>
-      shallow(m); emit(" + ("); shallow(kv); emit(")")
-    case Node(s, "map-++", List(m1, m2), _) =>
-      shallow(m1); emit(" ++ "); shallow(m2)
-    case Node(s, "map-keySet", List(m), _) =>
-      shallow(m); emit(".keySet");
-    case Node(s, "map-isEmpty", List(m), _) =>
-      shallow(m); emit(".isEmpty");
+    case Node(s, "map-apply", List(m, k), _) => es"$m($k)"
+    case Node(s, "map-contains", List(m, k), _) => es"$m.contains($k)"
+    case Node(s, "map-get", List(m, k), _) => es"$m.get($k)"
+    case Node(s, "map-getOrElse", List(m, k, d), _) => es"$m.getOrElse($k, $d)"
+    case Node(s, "map-size", List(m), _) => es"$m.size"
+    case Node(s, "map-+", List(m, kv), _) => es"$m + ($kv)"
+    case Node(s, "map-++", List(m1, m2), _) => es"$m1 ++ $m2"
+    case Node(s, "map-keySet", List(m), _) => es"$m.keySet"
+    case Node(s, "map-isEmpty", List(m), _) => es"$m.isEmpty"
     case Node(s, "map-foldLeft", List(m, z, b: Block, _), _) =>
       val p = PTuple(List(PVar(b.in(0)), PTuple(List(PVar(b.in(1)), PVar(b.in(2))))))
-      shallow(m); emit(".foldLeft(")
-      shallow(z); emit(") ")
+      es"$m.foldLeft($z) "
       quoteCaseBlock(b, p) //Note: quoteBlock will emit `{` and `}`
     case Node(s, "map-foreach", List(m, b: Block), _) =>
       val p = PTuple(b.in.map(PVar(_)))
-      shallow(m); emit(".foreach "); quoteCaseBlock(b, p)
+      es"$m.foreach "; quoteCaseBlock(b, p)
     case Node(s, "map-filter", List(m, b: Block), _) =>
       val p = PTuple(b.in.map(PVar(_)))
-      shallow(m); emit(".filter "); quoteCaseBlock(b, p)
+      es"$m.filter "; quoteCaseBlock(b, p)
     case Node(s, "map-map", List(m, b: Block), _) =>
       val p = PTuple(b.in.map(PVar(_)))
-      shallow(m); emit(".map "); quoteCaseBlock(b, p)
+      es"$m.map "; quoteCaseBlock(b, p)
     case Node(s, "map-mapmap", List(m, b: Block), _) =>
       val p = PTuple(b.in.map(PVar(_)))
-      shallow(m); emit(".map "); quoteCaseBlock(b, p)
+      es"$m.map "; quoteCaseBlock(b, p)
     case _ => super.shallow(n)
   }
 }

--- a/src/main/scala/lms/collection/SetOps.scala
+++ b/src/main/scala/lms/collection/SetOps.scala
@@ -96,38 +96,25 @@ trait ScalaCodeGen_Set extends ExtendedScalaCodeGen {
   override def shallow(n: Node): Unit = n match {
     case Node(s, "set-new", Const(mA: Manifest[_])::xs, _) =>
       val ty = remap(mA)
-      emit("Set["); emit(ty); emit("](")
+      emit(s"Set[$ty](")
       xs.zipWithIndex.map { case (x, i) =>
         shallow(x)
         if (i != xs.length-1) emit(", ")
       }
       emit(")")
-    case Node(_, "set-apply", List(s, x), _) =>
-      shallow(s); emit("("); shallow(x); emit(")")
-    case Node(_, "set-size", List(s), _) =>
-      shallow(s); emit(".size")
-    case Node(_, "set-isEmpty", List(s), _) =>
-      shallow(s); emit(".isEmpty")
-    case Node(_, "set-head", List(s), _) =>
-      shallow(s); emit(".head")
-    case Node(_, "set-tail", List(s), _) =>
-      shallow(s); emit(".tail")
-    case Node(_, "set-toList", List(s), _) =>
-      shallow(s); emit(".toList")
-    case Node(_, "set-++", List(s1, s2), _) =>
-      shallow(s1); emit(" ++ "); shallow(s2)
-    case Node(_, "set-intersect", List(s1, s2), _) =>
-      shallow(s1); emit(".intersect("); shallow(s2); emit(")")
-    case Node(_, "set-union", List(s1, s2), _) =>
-      shallow(s1); emit(".union("); shallow(s2); emit(")")
-    case Node(_, "set-subsetOf", List(s1, s2), _) =>
-      shallow(s1); emit(".subsetOf("); shallow(s2); emit(")")
-    case Node(_, "set-map", List(s, b), _) =>
-      shallow(s); emit(".map("); shallow(b); emit(")")
-    case Node(_, "set-foldLeft", List(s, z, b), _) =>
-      shallow(s); emit(".foldLeft("); shallow(z); emit(")("); shallow(b); emit(")")
-    case Node(_, "set-filter", List(s, b), _) =>
-      shallow(s); emit(".filter("); shallow(b); emit(")")
+    case Node(_, "set-apply", List(s, x), _) => es"$s($x)"
+    case Node(_, "set-size", List(s), _) => es"$s.size"
+    case Node(_, "set-isEmpty", List(s), _) => es"$s.isEmpty"
+    case Node(_, "set-head", List(s), _) => es"$s.head"
+    case Node(_, "set-tail", List(s), _) => es"$s.tail"
+    case Node(_, "set-toList", List(s), _) => es"$s.toList"
+    case Node(_, "set-++", List(s1, s2), _) => es"$s1 ++ $s2"
+    case Node(_, "set-intersect", List(s1, s2), _) => es"$s1.intersect($s2)"
+    case Node(_, "set-union", List(s1, s2), _) => es"$s1.union($s2)"
+    case Node(_, "set-subsetOf", List(s1, s2), _) => es"$s1.subsetOf($s2)"
+    case Node(_, "set-map", List(s, b), _) => es"$s.map($b)"
+    case Node(_, "set-foldLeft", List(s, z, b), _) => es"$s.foldLeft($z)($b)"
+    case Node(_, "set-filter", List(s, b), _) => es"$s.filter($b)"
     case _ => super.shallow(n)
   }
 }

--- a/src/main/scala/lms/collection/TupleOps.scala
+++ b/src/main/scala/lms/collection/TupleOps.scala
@@ -126,26 +126,15 @@ trait ScalaCodeGen_Tuple extends ExtendedScalaCodeGen {
 
   override def shallow(n: Node): Unit = n match {
     // Tuple2
-    case Node(s, "tuple2-new", List(fst, snd), _) =>
-      emit("("); shallow(fst); emit(", "); shallow(snd); emit(")")
-    case Node(s, "tuple2-1", List(t), _) =>
-      shallow(t); emit("._1")
-    case Node(s, "tuple2-2", List(t), _) =>
-      shallow(t); emit("._2")
-    case Node(s, "tuple2-swap", List(t), _) =>
-      shallow(t); emit(".swap")
+    case Node(s, "tuple2-new", List(fst, snd), _) => es"($fst, $snd)"
+    case Node(s, "tuple2-1", List(t), _) => es"$t._1"
+    case Node(s, "tuple2-2", List(t), _) => es"$t._2"
+    case Node(s, "tuple2-swap", List(t), _) => es"$t.swap"
     // Tuple3
-    case Node(s, "tuple3-new", List(fst, snd, trd), _) =>
-      emit("(")
-      shallow(fst); emit(", ")
-      shallow(snd); emit(", ")
-      shallow(trd); emit(")")
-    case Node(s, "tuple3-1", List(t), _) =>
-      shallow(t); emit("._1")
-    case Node(s, "tuple3-2", List(t), _) =>
-      shallow(t); emit("._2")
-    case Node(s, "tuple3-3", List(t), _) =>
-      shallow(t); emit("._3")
+    case Node(s, "tuple3-new", List(fst, snd, trd), _) => es"($fst, $snd, $trd)"
+    case Node(s, "tuple3-1", List(t), _) => es"$t._1"
+    case Node(s, "tuple3-2", List(t), _) => es"$t._2"
+    case Node(s, "tuple3-3", List(t), _) => es"$t._3"
     case _ => super.shallow(n)
   }
 }
@@ -193,29 +182,15 @@ trait CppCodeGen_Tuple extends ExtendedCPPCodeGen {
 
   override def shallow(n: Node): Unit = n match {
     // Tuple2
-    case Node(s, "tuple2-new", List(fst, snd), _) =>
-      emit("{")
-      shallow(fst); emit(", "); shallow(snd)
-      emit("}")
-    case Node(s, "tuple2-1", List(t), _) =>
-      emit("std::get<0>("); shallow(t); emit(")")
-    case Node(s, "tuple2-2", List(t), _) =>
-      emit("std::get<1>("); shallow(t); emit(")")
-    case Node(s, "tuple2-swap", List(t), _) =>
-      emit("Pair::swap("); shallow(t); emit(")")
+    case Node(s, "tuple2-new", List(fst, snd), _) => es"{$fst, $snd}"
+    case Node(s, "tuple2-1", List(t), _) => es"std::get<0>($t)"
+    case Node(s, "tuple2-2", List(t), _) => es"std::get<1>($t)"
+    case Node(s, "tuple2-swap", List(t), _) => es"Pair::swap($t)"
     // Tuple3
-    case Node(s, "tuple3-new", List(fst, snd, trd), _) =>
-      emit("{")
-      shallow(fst); emit(", ")
-      shallow(snd); emit(", ")
-      shallow(trd); 
-      emit("}")
-    case Node(s, "tuple3-1", List(t), _) =>
-      emit("std::get<0>("); shallow(t); emit(")")
-    case Node(s, "tuple3-2", List(t), _) =>
-      emit("std::get<1>("); shallow(t); emit(")")
-    case Node(s, "tuple3-3", List(t), _) =>
-      emit("std::get<2>("); shallow(t); emit(")")
+    case Node(s, "tuple3-new", List(fst, snd, trd), _) => es"{$fst, $snd, $trd}"
+    case Node(s, "tuple3-1", List(t), _) => es"std::get<0>($t)"
+    case Node(s, "tuple3-2", List(t), _) => es"std::get<1>($t)"
+    case Node(s, "tuple3-3", List(t), _) => es"std::get<2>($t)"
     case _ => super.shallow(n)
   }
 }

--- a/src/main/scala/lms/core/codegen.scala
+++ b/src/main/scala/lms/core/codegen.scala
@@ -152,6 +152,10 @@ abstract class CompactCodeGen extends CompactTraverser {
     /** `es` for `emit-and-shallow`, which turns an interpolated string
       * such as `es"The quick brown $fox jumps over the lazy $dog"`
       * into `emit("The quick brown "); shallow(fox); emit(" jumps over the lazy "); shallow(dog)`.
+      * Roughly speaking, the intertwined string is decoupled (by the Scala compiler) to a sequence 
+      * of raw strings `sc.parts` and a sequence of non-string arguments `args`, then we alternately 
+      * output the head of two sequences.
+      * See more doc here: https://docs.scala-lang.org/overviews/core/string-interpolation.html
       */
     def es(args: Any*): Unit = {
       val strings = sc.parts.iterator


### PR DESCRIPTION
Defines a string interpolator `es` for `emit-and-shallow`, which turns an interpolated string such as `es"The quick brown $fox jumps over the lazy $dog"` into `emit("The quick brown "); shallow(fox); emit(" jumps over the lazy "); shallow(dog)`.

There is also an `esln` that prints a newline at the end.