### PR TITLE
`Manifest` -> `Type` change proposal

### DIFF
--- a/src/main/scala/lms/core/types.scala
+++ b/src/main/scala/lms/core/types.scala
@@ -1,0 +1,143 @@
+package lms.core
+
+import lms.core.Backend.{Const, Exp, Sym}
+import lms.core.TypeMap.TypeExp
+
+import scala.collection.mutable
+
+object BaseTypeNames {
+  val Unit        = "Unit"
+  val Boolean     = "Boolean"
+  val Char        = "Char"
+  val Short       = "Short"
+  val Int         = "Int"
+  val Float       = "Float"
+  val Double      = "Double"
+  val String      = "String"
+  val Array       = "Array"
+}
+
+object Reflect {
+  def unapply(x: Any)(implicit tm: TypeMap): Option[(String, List[Exp])] = x match {
+    case s@Sym(_) =>
+      tm.g.findDefinition(s).map(n => (n.op, n.rhs.filter(_.isInstanceOf[Exp]).map(_.asInstanceOf[Exp])))
+    case _ => None
+  }
+}
+
+abstract class Type[T] {
+  def reify(x: Exp, tm: TypeMap): TypeMap.TypeExp
+}
+
+abstract class SimpleType[T] extends Type[T] {
+  def reify(x: Exp, tm: TypeMap): TypeMap.TypeExp = reify(tm)
+  def reify(tm: TypeMap): TypeMap.TypeExp
+}
+
+object TypeExp {
+  def of[T](x: Exp)(implicit t: Type[T], typeMap: TypeMap): TypeMap.TypeExp = t.reify(x, typeMap)
+}
+
+object TypeNames {
+  // TODO maybe Int?
+  val Unit:     String = "Unit"
+  val Boolean:  String = "Boolean"
+  val Char:     String = "Char"
+  val Short:    String = "Short"
+  val Int:      String = "Int"
+  val Float:    String = "Float"
+  val Double:   String = "Double"
+
+  val Array:    String = "Array"
+}
+
+object TypeConstants {
+  val Unit:     TypeExp = Const(TypeNames.Unit)
+  val Boolean:  TypeExp = Const(TypeNames.Boolean)
+  val Char:     TypeExp = Const(TypeNames.Char)
+  val Short:    TypeExp = Const(TypeNames.Short)
+  val Int:      TypeExp = Const(TypeNames.Int)
+  val Float:    TypeExp = Const(TypeNames.Float)
+  val Double:   TypeExp = Const(TypeNames.Double)
+}
+
+object ImplicitTypes {
+  import TypeConstants._
+  implicit val TUnit:     SimpleType[Unit]    = _ => Unit
+  implicit val TBoolean:  SimpleType[Boolean] = _ => Boolean
+  implicit val TChar:     SimpleType[Char]    = _ => Char
+  implicit val TShort:    SimpleType[Short]   = _ => Short
+  implicit val TInt:      SimpleType[Int]     = _ => Int
+  implicit val TFloat:    SimpleType[Float]   = _ => Float
+  implicit val TDouble:   SimpleType[Double]  = _ => Double
+
+  object Array {
+    def unapply(x: Any)(implicit tm: TypeMap): Option[TypeExp] = x match {
+      case Reflect(TypeNames.Array, t :: Nil) => Some(t)
+    }
+  }
+
+  implicit def mkTArray[T](implicit te: SimpleType[T]): SimpleType[Array[T]] =
+    (tm: TypeMap) => tm.g.reflect(TypeNames.Array, te.reify(tm))
+}
+
+case class Tensor[T:Type](shape: Const)
+
+object Tensor {
+  val name = "Tensor"
+
+  def unapply(x: Any)(implicit tm: TypeMap): Option[TypeExp] = x match {
+    case Reflect(Tensor.name, t :: Nil) => Some(t)
+  }
+
+  implicit def mkTensorType[T:SimpleType]: Type[Tensor[T]] = (_: Exp, tm: TypeMap) =>
+    tm.g.reflect(Tensor.name, implicitly[SimpleType[T]].reify(tm)/*, shape */)
+}
+
+
+case class TypeMap(g: GraphBuilder) extends mutable.HashMap[Exp, TypeExp]
+
+object TypeMap {
+
+  type TypeExp = Exp
+  def apply(): TypeMap = {
+    // TODO:  should we have the same GraphBuilder for types
+    //        and backend or can we refactor it
+    //        to share some code?
+    val g = new GraphBuilder
+    // TODO:  why is `g` initialized without any `curLocalDefs`?
+    //        What about `curLocalReads` etc which are not used yet.
+    g.curLocalDefs = Set()
+    TypeMap(g)
+  }
+
+}
+
+object Main {
+
+  def main(args: Array[String]): Unit = {
+    import TypeConstants._
+    import ImplicitTypes._
+    implicit val tm: TypeMap = TypeMap()
+
+    def Wrap[A:Type](x: lms.core.Backend.Exp): Unit = tm(x) = TypeExp.of[A](x)
+
+    val s1 = Sym(10)
+    val s2 = Sym(20)
+
+    Wrap[Array[Array[Float]]](s1)
+    Wrap[Array[Array[Int]]](s2)
+
+    tm(s1) match {
+      case Array(Array(t)) => println(s"element type $t")
+    }
+
+    tm(s2) match {
+      case Array(Array(Int)) => println("is Int")
+    }
+
+    println(tm)
+    println(tm.g.globalDefsCache)
+  }
+
+}


### PR DESCRIPTION
This PR introduces a `Type` typeclass based representation of types in LMS.

This implementation is based on the one present on [the previous version of LMS](https://github.com/TiarkRompf/virtualization-lms-core/blob/1f2f9b4423189f8ea55dd7d0d3c939d9418dc8cb/src/internal/Expressions.scala#L18-L54) and the one presented in
["Reflections on LMS: exploring front-end alternatives"](https://dl.acm.org/doi/abs/10.1145/2998392.2998399).

## Rationale

LMS relies on `Manifest`s in `Adapter.typeMap` for keeping track of types of nodes in the graph. Although manifests are in general only used in the backend for code generation, there are cases where we would like to provide additional information in the types of the nodes.
This has so far been overcome in ad-hoc ways adding this information at the `Node` level outside of the `typeMap` ([example1](https://github.com/Angelogeb/lms-clean/blob/0e54eca4ac4e7a478b38878c02eb5922c0e0ab28/src/main/scala/lms/collection/ListOps.scala#L123-L124), [example2](https://github.com/TiarkRompf/lms-clean/blob/5b029658fe2639122291d942423177d495a83ef5/src/main/scala/lms/transformation/distributed_tensor/distributedTensorBase.scala#L99-L105)). Although convenient, this is not uniform and requires additional code to keep the information in sync between the `typeMap` and the nodes.

### Design
* The `typeMap` is updated from a `Map[Exp, Manifest[_]]` to `Map[Exp, TypeExp]`.
* Types are represented as graph terms. This might allow using LMS in new contexts.
* Types are reflected on the graph by `Wrap`
* To introduce new types a `Type` instance must be provided
* The `Type` type class provides two `reify` methods: one for simple types and one for types
  that might need to inspect the `Exp`ression before reflecting a type (in the case of the tensors example2 above,
  this allows to promote the shape to the type level). I am not sure about the latter design decision and if there are
  alternatives.

### Open questions
* Should the type nodes be in the same graph as the expressions?
  * Do we have to change some parts of the backend to ignore such nodes or are they ignored by default?


## Tasks

- [x] Typeclass sketch with example in Main to be deleted
- [ ] Extend interface for easier migration (equivalent of `manifest[]` etc.)
- [ ] `Adapter.typeMap` and  `Adapter.oldTypeMap`: `HashMap[Exp, Manifest[_]]` -> `HashMap[Exp, TypeExp]`
- [ ] `Wrap[T:Manifest]` -> `Wrap[T:Type]`
- [ ] Update code using `Manifest` to `Type`
  - This will be a bit time consuming because the usage of Manifests hasn't been abstracted away using [`UtilOps`](https://github.com/TiarkRompf/lms-clean/blob/5b029658fe2639122291d942423177d495a83ef5/src/main/scala/lms/core/stub.scala#L649-L665) which would have
    allowed using refactoring tools.