### PR TITLE
add more NCCL test cases

### DIFF
--- a/src/main/scala/lms/thirdparty/cuda/cuda.scala
+++ b/src/main/scala/lms/thirdparty/cuda/cuda.scala
@@ -541,6 +541,7 @@ trait CCodeGenCudaOps extends CCodeGenSizeTOps with CudaCodeGenLibFunction with 
 
   override def remap(m: Manifest[_]): String = m.runtimeClass.getName match {
     case s: String if s.endsWith("Dim3") => "dim3"
+    case s: String if s.endsWith("CudaErrorT") => "CudaError_T"
     case _ => super.remap(m)
   }
 

--- a/src/main/scala/lms/thirdparty/cuda/cuda.scala
+++ b/src/main/scala/lms/thirdparty/cuda/cuda.scala
@@ -214,6 +214,9 @@ trait CudaOps extends Dsl with StackArrayOps with SizeTOps with CLibs with CudaF
     cudaCall(cudaMalloc(addr, SizeT(count * sizeOf[T])))
     addr
   }
+  def cudaMalloc3[T:Manifest](devPtr: Rep[Array[T]], count: Rep[Int])(implicit __pos: SourceContext) = {
+    libFunction[CudaErrorT]("cudaMalloc", Unwrap(devPtr), Unwrap(SizeT(count * sizeOf[T])))(Seq(1), Seq(0), Set(0))
+  }
 
   // cudaError_t cudaFree ( void* devPtr )
   def cudaFree[T:Manifest](devPtr: Rep[Array[T]]) =
@@ -537,11 +540,11 @@ trait CudaOps extends Dsl with StackArrayOps with SizeTOps with CLibs with CudaF
 
 trait CCodeGenCudaOps extends CCodeGenSizeTOps with CudaCodeGenLibFunction with CCodeGenLibs {
   // need to register the headers
-  registerHeader("<cuda_header.h>")
+  registerHeader("\"cuda_header.h\"")
 
   override def remap(m: Manifest[_]): String = m.runtimeClass.getName match {
     case s: String if s.endsWith("Dim3") => "dim3"
-    case s: String if s.endsWith("CudaErrorT") => "CudaError_T"
+    case s: String if s.endsWith("CudaErrorT") => "cudaError_t"
     case _ => super.remap(m)
   }
 

--- a/src/main/scala/lms/thirdparty/cuda/cuda.scala
+++ b/src/main/scala/lms/thirdparty/cuda/cuda.scala
@@ -386,7 +386,7 @@ trait CudaOps extends Dsl with StackArrayOps with SizeTOps with CLibs with CudaF
 
   // All CUDA calls return error code:
   // Except for kernel launches cudaError_t type
-  // cudaError_t cudaGetLastError(void)
+  //  cudaGetLastError(void)
   // Returns the code for the last error (no error has a code) Can be used to get error from kernel execution
   // char* cudaGetErrorString(cudaError_t code)
   // Returns a null-terminated character string describing the error

--- a/src/main/scala/lms/thirdparty/mpi/mpi.scala
+++ b/src/main/scala/lms/thirdparty/mpi/mpi.scala
@@ -187,7 +187,7 @@ trait MPIOps extends CMacro with LibStruct with LibFunction { b: Base =>
 
 trait CCodeGenMPI extends ExtendedCCodeGen {
 
-  registerHeader("<mpi_header.h>")
+  registerHeader("\"mpi_header.h\"")
 
   // NOTE: this type map from `mStr.endsWith("$DataStructure1")` to `DataStructure1`
   //       is necessary only if we may use this type without a struct instance,

--- a/src/out/thirdparty/nccl/mpi-reduce.check.cu
+++ b/src/out/thirdparty/nccl/mpi-reduce.check.cu
@@ -4,11 +4,11 @@ Emitting C Generated Code
 #include "nccl_header.h"
 #include <string.h>
 #include <stdlib.h>
-#include <cuda_header.h>
+#include "cuda_header.h"
 #include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include <mpi_header.h>
+#include "mpi_header.h"
 /**************** Snippet ****************/
 void Snippet(int x0) {
   ncclUniqueId x1;

--- a/src/out/thirdparty/nccl/one-device-per-process.check.cu
+++ b/src/out/thirdparty/nccl/one-device-per-process.check.cu
@@ -4,11 +4,11 @@ Emitting C Generated Code
 #include "nccl_header.h"
 #include <string.h>
 #include <stdlib.h>
-#include <cuda_header.h>
+#include "cuda_header.h"
 #include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include <mpi_header.h>
+#include "mpi_header.h"
 /**************** Snippet ****************/
 void Snippet(int x0) {
   int x1 = 0;

--- a/src/out/thirdparty/nccl/p2p-all2all.check.cu
+++ b/src/out/thirdparty/nccl/p2p-all2all.check.cu
@@ -1,0 +1,87 @@
+/*****************************************
+Emitting C Generated Code
+*******************************************/
+#include "nccl_header.h"
+#include <string.h>
+#include <stdlib.h>
+#include <cuda_header.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <mpi_header.h>
+/**************** Snippet ****************/
+void Snippet(int x0) {
+  int x1 = 0;
+  int x2 = 0;
+  MPICHECK(MPI_Init(NULL, NULL));
+  MPICHECK(MPI_Comm_rank(MPI_COMM_WORLD, &x1));
+  int x3 = MPI_Comm_size(MPI_COMM_WORLD, &x2);
+  MPICHECK(x3);
+  ncclUniqueId x4;
+  if (x1 == 0) NCCLCHECK(ncclGetUniqueId(&x4));
+  MPICHECK(MPI_Bcast(&x4, NCCL_UNIQUE_ID_BYTES, MPI_BYTE, 0, MPI_COMM_WORLD));
+  CUDA_CALL(cudaSetDevice(0));
+  cudaStream_t x5;
+  CudaError_T x6 = cudaStreamCreateWithFlags(&x5, cudaStreamDefault);
+  CUDA_CALL(x6);
+  ncclComm_t x7;
+  ncclResult_t x8 = ncclCommInitRank(&x7, x2, x4, x1);
+  NCCLCHECK(x8);
+  float* x9 = (float*)malloc(33554432 * sizeof(float));
+  int x10 = 0;
+  while (x10 != 33554432) {
+    x9[x10] = 1.0;
+    x10 = x10 + 1;
+  }
+  float** x11 = (float**)malloc(x2 * sizeof(float*));
+  int x12 = x2;
+  int x13 = 0;
+  while (x13 != x12) {
+    int x14 = x13;
+    CUDA_CALL(cudaMalloc(&x11[x14], 33554432));
+    CUDA_CALL(cudaMemcpy(x11[x14], x9, 33554432, cudaMemcpyHostToDevice));
+    x13 = x13 + 1;
+  }
+  float** x15 = (float**)malloc(x2 * sizeof(float*));
+  int x16 = x2;
+  int x17 = 0;
+  while (x17 != x16) {
+    CUDA_CALL(cudaMalloc(&x15[x17], 33554432));
+    x17 = x17 + 1;
+  }
+  NCCLCHECK(ncclGroupStart());
+  if (x1 == 0) {
+    int x18 = x2;
+    int x19 = 0;
+    while (x19 != x18) {
+      int x20 = x19;
+      NCCLCHECK(ncclSend(x11[x20], 33554432, ncclFloat, x20, x7, x5));
+      NCCLCHECK(ncclRecv(x15[x20], 33554432, ncclFloat, x20, x7, x5));
+      x19 = x19 + 1;
+    }
+  }
+  NCCLCHECK(ncclGroupEnd());
+  CUDA_CALL(cudaStreamSynchronize(x5));
+  int x21 = 0;
+  while (x21 != 33554432) {
+    CUDA_CALL(cudaMemcpy(x9, x15[x21], 33554432, cudaMemcpyDeviceToHost));
+    if (x9[0] != 1) printf("error");
+    x21 = x21 + 1;
+  }
+  CUDA_CALL(cudaFree(x11));
+  CUDA_CALL(cudaFree(x15));
+  NCCLCHECK(ncclCommDestroy(x7));
+  MPICHECK(MPI_Finalize());
+  printf("[MPI Rank %d] Success \n", x1);
+}
+/*****************************************
+End of C Generated Code
+*******************************************/
+int main(int argc, char *argv[]) {
+  if (argc != 2) {
+    printf("usage: %s <arg>\n", argv[0]);
+    return 0;
+  }
+  Snippet(atoi(argv[1]));
+  return 0;
+}

--- a/src/out/thirdparty/nccl/p2p-all2all.check.cu
+++ b/src/out/thirdparty/nccl/p2p-all2all.check.cu
@@ -14,65 +14,70 @@ void Snippet(int x0) {
   int x1 = 0;
   int x2 = 0;
   MPICHECK(MPI_Init(NULL, NULL));
-  MPICHECK(MPI_Comm_rank(MPI_COMM_WORLD, &x1));
-  int x3 = MPI_Comm_size(MPI_COMM_WORLD, &x2);
+  int x3 = MPI_Comm_rank(MPI_COMM_WORLD, &x1);
   MPICHECK(x3);
+  MPICHECK(MPI_Comm_size(MPI_COMM_WORLD, &x2));
+  printf("myRank: %d, nRanks: %d\n", x1, x2);
   ncclUniqueId x4;
+  ncclComm_t x5;
+  cudaStream_t x6;
   if (x1 == 0) NCCLCHECK(ncclGetUniqueId(&x4));
   MPICHECK(MPI_Bcast(&x4, NCCL_UNIQUE_ID_BYTES, MPI_BYTE, 0, MPI_COMM_WORLD));
-  CUDA_CALL(cudaSetDevice(0));
-  cudaStream_t x5;
-  cudaError_t x6 = cudaStreamCreateWithFlags(&x5, cudaStreamDefault);
-  CUDA_CALL(x6);
-  ncclComm_t x7;
-  ncclResult_t x8 = ncclCommInitRank(&x7, x2, x4, x1);
-  NCCLCHECK(x8);
-  float* x9 = (float*)malloc(33554432 * sizeof(float));
-  int x10 = 0;
-  while (x10 != 33554432) {
-    x9[x10] = 1.0;
-    x10 = x10 + 1;
+  float* x7 = (float*)malloc(1024 * sizeof(float));
+  int x8 = 0;
+  while (x8 != 1024) {
+    x7[x8] = 2.0;
+    x8 = x8 + 1;
   }
-  float** x11 = (float**)malloc(x2 * sizeof(float*));
-  int x12 = x2;
-  int x13 = 0;
-  while (x13 != x12) {
-    int x14 = x13;
-    CUDA_CALL(cudaMalloc(&x11[x14], 33554432));
-    CUDA_CALL(cudaMemcpy(x11[x14], x9, 33554432, cudaMemcpyHostToDevice));
-    x13 = x13 + 1;
+  CUDA_CALL(cudaSetDevice(x1));
+  float** x9 = (float**)malloc(x2 * sizeof(float*));
+  float** x10 = (float**)malloc(x2 * sizeof(float*));
+  int x11 = x2;
+  int x12 = 0;
+  while (x12 != x11) {
+    int x13 = x12;
+    CUDA_CALL(cudaMalloc(&x9[x13], (size_t)(1024 * sizeof(float))));
+    CUDA_CALL(cudaMalloc(&x10[x13], (size_t)(1024 * sizeof(float))));
+    CUDA_CALL(cudaMemcpy(x9[x13], x7, (size_t)(1024 * sizeof(float)), cudaMemcpyHostToDevice));
+    x12 = x12 + 1;
   }
-  float** x15 = (float**)malloc(x2 * sizeof(float*));
-  int x16 = x2;
-  int x17 = 0;
-  while (x17 != x16) {
-    CUDA_CALL(cudaMalloc(&x15[x17], 33554432));
-    x17 = x17 + 1;
-  }
+  CUDA_CALL(cudaStreamCreateWithFlags(&x6, cudaStreamDefault));
+  NCCLCHECK(ncclCommInitRank(&x5, x2, x4, x1));
   NCCLCHECK(ncclGroupStart());
-  if (x1 == 0) {
-    int x18 = x2;
-    int x19 = 0;
-    while (x19 != x18) {
-      int x20 = x19;
-      NCCLCHECK(ncclSend(x11[x20], 33554432, ncclFloat, x20, x7, x5));
-      NCCLCHECK(ncclRecv(x15[x20], 33554432, ncclFloat, x20, x7, x5));
-      x19 = x19 + 1;
-    }
+  int x14 = x2;
+  int x15 = 0;
+  while (x15 != x14) {
+    int x16 = x15;
+    NCCLCHECK(ncclSend(x9[x16], 1024, ncclFloat, x16, x5, x6));
+    NCCLCHECK(ncclRecv(x10[x16], 1024, ncclFloat, x16, x5, x6));
+    x15 = x15 + 1;
   }
   NCCLCHECK(ncclGroupEnd());
-  CUDA_CALL(cudaStreamSynchronize(x5));
-  int x21 = 0;
-  while (x21 != 33554432) {
-    CUDA_CALL(cudaMemcpy(x9, x15[x21], 33554432, cudaMemcpyDeviceToHost));
-    if (x9[0] != 1) printf("error");
-    x21 = x21 + 1;
+  CUDA_CALL(cudaStreamSynchronize(x6));
+  int x17 = 0;
+  int x18 = x2;
+  int x19 = 0;
+  while (x19 != x18) {
+    CUDA_CALL(cudaMemcpy(x7, x10[x19], (size_t)(1024 * sizeof(float)), cudaMemcpyDeviceToHost));
+    int x20 = 0;
+    while (x20 != 1024) {
+      if (x7[x20] != 2) x17 = x17 + 1;
+      x20 = x20 + 1;
+    }
+    x19 = x19 + 1;
   }
-  CUDA_CALL(cudaFree(x11));
-  CUDA_CALL(cudaFree(x15));
-  NCCLCHECK(ncclCommDestroy(x7));
+  int x21 = x2;
+  int x22 = 0;
+  while (x22 != x21) {
+    int x23 = x22;
+    CUDA_CALL(cudaFree(x9[x23]));
+    CUDA_CALL(cudaFree(x10[x23]));
+    x22 = x22 + 1;
+  }
+  NCCLCHECK(ncclCommDestroy(x5));
   MPICHECK(MPI_Finalize());
-  printf("[MPI Rank %d] Success \n", x1);
+  if (x17 != 0) printf("[MPI Rank %d] Found %d errors.\n", x1, x17);
+  else printf("[MPI Rank %d] Success \n", x1);
 }
 /*****************************************
 End of C Generated Code

--- a/src/out/thirdparty/nccl/p2p-all2all.check.cu
+++ b/src/out/thirdparty/nccl/p2p-all2all.check.cu
@@ -4,11 +4,11 @@ Emitting C Generated Code
 #include "nccl_header.h"
 #include <string.h>
 #include <stdlib.h>
-#include <cuda_header.h>
+#include "cuda_header.h"
 #include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include <mpi_header.h>
+#include "mpi_header.h"
 /**************** Snippet ****************/
 void Snippet(int x0) {
   int x1 = 0;
@@ -22,7 +22,7 @@ void Snippet(int x0) {
   MPICHECK(MPI_Bcast(&x4, NCCL_UNIQUE_ID_BYTES, MPI_BYTE, 0, MPI_COMM_WORLD));
   CUDA_CALL(cudaSetDevice(0));
   cudaStream_t x5;
-  CudaError_T x6 = cudaStreamCreateWithFlags(&x5, cudaStreamDefault);
+  cudaError_t x6 = cudaStreamCreateWithFlags(&x5, cudaStreamDefault);
   CUDA_CALL(x6);
   ncclComm_t x7;
   ncclResult_t x8 = ncclCommInitRank(&x7, x2, x4, x1);

--- a/src/out/thirdparty/nccl/p2p-gather.check.cu
+++ b/src/out/thirdparty/nccl/p2p-gather.check.cu
@@ -4,11 +4,11 @@ Emitting C Generated Code
 #include "nccl_header.h"
 #include <string.h>
 #include <stdlib.h>
-#include <cuda_header.h>
+#include "cuda_header.h"
 #include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include <mpi_header.h>
+#include "mpi_header.h"
 /**************** Snippet ****************/
 void Snippet(int x0) {
   int x1 = 0;
@@ -22,13 +22,13 @@ void Snippet(int x0) {
   MPICHECK(MPI_Bcast(&x4, NCCL_UNIQUE_ID_BYTES, MPI_BYTE, 0, MPI_COMM_WORLD));
   CUDA_CALL(cudaSetDevice(0));
   cudaStream_t x5;
-  CudaError_T x6 = cudaStreamCreateWithFlags(&x5, cudaStreamDefault);
+  cudaError_t x6 = cudaStreamCreateWithFlags(&x5, cudaStreamDefault);
   CUDA_CALL(x6);
   ncclComm_t x7;
   ncclResult_t x8 = ncclCommInitRank(&x7, x2, x4, x1);
   NCCLCHECK(x8);
   float* x9 = (float*)malloc(0 * sizeof(float));
-  CudaError_T x10 = cudaMalloc(&x9, (size_t)(33554432 * sizeof(float)));
+  cudaError_t x10 = cudaMalloc(&x9, (size_t)(33554432 * sizeof(float)));
   CUDA_CALL(x10);
   float* x11 = (float*)malloc(33554432 * sizeof(float));
   int x12 = 0;

--- a/src/out/thirdparty/nccl/p2p-gather.check.cu
+++ b/src/out/thirdparty/nccl/p2p-gather.check.cu
@@ -14,61 +14,75 @@ void Snippet(int x0) {
   int x1 = 0;
   int x2 = 0;
   MPICHECK(MPI_Init(NULL, NULL));
-  MPICHECK(MPI_Comm_rank(MPI_COMM_WORLD, &x1));
-  int x3 = MPI_Comm_size(MPI_COMM_WORLD, &x2);
+  int x3 = MPI_Comm_rank(MPI_COMM_WORLD, &x1);
   MPICHECK(x3);
-  ncclUniqueId x4;
-  if (x1 == 0) NCCLCHECK(ncclGetUniqueId(&x4));
-  MPICHECK(MPI_Bcast(&x4, NCCL_UNIQUE_ID_BYTES, MPI_BYTE, 0, MPI_COMM_WORLD));
-  CUDA_CALL(cudaSetDevice(0));
-  cudaStream_t x5;
-  cudaError_t x6 = cudaStreamCreateWithFlags(&x5, cudaStreamDefault);
-  CUDA_CALL(x6);
-  ncclComm_t x7;
-  ncclResult_t x8 = ncclCommInitRank(&x7, x2, x4, x1);
-  NCCLCHECK(x8);
-  float* x9 = (float*)malloc(0 * sizeof(float));
-  cudaError_t x10 = cudaMalloc(&x9, (size_t)(33554432 * sizeof(float)));
-  CUDA_CALL(x10);
-  float* x11 = (float*)malloc(33554432 * sizeof(float));
-  int x12 = 0;
-  while (x12 != 33554432) {
-    x11[x12] = 1.0;
-    x12 = x12 + 1;
+  int x4 = MPI_Comm_size(MPI_COMM_WORLD, &x2);
+  MPICHECK(x4);
+  printf("myRank: %d, nRanks: %d\n", x1, x2);
+  ncclUniqueId x5;
+  ncclComm_t x6;
+  cudaStream_t x7;
+  if (x1 == 0) NCCLCHECK(ncclGetUniqueId(&x5));
+  MPICHECK(MPI_Bcast(&x5, NCCL_UNIQUE_ID_BYTES, MPI_BYTE, 0, MPI_COMM_WORLD));
+  float* x8 = (float*)malloc(1024 * sizeof(float));
+  int x9 = 0;
+  while (x9 != 1024) {
+    x8[x9] = 2.0;
+    x9 = x9 + 1;
   }
-  float** x13 = (float**)malloc(x2 * sizeof(float*));
-  int x14 = x2;
-  int x15 = 0;
-  while (x15 != x14) {
-    int x16 = x15;
-    CUDA_CALL(cudaMalloc(&x13[x16], 33554432));
-    CUDA_CALL(cudaMemcpy(x13[x16], x11, 33554432, cudaMemcpyHostToDevice));
-    x15 = x15 + 1;
+  CUDA_CALL(cudaSetDevice(x1));
+  float* x10 = (float*)malloc(0 * sizeof(float));
+  CUDA_CALL(cudaMalloc(&x10, (size_t)(1024 * sizeof(float))));
+  CUDA_CALL(cudaMemcpy(x10, x8, (size_t)(1024 * sizeof(float)), cudaMemcpyHostToDevice));
+  float** x11 = (float**)malloc(x2 * sizeof(float*));
+  int x12 = x2;
+  int x13 = 0;
+  while (x13 != x12) {
+    CUDA_CALL(cudaMalloc(&x11[x13], (size_t)(1024 * sizeof(float))));
+    x13 = x13 + 1;
   }
+  cudaError_t x14 = cudaStreamCreateWithFlags(&x7, cudaStreamDefault);
+  CUDA_CALL(x14);
+  ncclResult_t x15 = ncclCommInitRank(&x6, x2, x5, x1);
+  NCCLCHECK(x15);
   NCCLCHECK(ncclGroupStart());
   if (x1 == 0) {
-    int x17 = x2;
-    int x18 = 0;
-    while (x18 != x17) {
-      int x19 = x18;
-      NCCLCHECK(ncclRecv(x13[x19], 33554432, ncclFloat, x19, x7, x5));
-      x18 = x18 + 1;
+    int x16 = x2;
+    int x17 = 0;
+    while (x17 != x16) {
+      int x18 = x17;
+      NCCLCHECK(ncclRecv(x11[x18], 1024, ncclFloat, x18, x6, x7));
+      x17 = x17 + 1;
     }
-    NCCLCHECK(ncclSend(x9, 33554432, ncclFloat, 0, x7, x5));
   }
+  NCCLCHECK(ncclSend(x10, 1024, ncclFloat, 0, x6, x7));
   NCCLCHECK(ncclGroupEnd());
-  CUDA_CALL(cudaStreamSynchronize(x5));
-  CUDA_CALL(cudaMemcpy(x11, x9, 33554432, cudaMemcpyDeviceToHost));
-  int x20 = 0;
-  while (x20 != 33554432) {
-    if (x11[0] != 1) printf("error");
-    x20 = x20 + 1;
+  CUDA_CALL(cudaStreamSynchronize(x7));
+  int x19 = 0;
+  if (x1 == 0) {
+    int x20 = x2;
+    int x21 = 0;
+    while (x21 != x20) {
+      CUDA_CALL(cudaMemcpy(x8, x11[x21], (size_t)(1024 * sizeof(float)), cudaMemcpyDeviceToHost));
+      int x22 = 0;
+      while (x22 != 1024) {
+        if (x8[x22] != 2) x19 = x19 + 1;
+        x22 = x22 + 1;
+      }
+      x21 = x21 + 1;
+    }
   }
-  CUDA_CALL(cudaFree(x9));
-  CUDA_CALL(cudaFree(x13));
-  NCCLCHECK(ncclCommDestroy(x7));
+  CUDA_CALL(cudaFree(x10));
+  int x23 = x2;
+  int x24 = 0;
+  while (x24 != x23) {
+    CUDA_CALL(cudaFree(x11[x24]));
+    x24 = x24 + 1;
+  }
+  NCCLCHECK(ncclCommDestroy(x6));
   MPICHECK(MPI_Finalize());
-  printf("[MPI Rank %d] Success \n", x1);
+  if (x19 != 0) printf("[MPI Rank %d] Found %d errors.\n", x1, x19);
+  else printf("[MPI Rank %d] Success \n", x1);
 }
 /*****************************************
 End of C Generated Code

--- a/src/out/thirdparty/nccl/p2p-gather.check.cu
+++ b/src/out/thirdparty/nccl/p2p-gather.check.cu
@@ -1,0 +1,83 @@
+/*****************************************
+Emitting C Generated Code
+*******************************************/
+#include "nccl_header.h"
+#include <string.h>
+#include <stdlib.h>
+#include <cuda_header.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <mpi_header.h>
+/**************** Snippet ****************/
+void Snippet(int x0) {
+  int x1 = 0;
+  int x2 = 0;
+  MPICHECK(MPI_Init(NULL, NULL));
+  MPICHECK(MPI_Comm_rank(MPI_COMM_WORLD, &x1));
+  int x3 = MPI_Comm_size(MPI_COMM_WORLD, &x2);
+  MPICHECK(x3);
+  ncclUniqueId x4;
+  if (x1 == 0) NCCLCHECK(ncclGetUniqueId(&x4));
+  MPICHECK(MPI_Bcast(&x4, NCCL_UNIQUE_ID_BYTES, MPI_BYTE, 0, MPI_COMM_WORLD));
+  CUDA_CALL(cudaSetDevice(0));
+  cudaStream_t x5;
+  CudaError_T x6 = cudaStreamCreateWithFlags(&x5, cudaStreamDefault);
+  CUDA_CALL(x6);
+  ncclComm_t x7;
+  ncclResult_t x8 = ncclCommInitRank(&x7, x2, x4, x1);
+  NCCLCHECK(x8);
+  float* x9 = (float*)malloc(0 * sizeof(float));
+  CudaError_T x10 = cudaMalloc(&x9, (size_t)(33554432 * sizeof(float)));
+  CUDA_CALL(x10);
+  float* x11 = (float*)malloc(33554432 * sizeof(float));
+  int x12 = 0;
+  while (x12 != 33554432) {
+    x11[x12] = 1.0;
+    x12 = x12 + 1;
+  }
+  float** x13 = (float**)malloc(x2 * sizeof(float*));
+  int x14 = x2;
+  int x15 = 0;
+  while (x15 != x14) {
+    int x16 = x15;
+    CUDA_CALL(cudaMalloc(&x13[x16], 33554432));
+    CUDA_CALL(cudaMemcpy(x13[x16], x11, 33554432, cudaMemcpyHostToDevice));
+    x15 = x15 + 1;
+  }
+  NCCLCHECK(ncclGroupStart());
+  if (x1 == 0) {
+    int x17 = x2;
+    int x18 = 0;
+    while (x18 != x17) {
+      int x19 = x18;
+      NCCLCHECK(ncclRecv(x13[x19], 33554432, ncclFloat, x19, x7, x5));
+      x18 = x18 + 1;
+    }
+    NCCLCHECK(ncclSend(x9, 33554432, ncclFloat, 0, x7, x5));
+  }
+  NCCLCHECK(ncclGroupEnd());
+  CUDA_CALL(cudaStreamSynchronize(x5));
+  CUDA_CALL(cudaMemcpy(x11, x9, 33554432, cudaMemcpyDeviceToHost));
+  int x20 = 0;
+  while (x20 != 33554432) {
+    if (x11[0] != 1) printf("error");
+    x20 = x20 + 1;
+  }
+  CUDA_CALL(cudaFree(x9));
+  CUDA_CALL(cudaFree(x13));
+  NCCLCHECK(ncclCommDestroy(x7));
+  MPICHECK(MPI_Finalize());
+  printf("[MPI Rank %d] Success \n", x1);
+}
+/*****************************************
+End of C Generated Code
+*******************************************/
+int main(int argc, char *argv[]) {
+  if (argc != 2) {
+    printf("usage: %s <arg>\n", argv[0]);
+    return 0;
+  }
+  Snippet(atoi(argv[1]));
+  return 0;
+}

--- a/src/out/thirdparty/nccl/p2p-scatter.check.cu
+++ b/src/out/thirdparty/nccl/p2p-scatter.check.cu
@@ -1,0 +1,82 @@
+/*****************************************
+Emitting C Generated Code
+*******************************************/
+#include "nccl_header.h"
+#include <string.h>
+#include <stdlib.h>
+#include <cuda_header.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <mpi_header.h>
+/**************** Snippet ****************/
+void Snippet(int x0) {
+  int x1 = 0;
+  int x2 = 0;
+  MPICHECK(MPI_Init(NULL, NULL));
+  MPICHECK(MPI_Comm_rank(MPI_COMM_WORLD, &x1));
+  int x3 = MPI_Comm_size(MPI_COMM_WORLD, &x2);
+  MPICHECK(x3);
+  ncclUniqueId x4;
+  if (x1 == 0) NCCLCHECK(ncclGetUniqueId(&x4));
+  MPICHECK(MPI_Bcast(&x4, NCCL_UNIQUE_ID_BYTES, MPI_BYTE, 0, MPI_COMM_WORLD));
+  CUDA_CALL(cudaSetDevice(0));
+  cudaStream_t x5;
+  CudaError_T x6 = cudaStreamCreateWithFlags(&x5, cudaStreamDefault);
+  CUDA_CALL(x6);
+  ncclComm_t x7;
+  ncclResult_t x8 = ncclCommInitRank(&x7, x2, x4, x1);
+  NCCLCHECK(x8);
+  float* x9 = (float*)malloc(33554432 * sizeof(float));
+  int x10 = 0;
+  while (x10 != 33554432) {
+    x9[x10] = 1.0;
+    x10 = x10 + 1;
+  }
+  float** x11 = (float**)malloc(x2 * sizeof(float*));
+  int x12 = x2;
+  int x13 = 0;
+  while (x13 != x12) {
+    int x14 = x13;
+    CUDA_CALL(cudaMalloc(&x11[x14], 33554432));
+    CUDA_CALL(cudaMemcpy(x11[x14], x9, 33554432, cudaMemcpyHostToDevice));
+    x13 = x13 + 1;
+  }
+  float* x15 = (float*)malloc(0 * sizeof(float));
+  CUDA_CALL(cudaMalloc(&x15, (size_t)(33554432 * sizeof(float))));
+  NCCLCHECK(ncclGroupStart());
+  if (x1 == 0) {
+    int x16 = x2;
+    int x17 = 0;
+    while (x17 != x16) {
+      int x18 = x17;
+      NCCLCHECK(ncclSend(x11[x18], 33554432, ncclFloat, x18, x7, x5));
+      x17 = x17 + 1;
+    }
+    NCCLCHECK(ncclRecv(x15, 33554432, ncclFloat, 0, x7, x5));
+  }
+  NCCLCHECK(ncclGroupEnd());
+  CUDA_CALL(cudaStreamSynchronize(x5));
+  CUDA_CALL(cudaMemcpy(x9, x15, 33554432, cudaMemcpyDeviceToHost));
+  int x19 = 0;
+  while (x19 != 33554432) {
+    if (x9[0] != 1) printf("error");
+    x19 = x19 + 1;
+  }
+  CUDA_CALL(cudaFree(x11));
+  CUDA_CALL(cudaFree(x15));
+  NCCLCHECK(ncclCommDestroy(x7));
+  MPICHECK(MPI_Finalize());
+  printf("[MPI Rank %d] Success \n", x1);
+}
+/*****************************************
+End of C Generated Code
+*******************************************/
+int main(int argc, char *argv[]) {
+  if (argc != 2) {
+    printf("usage: %s <arg>\n", argv[0]);
+    return 0;
+  }
+  Snippet(atoi(argv[1]));
+  return 0;
+}

--- a/src/out/thirdparty/nccl/p2p-scatter.check.cu
+++ b/src/out/thirdparty/nccl/p2p-scatter.check.cu
@@ -4,70 +4,79 @@ Emitting C Generated Code
 #include "nccl_header.h"
 #include <string.h>
 #include <stdlib.h>
-#include <cuda_header.h>
+#include "cuda_header.h"
 #include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include <mpi_header.h>
+#include "mpi_header.h"
 /**************** Snippet ****************/
 void Snippet(int x0) {
   int x1 = 0;
   int x2 = 0;
   MPICHECK(MPI_Init(NULL, NULL));
-  MPICHECK(MPI_Comm_rank(MPI_COMM_WORLD, &x1));
-  int x3 = MPI_Comm_size(MPI_COMM_WORLD, &x2);
+  int x3 = MPI_Comm_rank(MPI_COMM_WORLD, &x1);
   MPICHECK(x3);
-  ncclUniqueId x4;
-  if (x1 == 0) NCCLCHECK(ncclGetUniqueId(&x4));
-  MPICHECK(MPI_Bcast(&x4, NCCL_UNIQUE_ID_BYTES, MPI_BYTE, 0, MPI_COMM_WORLD));
-  CUDA_CALL(cudaSetDevice(0));
-  cudaStream_t x5;
-  CudaError_T x6 = cudaStreamCreateWithFlags(&x5, cudaStreamDefault);
-  CUDA_CALL(x6);
-  ncclComm_t x7;
-  ncclResult_t x8 = ncclCommInitRank(&x7, x2, x4, x1);
-  NCCLCHECK(x8);
-  float* x9 = (float*)malloc(33554432 * sizeof(float));
-  int x10 = 0;
-  while (x10 != 33554432) {
-    x9[x10] = 1.0;
-    x10 = x10 + 1;
+  int x4 = MPI_Comm_size(MPI_COMM_WORLD, &x2);
+  MPICHECK(x4);
+  printf("myRank: %d, nRanks: %d\n", x1, x2);
+  ncclUniqueId x5;
+  ncclComm_t x6;
+  cudaStream_t x7;
+  if (x1 == 0) NCCLCHECK(ncclGetUniqueId(&x5));
+  MPICHECK(MPI_Bcast(&x5, NCCL_UNIQUE_ID_BYTES, MPI_BYTE, 0, MPI_COMM_WORLD));
+  float* x8 = (float*)malloc(2014 * sizeof(float));
+  int x9 = 0;
+  while (x9 != 2014) {
+    x8[x9] = 2.0;
+    x9 = x9 + 1;
   }
-  float** x11 = (float**)malloc(x2 * sizeof(float*));
-  int x12 = x2;
-  int x13 = 0;
-  while (x13 != x12) {
-    int x14 = x13;
-    CUDA_CALL(cudaMalloc(&x11[x14], 33554432));
-    CUDA_CALL(cudaMemcpy(x11[x14], x9, 33554432, cudaMemcpyHostToDevice));
-    x13 = x13 + 1;
+  CUDA_CALL(cudaSetDevice(x1));
+  float** x10 = (float**)malloc(x2 * sizeof(float*));
+  int x11 = x2;
+  int x12 = 0;
+  while (x12 != x11) {
+    int x13 = x12;
+    CUDA_CALL(cudaMalloc(&x10[x13], 2014));
+    CUDA_CALL(cudaMemcpy(x10[x13], x8, 2014, cudaMemcpyHostToDevice));
+    x12 = x12 + 1;
   }
-  float* x15 = (float*)malloc(0 * sizeof(float));
-  CUDA_CALL(cudaMalloc(&x15, (size_t)(33554432 * sizeof(float))));
+  float* x14 = (float*)malloc(0 * sizeof(float));
+  CUDA_CALL(cudaMalloc(&x14, (size_t)(2014 * sizeof(float))));
+  cudaError_t x15 = cudaStreamCreateWithFlags(&x7, cudaStreamDefault);
+  CUDA_CALL(x15);
+  ncclResult_t x16 = ncclCommInitRank(&x6, x2, x5, x1);
+  NCCLCHECK(x16);
   NCCLCHECK(ncclGroupStart());
   if (x1 == 0) {
-    int x16 = x2;
-    int x17 = 0;
-    while (x17 != x16) {
-      int x18 = x17;
-      NCCLCHECK(ncclSend(x11[x18], 33554432, ncclFloat, x18, x7, x5));
-      x17 = x17 + 1;
+    int x17 = x2;
+    int x18 = 0;
+    while (x18 != x17) {
+      int x19 = x18;
+      NCCLCHECK(ncclSend(x10[x19], 2014, ncclFloat, x19, x6, x7));
+      x18 = x18 + 1;
     }
-    NCCLCHECK(ncclRecv(x15, 33554432, ncclFloat, 0, x7, x5));
   }
+  NCCLCHECK(ncclRecv(x14, 2014, ncclFloat, 0, x6, x7));
   NCCLCHECK(ncclGroupEnd());
-  CUDA_CALL(cudaStreamSynchronize(x5));
-  CUDA_CALL(cudaMemcpy(x9, x15, 33554432, cudaMemcpyDeviceToHost));
-  int x19 = 0;
-  while (x19 != 33554432) {
-    if (x9[0] != 1) printf("error");
-    x19 = x19 + 1;
+  CUDA_CALL(cudaStreamSynchronize(x7));
+  CUDA_CALL(cudaMemcpy(x8, x14, 2014, cudaMemcpyDeviceToHost));
+  int x20 = 0;
+  int x21 = 0;
+  while (x21 != 2014) {
+    if (x8[0] != 2) x20 = x20 + 1;
+    x21 = x21 + 1;
   }
-  CUDA_CALL(cudaFree(x11));
-  CUDA_CALL(cudaFree(x15));
-  NCCLCHECK(ncclCommDestroy(x7));
+  int x22 = x2;
+  int x23 = 0;
+  while (x23 != x22) {
+    CUDA_CALL(cudaFree(x10[x23]));
+    x23 = x23 + 1;
+  }
+  CUDA_CALL(cudaFree(x14));
+  NCCLCHECK(ncclCommDestroy(x6));
   MPICHECK(MPI_Finalize());
-  printf("[MPI Rank %d] Success \n", x1);
+  if (x20 != 0) printf("[MPI Rank %d] Found %d errors.\n", x1, x20);
+  else printf("[MPI Rank %d] Success \n", x1);
 }
 /*****************************************
 End of C Generated Code

--- a/src/out/thirdparty/nccl/p2p-scatter.check.cu
+++ b/src/out/thirdparty/nccl/p2p-scatter.check.cu
@@ -24,9 +24,9 @@ void Snippet(int x0) {
   cudaStream_t x7;
   if (x1 == 0) NCCLCHECK(ncclGetUniqueId(&x5));
   MPICHECK(MPI_Bcast(&x5, NCCL_UNIQUE_ID_BYTES, MPI_BYTE, 0, MPI_COMM_WORLD));
-  float* x8 = (float*)malloc(2014 * sizeof(float));
+  float* x8 = (float*)malloc(1024 * sizeof(float));
   int x9 = 0;
-  while (x9 != 2014) {
+  while (x9 != 1024) {
     x8[x9] = 2.0;
     x9 = x9 + 1;
   }
@@ -36,12 +36,12 @@ void Snippet(int x0) {
   int x12 = 0;
   while (x12 != x11) {
     int x13 = x12;
-    CUDA_CALL(cudaMalloc(&x10[x13], 2014));
-    CUDA_CALL(cudaMemcpy(x10[x13], x8, (size_t)(2014 * sizeof(float)), cudaMemcpyHostToDevice));
+    CUDA_CALL(cudaMalloc(&x10[x13], (size_t)(1024 * sizeof(float))));
+    CUDA_CALL(cudaMemcpy(x10[x13], x8, (size_t)(1024 * sizeof(float)), cudaMemcpyHostToDevice));
     x12 = x12 + 1;
   }
   float* x14 = (float*)malloc(0 * sizeof(float));
-  CUDA_CALL(cudaMalloc(&x14, (size_t)(2014 * sizeof(float))));
+  CUDA_CALL(cudaMalloc(&x14, (size_t)(1024 * sizeof(float))));
   cudaError_t x15 = cudaStreamCreateWithFlags(&x7, cudaStreamDefault);
   CUDA_CALL(x15);
   ncclResult_t x16 = ncclCommInitRank(&x6, x2, x5, x1);
@@ -52,17 +52,17 @@ void Snippet(int x0) {
     int x18 = 0;
     while (x18 != x17) {
       int x19 = x18;
-      NCCLCHECK(ncclSend(x10[x19], 2014, ncclFloat, x19, x6, x7));
+      NCCLCHECK(ncclSend(x10[x19], 1024, ncclFloat, x19, x6, x7));
       x18 = x18 + 1;
     }
   }
-  NCCLCHECK(ncclRecv(x14, 2014, ncclFloat, 0, x6, x7));
+  NCCLCHECK(ncclRecv(x14, 1024, ncclFloat, 0, x6, x7));
   NCCLCHECK(ncclGroupEnd());
   CUDA_CALL(cudaStreamSynchronize(x7));
-  CUDA_CALL(cudaMemcpy(x8, x14, (size_t)(2014 * sizeof(float)), cudaMemcpyDeviceToHost));
+  CUDA_CALL(cudaMemcpy(x8, x14, (size_t)(1024 * sizeof(float)), cudaMemcpyDeviceToHost));
   int x20 = 0;
   int x21 = 0;
-  while (x21 != 2014) {
+  while (x21 != 1024) {
     if (x8[0] != 2) x20 = x20 + 1;
     x21 = x21 + 1;
   }

--- a/src/out/thirdparty/nccl/p2p-scatter.check.cu
+++ b/src/out/thirdparty/nccl/p2p-scatter.check.cu
@@ -37,7 +37,7 @@ void Snippet(int x0) {
   while (x12 != x11) {
     int x13 = x12;
     CUDA_CALL(cudaMalloc(&x10[x13], 2014));
-    CUDA_CALL(cudaMemcpy(x10[x13], x8, 2014, cudaMemcpyHostToDevice));
+    CUDA_CALL(cudaMemcpy(x10[x13], x8, (size_t)(2014 * sizeof(float)), cudaMemcpyHostToDevice));
     x12 = x12 + 1;
   }
   float* x14 = (float*)malloc(0 * sizeof(float));
@@ -59,7 +59,7 @@ void Snippet(int x0) {
   NCCLCHECK(ncclRecv(x14, 2014, ncclFloat, 0, x6, x7));
   NCCLCHECK(ncclGroupEnd());
   CUDA_CALL(cudaStreamSynchronize(x7));
-  CUDA_CALL(cudaMemcpy(x8, x14, 2014, cudaMemcpyDeviceToHost));
+  CUDA_CALL(cudaMemcpy(x8, x14, (size_t)(2014 * sizeof(float)), cudaMemcpyDeviceToHost));
   int x20 = 0;
   int x21 = 0;
   while (x21 != 2014) {

--- a/src/out/thirdparty/nccl/p2p-sendrecv.check.cu
+++ b/src/out/thirdparty/nccl/p2p-sendrecv.check.cu
@@ -1,0 +1,78 @@
+/*****************************************
+Emitting C Generated Code
+*******************************************/
+#include "nccl_header.h"
+#include <string.h>
+#include <stdlib.h>
+#include <cuda_header.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <mpi_header.h>
+/**************** Snippet ****************/
+void Snippet(int x0) {
+  int x1 = 0;
+  int x2 = 0;
+  MPICHECK(MPI_Init(NULL, NULL));
+  MPICHECK(MPI_Comm_rank(MPI_COMM_WORLD, &x1));
+  MPICHECK(MPI_Comm_size(MPI_COMM_WORLD, &x2));
+  ncclUniqueId x3;
+  if (x1 == 0) NCCLCHECK(ncclGetUniqueId(&x3));
+  MPICHECK(MPI_Bcast(&x3, NCCL_UNIQUE_ID_BYTES, MPI_BYTE, 0, MPI_COMM_WORLD));
+  CUDA_CALL(cudaSetDevice(0));
+  cudaStream_t x4;
+  CUDA_CALL(cudaStreamCreateWithFlags(&x4, cudaStreamDefault));
+  ncclComm_t x5;
+  NCCLCHECK(ncclCommInitRank(&x5, x2, x3, x1));
+  float* x6 = (float*)malloc(0 * sizeof(float));
+  CUDA_CALL(cudaMalloc(&x6, (size_t)(33554432 * sizeof(float))));
+  float* x7 = (float*)malloc(0 * sizeof(float));
+  CUDA_CALL(cudaMalloc(&x7, (size_t)(33554432 * sizeof(float))));
+  float* x8 = (float*)malloc(33554432 * sizeof(float));
+  int x9 = 0;
+  while (x9 != 33554432) {
+    x8[x9] = 0.0;
+    x9 = x9 + 1;
+  }
+  CUDA_CALL(cudaMemcpy(x6, x8, 33554432, cudaMemcpyHostToDevice));
+  float* x10 = (float*)malloc(33554432 * sizeof(float));
+  int x11 = 0;
+  while (x11 != 33554432) {
+    x10[x11] = 1.0;
+    x11 = x11 + 1;
+  }
+  CUDA_CALL(cudaMemcpy(x7, x10, 33554432, cudaMemcpyHostToDevice));
+  NCCLCHECK(ncclGroupStart());
+  NCCLCHECK(ncclSend(x6, 33554432, ncclFloat, 1, x5, x4));
+  NCCLCHECK(ncclRecv(x7, 33554432, ncclFloat, 0, x5, x4));
+  NCCLCHECK(ncclGroupEnd());
+  CUDA_CALL(cudaStreamSynchronize(x4));
+  CUDA_CALL(cudaMemcpy(x8, x6, 33554432, cudaMemcpyDeviceToHost));
+  int x12 = 0;
+  while (x12 != 33554432) {
+    if (x8[0] != 1) printf("error");
+    x12 = x12 + 1;
+  }
+  CUDA_CALL(cudaMemcpy(x10, x7, 33554432, cudaMemcpyDeviceToHost));
+  int x13 = 0;
+  while (x13 != 33554432) {
+    if (x10[0] != 0) printf("error");
+    x13 = x13 + 1;
+  }
+  CUDA_CALL(cudaFree(x6));
+  CUDA_CALL(cudaFree(x7));
+  NCCLCHECK(ncclCommDestroy(x5));
+  MPICHECK(MPI_Finalize());
+  printf("[MPI Rank %d] Success \n", x1);
+}
+/*****************************************
+End of C Generated Code
+*******************************************/
+int main(int argc, char *argv[]) {
+  if (argc != 2) {
+    printf("usage: %s <arg>\n", argv[0]);
+    return 0;
+  }
+  Snippet(atoi(argv[1]));
+  return 0;
+}

--- a/src/out/thirdparty/nccl/p2p-sendrecv.check.cu
+++ b/src/out/thirdparty/nccl/p2p-sendrecv.check.cu
@@ -34,7 +34,7 @@ void Snippet(int x0) {
     x9[x10] = 2.0;
     x10 = x10 + 1;
   }
-  CUDA_CALL(cudaMemcpy(x7, x9, 1024, cudaMemcpyHostToDevice));
+  CUDA_CALL(cudaMemcpy(x7, x9, (size_t)(1024 * sizeof(float)), cudaMemcpyHostToDevice));
   CUDA_CALL(cudaStreamCreateWithFlags(&x6, cudaStreamDefault));
   NCCLCHECK(ncclCommInitRank(&x5, x2, x4, x1));
   int x11 = x1 == 0 ? 1 : 0;
@@ -43,7 +43,7 @@ void Snippet(int x0) {
   NCCLCHECK(ncclRecv(x8, 1024, ncclFloat, x11, x5, x6));
   NCCLCHECK(ncclGroupEnd());
   CUDA_CALL(cudaStreamSynchronize(x6));
-  CUDA_CALL(cudaMemcpy(x9, x8, 1024, cudaMemcpyDeviceToHost));
+  CUDA_CALL(cudaMemcpy(x9, x8, (size_t)(1024 * sizeof(float)), cudaMemcpyDeviceToHost));
   int x12 = 0;
   int x13 = 0;
   while (x13 != 1024) {

--- a/src/out/thirdparty/nccl/sanity-check.check.cu
+++ b/src/out/thirdparty/nccl/sanity-check.check.cu
@@ -4,11 +4,11 @@ Emitting C Generated Code
 #include "nccl_header.h"
 #include <string.h>
 #include <stdlib.h>
-#include <cuda_header.h>
+#include "cuda_header.h"
 #include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include <mpi_header.h>
+#include "mpi_header.h"
 /**************** Snippet ****************/
 void Snippet(int x0) {
   ncclComm_t x1;

--- a/src/out/thirdparty/nccl/single-process-single-device.check.cu
+++ b/src/out/thirdparty/nccl/single-process-single-device.check.cu
@@ -4,11 +4,11 @@ Emitting C Generated Code
 #include "nccl_header.h"
 #include <string.h>
 #include <stdlib.h>
-#include <cuda_header.h>
+#include "cuda_header.h"
 #include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include <mpi_header.h>
+#include "mpi_header.h"
 /**************** Snippet ****************/
 void Snippet(int x0) {
   ncclComm_t x1;

--- a/src/test/scala/lms/thirdparty/test_nccl.scala
+++ b/src/test/scala/lms/thirdparty/test_nccl.scala
@@ -1,19 +1,21 @@
 package lms
 package thirdparty
 
+import lms.core._
 import lms.core.stub._
 import lms.core.virtualize
 import lms.macros.SourceContext
 import lms.collection._
-import lms.collection.mutable.ArrayTypeLess
+// import lms.collection.mutable.ArrayTypeLess
+import lms.collection.mutable._
 import lms.thirdparty.array_computation.{CUDATypeLess, CCodeGenCudaOps, CudaOps}
 
 
 class NCCLTest extends TutorialFunSuite {
   val under = "thirdparty/nccl/"
 
-  abstract class DslDriverCNCCL[A: Manifest, B: Manifest] extends DslDriverC[A,B] with NCCLOps with CudaOps with SizeTOps with MPIOps { q =>
-    override val codegen = new DslGenC with CCodeGenLibs with CCodeGenCudaOps with CCodeGenSizeTOps with CCodeGenMPI {
+  abstract class DslDriverCNCCL[A: Manifest, B: Manifest] extends DslDriverC[A,B] with NCCLOps with CudaOps with SizeTOps with MPIOps with ArrayOps{ q =>
+    override val codegen = new DslGenC with CCodeGenLibs with CCodeGenCudaOps with CCodeGenSizeTOps with CCodeGenMPI with CCodeGenNCCLOps {
       val IR: q.type = q
 
       registerHeader("\"nccl_header.h\"")
@@ -21,13 +23,12 @@ class NCCLTest extends TutorialFunSuite {
     }
     override val compilerCommand = "nvcc -std=c++11 -O3"
 
-
     val curPath = System.getProperty("user.dir")
     override val sourceFile = s"$curPath/snippet.cu"
     override val executable = s"$curPath/snippet"
   }
 
-
+ 
   test("sanity-check") {
     // just sanity check. Output code not runnable
     val driver = new DslDriverCNCCL[Int, Unit] {
@@ -243,6 +244,346 @@ class NCCLTest extends TutorialFunSuite {
       }
     }
     check("mpi-reduce", driver.code, "cu")
+  }
+
+  test("p2p-sendrecv") {
+    val driver = new DslDriverCNCCL[Int, Unit] {
+      @virtualize
+      def snippet(arg:Rep[Int]) = {
+        val size = 32*1024*1024
+        var myRank = 0
+        var nRanks = 0
+        val localRank = 0
+
+        // initializing MPI
+        MPI_CHECK(mpi_init())
+        MPI_CHECK(mpi_comm_rank(mpi_comm_world, myRank))
+        MPI_CHECK(mpi_comm_size(mpi_comm_world, nRanks))
+
+        // calculating localRank
+        // for now, localRank = 0
+
+        // get NCCL unique ID at rank 0 and broadcast it to all others
+        var id = ncclUniqueId
+        if (myRank == 0) {
+          ncclCheck(ncclGetUniqueId(id))
+        }
+        MPI_CHECK(mpi_bcast_one(id, ncclUniqueIdBytes, mpi_byte, 0, mpi_comm_world))
+
+        // picking a GPU based on localRank
+        cudaCall(cudaSetDevice(localRank))
+
+        val s = cudaStream
+        cudaCall(cudaStreamCreateWithFlags(s, cudaStreamDefault))
+
+        // initializing NCCL
+        val comm = ncclComm
+        ncclCheck(ncclCommInitRank(comm, nRanks, id, myRank))
+
+        // allocate and initialize buffers
+        val sendbuff = cudaMalloc2[Float](size)
+        val recvbuff = cudaMalloc2[Float](size)
+        val zero = NewArray[Float](size)
+        for (i <- (0 until size): Rep[Range]) {
+          zero(i) = 0
+        }
+        cudaCall(cudaMemcpy[Float](sendbuff, zero, SizeT(size), host2device))
+        val one = NewArray[Float](size)
+        for (i <- (0 until size): Rep[Range]) {
+          one(i) = 1
+        }
+        cudaCall(cudaMemcpy[Float](recvbuff, one, SizeT(size), host2device))
+
+        // one-to-all (scatter)
+        ncclCheck(ncclGroupStart())
+        ncclCheck(ncclSend(sendbuff, SizeT(size), ncclFloat, 1, comm, s))
+        ncclCheck(ncclRecv(recvbuff, SizeT(size), ncclFloat, 0, comm, s))
+        ncclCheck(ncclGroupEnd())
+
+        cudaCall(cudaStreamSynchronize(s))
+
+        // check results
+        cudaCall(cudaMemcpy[Float](zero, sendbuff, SizeT(size), device2host))
+        for (i <- (0 until size): Rep[Range]) {
+          if (zero(0) != 1) {
+            printf("error")
+          }
+        }
+        cudaCall(cudaMemcpy[Float](one, recvbuff, SizeT(size), device2host))
+        for (i <- (0 until size): Rep[Range]) {
+          if (one(0) != 0) {
+            printf("error")
+          }
+        }
+
+        // free device buffers
+        cudaCall(cudaFree(sendbuff))
+        cudaCall(cudaFree(recvbuff))
+
+        // finalizing NCCL
+        ncclCheck(ncclCommDestroy(comm))
+
+        // finalizing MPI
+        MPI_CHECK(mpi_finalize())
+
+        printf("[MPI Rank %d] Success \n", myRank)
+      }
+    }
+    // System.out.println(indent(driver.code))
+    check("p2p-sendrecv", driver.code, "cu")
+  }
+  
+  test("p2p-scatter") {
+    val driver = new DslDriverCNCCL[Int, Unit] {
+      @virtualize
+      def snippet(arg:Rep[Int]) = {
+        val size = 32*1024*1024
+        var myRank = 0
+        var nRanks = 0
+        val localRank = 0
+
+        // initializing MPI
+        MPI_CHECK(mpi_init())
+        MPI_CHECK(mpi_comm_rank(mpi_comm_world, myRank))
+        MPI_CHECK(mpi_comm_size(mpi_comm_world, nRanks))
+
+        // calculating localRank
+        // for now, localRank = 0
+
+        // get NCCL unique ID at rank 0 and broadcast it to all others
+        var id = ncclUniqueId
+        if (myRank == 0) {
+          ncclCheck(ncclGetUniqueId(id))
+        }
+        MPI_CHECK(mpi_bcast_one(id, ncclUniqueIdBytes, mpi_byte, 0, mpi_comm_world))
+
+        // picking a GPU based on localRank
+        cudaCall(cudaSetDevice(localRank))
+
+        val s = cudaStream
+        cudaCall(cudaStreamCreateWithFlags(s, cudaStreamDefault))
+
+        // initializing NCCL
+        val comm = ncclComm
+        ncclCheck(ncclCommInitRank(comm, nRanks, id, myRank))
+
+        // allocte and initialize buffers
+        val one = NewArray[Float](size)
+        for (i <- (0 until size): Rep[Range]) {
+          one(i) = 1
+        }
+        val sendbuff = NewArray[Array[Float]](nRanks)
+        for (i <- (0 until nRanks): Rep[Range]) {
+          cudaCall(cudaMalloc[Float](sendbuff(i), SizeT(size)))
+          cudaCall(cudaMemcpy[Float](sendbuff(i), one, SizeT(size), host2device))
+        }
+        val recvbuff = cudaMalloc2[Float](size)
+        
+        
+        // one-to-all (scatter)
+        ncclCheck(ncclGroupStart())
+        if (myRank == localRank) {
+          for (i <- (0 until nRanks): Rep[Range]) {
+            ncclCheck(ncclSend(sendbuff(i), SizeT(size), ncclFloat, i, comm, s))
+          }
+          ncclCheck(ncclRecv(recvbuff, SizeT(size), ncclFloat, 0, comm, s))
+        }
+        ncclCheck(ncclGroupEnd())
+
+        cudaCall(cudaStreamSynchronize(s))
+
+        // check results
+        cudaCall(cudaMemcpy[Float](one, recvbuff, SizeT(size), device2host))
+        for (i <- (0 until size): Rep[Range]) {
+          if (one(0) != 1) {
+            printf("error")
+          }
+        }
+
+        // free device buffers
+        cudaCall(cudaFree(sendbuff))
+        cudaCall(cudaFree(recvbuff))
+
+        // finalizing NCCL
+        ncclCheck(ncclCommDestroy(comm))
+
+        // finalizing MPI
+        MPI_CHECK(mpi_finalize())
+
+        printf("[MPI Rank %d] Success \n", myRank)
+      }
+    }
+    // System.out.println(indent(driver.code))
+    check("p2p-scatter", driver.code, "cu")
+  }
+
+  test("p2p-gather") {
+    val driver = new DslDriverCNCCL[Int, Unit] {
+      @virtualize
+      def snippet(arg:Rep[Int]) = {
+        val size = 32*1024*1024
+        var myRank = 0
+        var nRanks = 0
+        val localRank = 0
+
+        // initializing MPI
+        MPI_CHECK(mpi_init())
+        MPI_CHECK(mpi_comm_rank(mpi_comm_world, myRank))
+        MPI_CHECK(mpi_comm_size(mpi_comm_world, nRanks))
+
+        // calculating localRank
+        // for now, localRank = 0
+
+        // get NCCL unique ID at rank 0 and broadcast it to all others
+        var id = ncclUniqueId
+        if (myRank == 0) {
+          ncclCheck(ncclGetUniqueId(id))
+        }
+        MPI_CHECK(mpi_bcast_one(id, ncclUniqueIdBytes, mpi_byte, 0, mpi_comm_world))
+
+        // picking a GPU based on localRank
+        cudaCall(cudaSetDevice(localRank))
+
+        val s = cudaStream
+        cudaCall(cudaStreamCreateWithFlags(s, cudaStreamDefault))
+
+        // initializing NCCL
+        val comm = ncclComm
+        ncclCheck(ncclCommInitRank(comm, nRanks, id, myRank))
+
+        // allocate and initialize buffers
+        val sendbuff = cudaMalloc2[Float](size)
+        val one = NewArray[Float](size)
+        for (i <- (0 until size): Rep[Range]) {
+          one(i) = 1
+        }
+        val recvbuff = NewArray[Array[Float]](nRanks)
+        for (i <- (0 until nRanks): Rep[Range]) {
+          cudaCall(cudaMalloc[Float](recvbuff(i), SizeT(size)))
+          cudaCall(cudaMemcpy[Float](recvbuff(i), one, SizeT(size), host2device))
+        }
+        
+        // one-to-all (scatter)
+        ncclCheck(ncclGroupStart())
+        if (myRank == localRank) {
+          for (i <- (0 until nRanks): Rep[Range]) {
+            ncclCheck(ncclRecv(recvbuff(i), SizeT(size), ncclFloat, i, comm, s))
+          }
+          ncclCheck(ncclSend(sendbuff, SizeT(size), ncclFloat, 0, comm, s))
+        }
+        ncclCheck(ncclGroupEnd())
+
+        cudaCall(cudaStreamSynchronize(s))
+
+        // check results
+        cudaCall(cudaMemcpy[Float](one, sendbuff, SizeT(size), device2host))
+        for (i <- (0 until size): Rep[Range]) {
+          if (one(0) != 1) {
+            printf("error")
+          }
+        }
+
+        // free device buffers
+        cudaCall(cudaFree(sendbuff))
+        cudaCall(cudaFree(recvbuff))
+
+        // finalizing NCCL
+        ncclCheck(ncclCommDestroy(comm))
+
+        // finalizing MPI
+        MPI_CHECK(mpi_finalize())
+
+        printf("[MPI Rank %d] Success \n", myRank)
+      }
+    }
+    // System.out.println(indent(driver.code))
+    check("p2p-gather", driver.code, "cu")
+  }
+
+  test("p2p-all2all") {
+    val driver = new DslDriverCNCCL[Int, Unit] {
+      @virtualize
+      def snippet(arg:Rep[Int]) = {
+        val size = 32*1024*1024
+        var myRank = 0
+        var nRanks = 0
+        val localRank = 0
+
+        // initializing MPI
+        MPI_CHECK(mpi_init())
+        MPI_CHECK(mpi_comm_rank(mpi_comm_world, myRank))
+        MPI_CHECK(mpi_comm_size(mpi_comm_world, nRanks))
+
+        // calculating localRank
+        // for now, localRank = 0
+
+        // get NCCL unique ID at rank 0 and broadcast it to all others
+        var id = ncclUniqueId
+        if (myRank == 0) {
+          ncclCheck(ncclGetUniqueId(id))
+        }
+        MPI_CHECK(mpi_bcast_one(id, ncclUniqueIdBytes, mpi_byte, 0, mpi_comm_world))
+
+        // picking a GPU based on localRank
+        cudaCall(cudaSetDevice(localRank))
+
+        val s = cudaStream
+        cudaCall(cudaStreamCreateWithFlags(s, cudaStreamDefault))
+
+        // initializing NCCL
+        val comm = ncclComm
+        ncclCheck(ncclCommInitRank(comm, nRanks, id, myRank))
+
+        // allocate and initialize buffers
+        val one = NewArray[Float](size)
+        for (i <- (0 until size): Rep[Range]) {
+          one(i) = 1
+        }
+        val sendbuff = NewArray[Array[Float]](nRanks)
+        for (i <- (0 until nRanks): Rep[Range]) {
+          cudaCall(cudaMalloc[Float](sendbuff(i), SizeT(size)))
+          cudaCall(cudaMemcpy[Float](sendbuff(i), one, SizeT(size), host2device))
+        }
+        val recvbuff = NewArray[Array[Float]](nRanks)
+        for (i <- (0 until nRanks): Rep[Range]) {
+          cudaCall(cudaMalloc[Float](recvbuff(i), SizeT(size)))
+        }
+        
+        // all-to-all
+        ncclCheck(ncclGroupStart())
+        if (myRank == localRank) {
+          for (i <- (0 until nRanks): Rep[Range]) {
+            ncclCheck(ncclSend(sendbuff(i), SizeT(size), ncclFloat, i, comm, s))
+            ncclCheck(ncclRecv(recvbuff(i), SizeT(size), ncclFloat, i, comm, s))
+          }
+        }
+        ncclCheck(ncclGroupEnd())
+
+        cudaCall(cudaStreamSynchronize(s))
+
+        // check results
+        for (i <- (0 until size): Rep[Range]) {
+          cudaCall(cudaMemcpy[Float](one, recvbuff(i), SizeT(size), device2host))
+          if (one(0) != 1) {
+            printf("error")
+          }
+        }
+
+        // free device buffers
+        cudaCall(cudaFree(sendbuff))
+        cudaCall(cudaFree(recvbuff))
+
+        // finalizing NCCL
+        ncclCheck(ncclCommDestroy(comm))
+
+        // finalizing MPI
+        MPI_CHECK(mpi_finalize())
+
+        printf("[MPI Rank %d] Success \n", myRank)
+      }
+    }
+    // System.out.println(indent(driver.code))
+    check("p2p-all2all", driver.code, "cu")
   }
 }
 

--- a/src/test/scala/lms/thirdparty/test_nccl.scala
+++ b/src/test/scala/lms/thirdparty/test_nccl.scala
@@ -329,7 +329,7 @@ class NCCLTest extends TutorialFunSuite {
     val driver = new DslDriverCNCCL[Int, Unit] {
       @virtualize
       def snippet(arg:Rep[Int]) = {
-        val size = 2014
+        val size = 1024
         var myRank = 0
         var nRanks = 0
 
@@ -359,7 +359,7 @@ class NCCLTest extends TutorialFunSuite {
         cudaCall(cudaSetDevice(myRank))
         val sendbuff = NewArray[Array[Float]](nRanks)
         for (i <- (0 until nRanks): Rep[Range]) {
-          cudaCall(cudaMalloc[Float](sendbuff(i), SizeT(size)))
+          cudaCall(cudaMalloc3[Float](sendbuff(i), size))
           cudaCall(cudaMemcpyOfT[Float](sendbuff(i), values, size, host2device))
         }
         val recvbuff = cudaMalloc2[Float](size)


### PR DESCRIPTION
add four more test cases (p2p) for NCCL. Modified `remap` in cuda.scala and nccl.scala to map NCCL_Result and CudaErrorT types correctly.