### PR TITLE
[AIRCOP] some fix on cudnn ops

### DIFF
--- a/src/main/scala/lms/thirdparty/cuda/cublas.scala
+++ b/src/main/scala/lms/thirdparty/cuda/cublas.scala
@@ -141,7 +141,7 @@ object CUBLASTypeLess extends Dsl with CLibs {
     ldc: leading dimension of two-dimensional array used to store matrix C
     */
     def CUBLAS_SGEMM(handle: CUBLAS_HANDLE, transa: CUBLAS_OPERATION, transb: CUBLAS_OPERATION,
-                    m: INT, n: INT, k: INT, alpha: FLOAT, A: ARRAY, lda: INT, B: ARRAY, ldb: INT, beta: FLOAT, C: ARRAY, ldc: INT)(implicit __pos: SourceContext) = {
+                    m: INT, n: INT, k: INT, alpha: VAR, A: ARRAY, lda: INT, B: ARRAY, ldb: INT, beta: VAR, C: ARRAY, ldc: INT)(implicit __pos: SourceContext) = {
       assert(A.et == manifest[Float] && B.et == manifest[Float] && C.et == manifest[Float])
       CUBLAS_CALL(Unwrap(libFunction[Any]("cublasSgemm", handle.x, transa.x, transb.x, m.x, n.x, k.x, alpha.x,
         A.x, lda.x, B.x, ldb.x, beta.x, C.x, ldc.x)(Seq(0,7,9,12), Seq(12), Set(6, 11))))

--- a/src/main/scala/lms/thirdparty/cuda/cudnnPooling.scala
+++ b/src/main/scala/lms/thirdparty/cuda/cudnnPooling.scala
@@ -44,7 +44,7 @@ trait CUDNNPoolingTypeLess extends Dsl with CLibs with CUDNNBaseTypeLess {
 
     def CUDNN_POOLING_BWD(handle: TOP, poolingDesc: CUDNN_POOLING_DESCRIPTOR, alpha: VAR, yDesc: TOP,
                           y: TOP, dyDesc: TOP, dy: TOP, xDesc: TOP, xData: TOP,
-                          beta: VAR, dxDesc: TOP, dx: TOP) =
+                          beta: VAR, dxDesc: TOP, dx: TOP)(implicit __pos: SourceContext) =
     LIB_FUNCTION(manifest[CUDNN_RESULT], "cudnnPoolingBackward", handle.x, poolingDesc.x, alpha.x, yDesc.x, y.x, dyDesc.x, dy.x,
       xDesc.x, xData.x, beta.x, dxDesc.x, dx.x)(Seq(0,1,2,3,4,5,6,7,8,9,10), Seq(11), Set[Int](2,9))
   

--- a/src/main/scala/lms/thirdparty/cuda/cudnnPooling.scala
+++ b/src/main/scala/lms/thirdparty/cuda/cudnnPooling.scala
@@ -16,6 +16,38 @@ trait CUDNNPoolingTypeLess extends Dsl with CLibs with CUDNNBaseTypeLess {
   import CLibTypeLess._
 
   class CUDNN_POOLING_DESCRIPTOR(override val x: Backend.Exp) extends TOP(x)
+
+  def CUDNN_POOLING_MAX(implicit __pos: SourceContext) = CMACRO("CUDNN_POOLING_MAX", manifest[Int])
+  def CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING(implicit __pos: SourceContext) = CMACRO("CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING", manifest[Int])
+  def CUDNN_POOLING_AVERAGE_COUNT_EXCLUDE_PADDING(implicit __pos: SourceContext) = CMACRO("CUDNN_POOLING_AVERAGE_COUNT_EXCLUDE_PADDING", manifest[Int])
+  def CUDNN_POOLING_MAX_DETERMINISTIC(implicit __pos: SourceContext) = CMACRO("CUDNN_POOLING_MAX_DETERMINISTIC", manifest[Int])
+
+  def CUDNN_CREATE_POOLING_DESCRIPTOR(poolingDesc: CUDNN_POOLING_DESCRIPTOR)(implicit __pos: SourceContext) =
+    LIB_FUNCTION(manifest[CUDNN_RESULT], "cudnnCreatePoolingDescriptor", poolingDesc.x)(Seq(), Seq(0), Set[Int](0))
+
+  def CUDNN_DESTROY_POOLING_DESCRIPTOR(poolingDesc: TOP)(implicit __pos: SourceContext) = 
+    LIB_FUNCTION(manifest[CUDNN_RESULT], "cudnnDestroyPoolingDescriptor", poolingDesc.x)(Seq(), Seq(0), Set[Int]())
+   
+  def CUDNN_SET_POOLING_2D_DESCRIPTOR(poolingDesc: CUDNN_POOLING_DESCRIPTOR, mode: TOP, maxpoolingNanOpt: TOP, windowHeight: INT, windowWidth: INT,
+                                      verticalPadding: INT, horizontalPadding: INT, verticalStride: INT, horizontalStride: INT)(implicit __pos: SourceContext) =
+    LIB_FUNCTION(manifest[CUDNN_RESULT], "cudnnSetPooling2dDescriptor", poolingDesc.x, mode.x, maxpoolingNanOpt.x, windowHeight.x, windowWidth.x,
+      verticalPadding.x, horizontalPadding.x, verticalStride.x, horizontalStride.x)(Seq(1,2,3,4,5,6,7,8), Seq(0), Set[Int]())
+
+  def CUDNN_GET_POOLING_2D_FWD_OUTPUT_DIM(poolingDesc: CUDNN_POOLING_DESCRIPTOR, inputDesc: TOP, n: INT, c: INT, h: INT, w: INT)(implicit __pos: SourceContext) =
+    LIB_FUNCTION(manifest[CUDNN_RESULT], "cudnnGetPooling2dForwardOutputDim", poolingDesc.x, inputDesc.x, n.x, c.x, h.x, w.x)(Seq(0,1), Seq(2,3,4,5),
+      Set[Int](2,3,4,5))
+  
+  def CUDNN_POOLING_FWD(handle: TOP, poolingDesc: CUDNN_POOLING_DESCRIPTOR, alpha: VAR, xDesc: TOP,
+                          x: TOP, beta: VAR, yDesc: TOP, y: TOP)(implicit __pos: SourceContext) =
+    LIB_FUNCTION(manifest[CUDNN_RESULT], "cudnnPoolingForward", handle.x, poolingDesc.x, alpha.x, xDesc.x, x.x, beta.x, yDesc.x,
+      y.x)(Seq(0,1,2,3,4,5,6), Seq(2,5,7), Set[Int](2,5))
+
+    def CUDNN_POOLING_BWD(handle: TOP, poolingDesc: CUDNN_POOLING_DESCRIPTOR, alpha: VAR, yDesc: TOP,
+                          y: TOP, dyDesc: TOP, dy: TOP, xDesc: TOP, xData: TOP,
+                          beta: VAR, dxDesc: TOP, dx: TOP) =
+    LIB_FUNCTION(manifest[CUDNN_RESULT], "cudnnPoolingBackward", handle.x, poolingDesc.x, alpha.x, yDesc.x, y.x, dyDesc.x, dy.x,
+      xDesc.x, xData.x, beta.x, dxDesc.x, dx.x)(Seq(0,1,2,3,4,5,6,7,8,9,10), Seq(11), Set[Int](2,9))
+  
 }
 
 trait CUDNNPoolingOps extends CLibs with CudaOps with CUDNNBaseOps {

--- a/src/main/scala/lms/transformation/deviced_tensor/devicedTensor2array.scala
+++ b/src/main/scala/lms/transformation/deviced_tensor/devicedTensor2array.scala
@@ -16,6 +16,7 @@ import Backend._
 // respect device allocation (simple distinction of GPU and CPU)
 abstract class DevicedTensorLowering extends Transformer {
 
+  import BaseTypeLess._
   import PrimitiveTypeLess._
   import ArrayTypeLess._
   import ArrayCPUTypeLess._
@@ -163,8 +164,8 @@ abstract class DevicedTensorLowering extends Transformer {
           val m = INT(x_shape(0))
           val n = INT(y_shape(1))
           val k = INT(x_shape(1))
-          CUBLAS_SGEMM(CUBLAS_HANDLE, CUBLAS_OP_N, CUBLAS_OP_N, n, m, k, ONE, new ARRAY(transform(y)), n, new ARRAY(transform(x)),
-            k, ZERO, res, n)
+          CUBLAS_SGEMM(CUBLAS_HANDLE, CUBLAS_OP_N, CUBLAS_OP_N, n, m, k, VAR(ONE), new ARRAY(transform(y)), n, new ARRAY(transform(x)),
+            k, VAR(ZERO), res, n)
         } else {
           throw new Exception("dot for higher than 2D is not yet supported")
         }

--- a/src/main/scala/lms/transformation/distributed_tensor/distributedTensorConv.scala
+++ b/src/main/scala/lms/transformation/distributed_tensor/distributedTensorConv.scala
@@ -297,9 +297,15 @@ trait FixedSizeDistributedTensorOpsConv extends FixedSizeDistributedTensorOpsBas
       ((0 until 1): Range).toList.map(i => Wrap[Tensor[T]](TENSORS.getResult(op, i).x))
     }
 
-    def pooling(anno: Anno, params: PoolingParam)(implicit __pos: SourceContext): Rep[Tensor[T]] = {
+    def maxpool(anno: Anno, params: PoolingParam, deterministic: Boolean = false)(implicit __pos: SourceContext): Rep[Tensor[T]] = {
       val self = tensor(x)
-      val t = PoolingForward(self, params, "max", anno, __pos)
+      val t = PoolingForward(self, params, if (deterministic) "max_dtm" else "max", anno, __pos)
+      Wrap[Tensor[T]](t.x)
+    }
+
+    def avgpool(anno: Anno, params: PoolingParam, include_pad: Boolean = false)(implicit __pos: SourceContext): Rep[Tensor[T]] = {
+      val self = tensor(x)
+      val t = PoolingForward(self, params, if (include_pad) "avg_in_pad" else "avg_ex_pad", anno, __pos)
       Wrap[Tensor[T]](t.x)
     }
   }

--- a/src/main/scala/lms/transformation/distributed_tensor/distributedTensorConv.scala
+++ b/src/main/scala/lms/transformation/distributed_tensor/distributedTensorConv.scala
@@ -257,6 +257,7 @@ trait FixedSizeDistributedTensorOpsConv extends FixedSizeDistributedTensorOpsBas
       Wrap[Tensor[T]](t.x)
     }
 
+    // move to new file
     val softmax_params_def = SoftmaxParam(1.0f, 0.0f)
     def softmax(anno: Anno, params: SoftmaxParam = softmax_params_def)(implicit __pos: SourceContext): Rep[Tensor[T]] = {
       val t = SoftmaxForward(self, params, anno, __pos)
@@ -270,7 +271,7 @@ trait FixedSizeDistributedTensorOpsConv extends FixedSizeDistributedTensorOpsBas
       Wrap[Tensor[T]](t.x)
     }
     
-    def tanh(anno: Anno)(implicit __pos: SourceContext): Rep[Tensor[T]] = {
+    def cudnn_tanh(anno: Anno)(implicit __pos: SourceContext): Rep[Tensor[T]] = {
       val self = tensor(x)
       val p = ActivationParam(1.0f, 0.0f, 0.0f)
       val t = ActivationForward(self, p, "tanh", anno, __pos)

--- a/src/main/scala/lms/transformation/distributed_tensor/distributedTensorConv.scala
+++ b/src/main/scala/lms/transformation/distributed_tensor/distributedTensorConv.scala
@@ -230,24 +230,18 @@ trait FixedSizeDistributedTensorOpsConv extends FixedSizeDistributedTensorOpsBas
     }
 
     // clipped relu
-    def crelu(threshold: Float, anno: Anno)(implicit __pos: SourceContext): Rep[Tensor[T]] = {
+    def relu(threshold: Float, anno: Anno)(implicit __pos: SourceContext): Rep[Tensor[T]] = {
       val self = tensor(x)
       val p = ActivationParam(1.0f, 0.0f, threshold)
       val t = ActivationForward(self, p, "crelu", anno, __pos)
       Wrap[Tensor[T]](t.x)
     }
 
-    def relu(upper_bound: Float, anno: Anno)(implicit __pos: SourceContext): Rep[Tensor[T]] = {
+    def elu(alpha: Float, anno: Anno)(implicit __pos: SourceContext): Rep[Tensor[T]] = {
       val self = tensor(x)
-      val p = ActivationParam(1.0f, 0.0f, upper_bound)
-      val t = ActivationForward(self, p, "relu", anno, __pos)
-      Wrap[Tensor[T]](t.x)
-    }
-
-    def elu(anno: Anno)(implicit __pos: SourceContext): Rep[Tensor[T]] = {
-      val self = tensor(x)
-      val p = ActivationParam(1.0f, 0.0f, 0.0f)
+      val p = ActivationParam(1.0f, 0.0f, alpha)
       val t = ActivationForward(self, p, "elu", anno, __pos)
+      Wrap[Tensor[T]](t.x)
     }
     
     def dropout(anno: Anno, params: DropoutParam = dropout_params_def)(implicit __pos: SourceContext): List[Rep[Tensor[T]]] = {

--- a/src/main/scala/lms/transformation/distributed_tensor/distributedTensorConv.scala
+++ b/src/main/scala/lms/transformation/distributed_tensor/distributedTensorConv.scala
@@ -224,9 +224,30 @@ trait FixedSizeDistributedTensorOpsConv extends FixedSizeDistributedTensorOpsBas
     
     def tanh(anno: Anno)(implicit __pos: SourceContext): Rep[Tensor[T]] = {
       val self = tensor(x)
-       val p = ActivationParam(1.0f, 0.0f, 0.0f)
+      val p = ActivationParam(1.0f, 0.0f, 0.0f)
       val t = ActivationForward(self, p, "tanh", anno, __pos)
       Wrap[Tensor[T]](t.x)
+    }
+
+    // clipped relu
+    def crelu(threshold: Float, anno: Anno)(implicit __pos: SourceContext): Rep[Tensor[T]] = {
+      val self = tensor(x)
+      val p = ActivationParam(1.0f, 0.0f, threshold)
+      val t = ActivationForward(self, p, "crelu", anno, __pos)
+      Wrap[Tensor[T]](t.x)
+    }
+
+    def relu(upper_bound: Float, anno: Anno)(implicit __pos: SourceContext): Rep[Tensor[T]] = {
+      val self = tensor(x)
+      val p = ActivationParam(1.0f, 0.0f, upper_bound)
+      val t = ActivationForward(self, p, "relu", anno, __pos)
+      Wrap[Tensor[T]](t.x)
+    }
+
+    def elu(anno: Anno)(implicit __pos: SourceContext): Rep[Tensor[T]] = {
+      val self = tensor(x)
+      val p = ActivationParam(1.0f, 0.0f, 0.0f)
+      val t = ActivationForward(self, p, "elu", anno, __pos)
     }
     
     def dropout(anno: Anno, params: DropoutParam = dropout_params_def)(implicit __pos: SourceContext): List[Rep[Tensor[T]]] = {

--- a/src/main/scala/lms/transformation/mpi_nccl_transformation/distributedTensor2MPINCCL.scala
+++ b/src/main/scala/lms/transformation/mpi_nccl_transformation/distributedTensor2MPINCCL.scala
@@ -26,20 +26,13 @@ class DistributeTensor2MPI_NCCLAnalysis extends Traverser {
     var hasCublas = false
     var hasCudnn = false
 
+    val cudnn_ops = List("tensor_conv", "tensor_softmax", "tensor_activation", "tensors_dropout")
+
     override def traverse(n: Node): Unit = n match {
         case Node(s, op, _, _) if op.startsWith("tensor_dot") =>
             hasCublas = true
             super.traverse(n)
-        case Node(s, op, _, _) if op.startsWith("tensor_conv") =>
-            hasCudnn = true
-            super.traverse(n)
-        case Node(s, op, _, _) if op.startsWith("tensor_softmax") =>
-            hasCudnn = true
-            super.traverse(n)
-        case Node(s, op, _, _) if op.startsWith("tensor_activation") =>
-            hasCudnn = true
-            super.traverse(n)
-        case Node(s, op, _, _) if op.startsWith("tensors_dropout") =>
+        case Node(s, op, _, _) if cudnn_ops.exists(op.startsWith) =>
             hasCudnn = true
             super.traverse(n)
         case _ => super.traverse(n)

--- a/src/main/scala/lms/transformation/mpi_nccl_transformation/distributedTensor2MPINCCL.scala
+++ b/src/main/scala/lms/transformation/mpi_nccl_transformation/distributedTensor2MPINCCL.scala
@@ -26,7 +26,7 @@ class DistributeTensor2MPI_NCCLAnalysis extends Traverser {
     var hasCublas = false
     var hasCudnn = false
 
-    val cudnn_ops = List("tensor_conv", "tensor_softmax", "tensor_activation", "tensors_dropout")
+    val cudnn_ops = List("tensor_conv", "tensor_softmax", "tensor_activation", "tensors_dropout", "tensor_pooling")
 
     override def traverse(n: Node): Unit = n match {
         case Node(s, op, _, _) if op.startsWith("tensor_dot") =>

--- a/src/main/scala/lms/transformation/mpi_nccl_transformation/distributedTensor2MPINCCLBase.scala
+++ b/src/main/scala/lms/transformation/mpi_nccl_transformation/distributedTensor2MPINCCLBase.scala
@@ -49,14 +49,12 @@ abstract class DistributeTensor2MPI_NCCLBase extends Transformer with MPIOps wit
     CUDA_MALLOC(size, m)
   }
 
-  // TODO: change it to better name, and add INT counterparts to other gpu functions as well
-  def gpu_array1(size: INT, m: Manifest[_], device: INT)(implicit __pos: SourceContext): ARRAY = {
+  def GPU_ARRAY(size: INT, m: Manifest[_], device: INT)(implicit __pos: SourceContext): ARRAY = {
     CUDA_SET_DEVICE(device)
     CUDA_MALLOC(size, m)
   }
 
-  // TODO: change it to better name, and add INT counterparts to other gpu functions as well
-  def gpu_array1_by_byte(size: INT, m: Manifest[_], device: INT)(implicit __pos: SourceContext): ARRAY = {
+  def GPU_ARRAY_BY_BYTE(size: INT, m: Manifest[_], device: INT)(implicit __pos: SourceContext): ARRAY = {
     CUDA_SET_DEVICE(device)
     CUDA_MALLOC_BYTES(size, m)
   }

--- a/src/main/scala/lms/transformation/mpi_nccl_transformation/distributedTensor2MPINCCLBase.scala
+++ b/src/main/scala/lms/transformation/mpi_nccl_transformation/distributedTensor2MPINCCLBase.scala
@@ -134,6 +134,7 @@ abstract class DistributeTensor2MPI_NCCLBase extends Transformer with MPIOps wit
   var cudnnTensor2Desc: HashMap[Seq[Int], (TOP, String)] = HashMap()
   var cudnnConv2Desc: HashMap[Seq[Int], CUDNN_CONV_DESCRIPTOR] = HashMap()
   var cudnnActv2Desc: HashMap[(String, Float), CUDNN_ACTIVATION_DESCRIPTOR] = HashMap()
+  var cudnnPool2Desc: HashMap[(String, Seq[Int]), CUDNN_POOLING_DESCRIPTOR] = HashMap()
   def set_up_cudnn(implicit __pos: SourceContext) = {
     val dummy = myCUDNNComm
     // cudnnTensor2Desc = HashMap()  // todo: FIXME
@@ -150,6 +151,9 @@ abstract class DistributeTensor2MPI_NCCLBase extends Transformer with MPIOps wit
     }
     cudnnActv2Desc foreach {
       case (_, desc) => CUDNN_DESTROY_ACTIVATION_DESCRIPTOR(desc)
+    }
+    cudnnPool2Desc foreach {
+      case (_, desc) => CUDNN_DESTROY_POOLING_DESCRIPTOR(desc)
     }
   }
 

--- a/src/main/scala/lms/transformation/mpi_nccl_transformation/distributedTensor2MPINCCLConv.scala
+++ b/src/main/scala/lms/transformation/mpi_nccl_transformation/distributedTensor2MPINCCLConv.scala
@@ -131,7 +131,7 @@ trait DistributeTensor2MPI_NCCLConv extends DistributeTensor2MPI_NCCLBase with C
     }
   }
 
-  def getDropoutDescriptor(states: ARRAY, states_bytes: VAR, params: DropoutParam): CUDNN_DROPOUT_DESCRIPTOR = {
+  def getDropoutDescriptor(states: ARRAY, states_bytes: VAR, params: DropoutParam)(implicit __pos: SourceContext): CUDNN_DROPOUT_DESCRIPTOR = {
     val DropoutParam(dropout, seed) = params
     generate_comment("begin creating dropout descriptor")
     val desc = new CUDNN_DROPOUT_DESCRIPTOR(NEW_STRUCT(manifest[CUDNN_DROPOUT_DESCRIPTOR], "cudnnDropoutDescriptor_t").x)

--- a/src/main/scala/lms/transformation/mpi_nccl_transformation/distributedTensor2MPINCCLConv.scala
+++ b/src/main/scala/lms/transformation/mpi_nccl_transformation/distributedTensor2MPINCCLConv.scala
@@ -116,8 +116,8 @@ trait DistributeTensor2MPI_NCCLConv extends DistributeTensor2MPI_NCCLBase with C
         CUDNN_CHECK(CUDNN_CREATE_POOLING_DESCRIPTOR(desc))
         val cudnnMode: TOP = mode match {
           case "max"          => CUDNN_POOLING_MAX
-          case "avg"          => CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING
-          case "avg_no_pad"   => CUDNN_POOLING_AVERAGE_COUNT_EXCLUDE_PADDING
+          case "avg_in_pad"   => CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING
+          case "avg_ex_pad"   => CUDNN_POOLING_AVERAGE_COUNT_EXCLUDE_PADDING
           case "max_dtm"      => CUDNN_POOLING_MAX_DETERMINISTIC
           case _              => CUDNN_POOLING_MAX
         }

--- a/src/main/scala/lms/transformation/mpi_nccl_transformation/distributedTensor2MPINCCLConv.scala
+++ b/src/main/scala/lms/transformation/mpi_nccl_transformation/distributedTensor2MPINCCLConv.scala
@@ -150,6 +150,7 @@ trait DistributeTensor2MPI_NCCLConv extends DistributeTensor2MPI_NCCLBase with C
       val filter_descriptor = getTensorDescriptor(filter_shape, "filter")
       val conv_descriptor = getConvDescriptor(padding, strides, dilation)
 
+      /*
       generate_comment("begin finding convolution output tensor shape")
       var output_batchsize = 0
       var output_height = 0
@@ -168,6 +169,14 @@ trait DistributeTensor2MPI_NCCLConv extends DistributeTensor2MPI_NCCLBase with C
 
       generate_comment("begin allocating gpu array for the output of convolution")
       val output_size = output_batchsize * output_height * output_width * output_channels
+      val output = gpu_array(output_size, manifest[Float], myNCCLRank)
+      generate_comment("end allocating gpu array for the output of convolution")
+      */
+      val output_shape = tensor_shape(s, useOldMetadata = true)
+      val output_descriptor = getTensorDescriptor(output_shape, "tensor")
+
+      generate_comment("begin allocating gpu array for the output of convolution")
+      val output_size = output_shape.fold(1) { (a, b) => a * b }
       val output = gpu_array(output_size, manifest[Float], myNCCLRank)
       generate_comment("end allocating gpu array for the output of convolution")
 

--- a/src/main/scala/lms/transformation/mpi_nccl_transformation/distributedTensor2MPINCCLConv.scala
+++ b/src/main/scala/lms/transformation/mpi_nccl_transformation/distributedTensor2MPINCCLConv.scala
@@ -89,6 +89,7 @@ trait DistributeTensor2MPI_NCCLConv extends DistributeTensor2MPI_NCCLBase with C
         CUDNN_CHECK(CUDNN_CREATE_ACTIVATION_DESCRIPTOR(desc))
         val cudnnMode: TOP = mode match {
           case "relu"       => CUDNN_ACTIVATION_RELU
+          case "crelu"      => CUDNN_ACTIVATION_CLIPPED_RELU
           case "sigmoid"    => CUDNN_ACTIVATION_SIGMOID
           case "tanh"       => CUDNN_ACTIVATION_TANH
           case "elu"        => CUDNN_ACTIVATION_ELU

--- a/src/main/scala/lms/transformation/mpi_nccl_transformation/distributedTensor2MPINCCLConv.scala
+++ b/src/main/scala/lms/transformation/mpi_nccl_transformation/distributedTensor2MPINCCLConv.scala
@@ -161,7 +161,7 @@ trait DistributeTensor2MPI_NCCLConv extends DistributeTensor2MPI_NCCLBase with C
       generate_comment("begin finding convolution backward workspace size")
 
       generate_comment("begin allocating gpu array for convolution forward workspace")
-      val d_workspace = gpu_array1_by_byte(INT(workspace_bytes_v(pos)), manifest[Float], myNCCLRank)
+      val d_workspace = GPU_ARRAY_BY_BYTE(INT(workspace_bytes_v(pos)), manifest[Float], myNCCLRank)
       generate_comment("end allocating gpu array for convolution forward workspace")
 
       generate_comment("begin convolution forward pass")
@@ -211,7 +211,7 @@ trait DistributeTensor2MPI_NCCLConv extends DistributeTensor2MPI_NCCLBase with C
       generate_comment("end finding convolution backward data workspace size")
 
       generate_comment("begin allocating gpu array for convolution backward data workspace")
-      val d_workspace = gpu_array1_by_byte(INT(workspace_bytes_v(pos)), manifest[Float], myNCCLRank)
+      val d_workspace = GPU_ARRAY_BY_BYTE(INT(workspace_bytes_v(pos)), manifest[Float], myNCCLRank)
       generate_comment("end allocating gpu array for convolution backward data workspace")
 
       generate_comment("begin convolution backward data pass")
@@ -261,7 +261,7 @@ trait DistributeTensor2MPI_NCCLConv extends DistributeTensor2MPI_NCCLBase with C
       generate_comment("end finding convolution backward filter workspace size")
 
       generate_comment("begin allocating gpu array for convolution backward filter workspace")
-      val d_workspace = gpu_array1_by_byte(INT(workspace_bytes_v(pos)), manifest[Float], myNCCLRank)
+      val d_workspace = GPU_ARRAY_BY_BYTE(INT(workspace_bytes_v(pos)), manifest[Float], myNCCLRank)
       generate_comment("end allocating gpu array for convolution backward filter workspace")
      
       generate_comment("begin convolution backward filter pass")
@@ -401,11 +401,11 @@ trait DistributeTensor2MPI_NCCLConv extends DistributeTensor2MPI_NCCLBase with C
       generate_comment("end finding dropout forward states bytes")
 
       generate_comment("begin allocating gpu array for the reserve space of dropout forward")
-      val d_reservespace = gpu_array1_by_byte(INT(reserve_bytes(pos)), manifest[Float], myNCCLRank)
+      val d_reservespace = GPU_ARRAY_BY_BYTE(INT(reserve_bytes(pos)), manifest[Float], myNCCLRank)
       generate_comment("end allocating gpu array for the reserve space of dropout forward")
 
       generate_comment("begin allocating gpu array for the states of dropout forward")
-      val d_states = gpu_array1_by_byte(INT(states_bytes(pos)), manifest[Float], myNCCLRank)
+      val d_states = GPU_ARRAY_BY_BYTE(INT(states_bytes(pos)), manifest[Float], myNCCLRank)
       generate_comment("end allocating gpu array for the states of dropout forward")
 
       generate_comment("begin creating dropout descriptor")
@@ -460,7 +460,7 @@ trait DistributeTensor2MPI_NCCLConv extends DistributeTensor2MPI_NCCLBase with C
       generate_comment("end finding dropout backward states bytes")
 
       generate_comment("begin allocating gpu array for the states of dropout backward")
-      val d_states = gpu_array1_by_byte(INT(states_bytes(pos)), manifest[Float], myNCCLRank)
+      val d_states = GPU_ARRAY_BY_BYTE(INT(states_bytes(pos)), manifest[Float], myNCCLRank)
       generate_comment("end allocating gpu array for the states of dropout backward")
 
       generate_comment("begin creating dropout descriptor")

--- a/src/main/scala/lms/transformation/mpi_nccl_transformation/distributedTensor2MPINCCLGemm.scala
+++ b/src/main/scala/lms/transformation/mpi_nccl_transformation/distributedTensor2MPINCCLGemm.scala
@@ -35,7 +35,7 @@ trait DistributeTensor2MPI_NCCLGemm extends DistributeTensor2MPI_NCCLBase {
       assert(man == manifest[Float], s"Using cublas for dot operation, which only support float element type, but got: ${man}")
       val array = gpu_array(size, man, device)
       // we use transpose option because the cublas function assume column-major
-      CUBLAS_SGEMM(CUBLAS_HANDLE, CUBLAS_OP_T, CUBLAS_OP_T, m, n, k, ONE, new ARRAY(left_operand), m, new ARRAY(right_operand), k, ZERO, array, m)
+      CUBLAS_SGEMM(CUBLAS_HANDLE, CUBLAS_OP_T, CUBLAS_OP_T, m, n, k, VAR(ONE), new ARRAY(left_operand), m, new ARRAY(right_operand), k, VAR(ZERO), array, m)
       array
     }
   // helper function for computing dot product in GPUs
@@ -46,7 +46,7 @@ trait DistributeTensor2MPI_NCCLGemm extends DistributeTensor2MPI_NCCLBase {
       val array = gpu_array(size, man, device)
       // the transpose options should also take account into the column-major assumption of the cublas function
       CUBLAS_SGEMM(CUBLAS_HANDLE, if (transL) CUBLAS_OP_N else CUBLAS_OP_T, if (transR) CUBLAS_OP_N else CUBLAS_OP_T,
-        m, n, k, ONE, new ARRAY(left_operand), m, new ARRAY(right_operand), k, ZERO, array, m)
+        m, n, k, VAR(ONE), new ARRAY(left_operand), m, new ARRAY(right_operand), k, VAR(ZERO), array, m)
       array
     }
 

--- a/src/main/scala/lms/transformation/util/utils.scala
+++ b/src/main/scala/lms/transformation/util/utils.scala
@@ -99,4 +99,5 @@ trait CudnnUtils {
   case class SoftmaxParam(val alpha: Float, val beta: Float)
   case class ActivationParam(val alpha: Float, val beta: Float, val coef: Float)
   case class DropoutParam(val dropout: Float, val seed: Int)
+  case class PoolingParam(val alpha: Float, val beta: Float, val window: Seq[Int], val padding: Seq[Int], val strides: Seq[Int])
 }

--- a/src/out/transformer/distributed_tensor/dot.check.cu
+++ b/src/out/transformer/distributed_tensor/dot.check.cu
@@ -114,7 +114,9 @@ void Snippet(int x0) {
     CUDA_CALL(cudaSetDevice(x6));
     float* x40 = (float*)malloc(0 * sizeof(float));
     CUDA_CALL(cudaMalloc(&x40, (size_t)(1024 * sizeof(float))));
-    CUBLAS_CALL(cublasSgemm(x7, CUBLAS_OP_N, CUBLAS_OP_T, 32, 32, 32, &1.0, x38, 32, x39, 32, &0.0, x40, 32));
+    float x41 = 1.0;
+    float x42 = 0.0;
+    CUBLAS_CALL(cublasSgemm(x7, CUBLAS_OP_N, CUBLAS_OP_T, 32, 32, 32, &x41, x38, 32, x39, 32, &x42, x40, 32));
     // end computing DOT on GPU for size 1024 and type Float at device (pre-rename) x39 with left_operand x168 and right_operand x184 with transpose options
     ncclAllReduce(x40, x40, (size_t)1024, ncclFloat32, ncclSum, x4, x5);
     // begin computing ACCUM on GPU for size 1024 and type Float at device (pre-rename) x39 with base_operand x91 and addition_operand x197
@@ -129,12 +131,12 @@ void Snippet(int x0) {
   }
   if (x6 == 0) {
     // begin copying GPU array x68 to CPU and print for size 1024 and type Float
-    float* x41 = (float*)malloc(1024 * sizeof(float));
-    CUDA_CALL(cudaMemcpy(x41, x10, (size_t)(1024 * sizeof(float)), cudaMemcpyDeviceToHost));
-    int x42 = 0;
-    while (x42 != 1024) {
-      printf("%f ", x41[x42]);
-      x42 = x42 + 1;
+    float* x43 = (float*)malloc(1024 * sizeof(float));
+    CUDA_CALL(cudaMemcpy(x43, x10, (size_t)(1024 * sizeof(float)), cudaMemcpyDeviceToHost));
+    int x44 = 0;
+    while (x44 != 1024) {
+      printf("%f ", x43[x44]);
+      x44 = x44 + 1;
     }
     printf("\n");
     // end copying GPU array x68 to CPU and print for size 1024 and type Float

--- a/src/out/transformer/distributed_tensor/pooling.check.cu
+++ b/src/out/transformer/distributed_tensor/pooling.check.cu
@@ -1,0 +1,170 @@
+/*****************************************
+Emitting C Generated Code
+*******************************************/
+#include "cudnn_header.h"
+#include "nccl_header.h"
+#include <string.h>
+#include <cblas.h>
+#include <stdlib.h>
+#include "cuda_header.h"
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include "mpi_header.h"
+/************* Functions **************/
+__global__ void x11(float* x12, float x13, int x14) {
+  int x15 = gridDim.x * blockDim.x;
+  int x16 = threadIdx.x + blockIdx.x * blockDim.x;
+  while (x16 < x14) {
+    x12[x16] = x13;
+    x16 = x16 + x15;
+  }
+}
+__global__ void x19(float* x20, float* x21, int x22) {
+  // begin generating kernel function for ACCUM of type Float
+  int x23 = gridDim.x * blockDim.x;
+  int x24 = threadIdx.x + blockIdx.x * blockDim.x;
+  while (x24 < x22) {
+    int x25 = x24;
+    x20[x25] = x20[x25] + x21[x25];
+    x24 = x24 + x23;
+  }
+  // end generating kernel function for ACCUM of type Float
+}
+__global__ void x26(float* x27, float* x28, float* x29, int x30) {
+  // begin generating kernel function for SGD of type Float
+  int x31 = gridDim.x * blockDim.x;
+  int x32 = threadIdx.x + blockIdx.x * blockDim.x;
+  while (x32 < x30) {
+    int x33 = x32;
+    float x34 = x29[x33] * 0.5 + x28[x33];
+    x27[x33] = x27[x33] - x34 * 1.0E-4;
+    x29[x33] = x34;
+    x32 = x32 + x31;
+  }
+  // end generating kernel function for SGD of type Float
+}
+/**************** Snippet ****************/
+void Snippet(int x0) {
+  // begin setting up the MPI/NCCL environment
+  int x1 = 0;
+  int x2 = 0;
+  MPICHECK(MPI_Init(NULL, NULL));
+  MPICHECK(MPI_Comm_rank(MPI_COMM_WORLD, &x2));
+  MPICHECK(MPI_Comm_size(MPI_COMM_WORLD, &x1));
+  MPICHECK(MPI_Barrier(MPI_COMM_WORLD));
+  CUDA_CALL(cudaSetDevice(x2));
+  ncclUniqueId x3;
+  NCCLCHECK(ncclGetUniqueId(&x3));
+  MPICHECK(MPI_Bcast(&x3, NCCL_UNIQUE_ID_BYTES, MPI_CHAR, 0, MPI_COMM_WORLD));
+  ncclComm_t x4;
+  NCCLCHECK(ncclCommInitRank(&x4, x1, x3, x2));
+  cudaStream_t x5;
+  CUDA_CALL(cudaStreamCreateWithFlags(&x5, cudaStreamNonBlocking));
+  int x6 = x2;
+  // end setting up the MPI/NCCL environment
+  // begin initializing random GPU array of size 162 and type Float at device (pre-rename) x39
+  float* x7 = (float*)malloc(162 * sizeof(float));
+  int x8 = 0;
+  while (x8 != 162) {
+    x7[x8] = (float)(rand() - RAND_MAX / 2) / (float)RAND_MAX;
+    x8 = x8 + 1;
+  }
+  CUDA_CALL(cudaSetDevice(x6));
+  float* x9 = (float*)malloc(0 * sizeof(float));
+  CUDA_CALL(cudaMalloc(&x9, (size_t)(162 * sizeof(float))));
+  CUDA_CALL(cudaMemcpy(x9, x7, (size_t)(162 * sizeof(float)), cudaMemcpyHostToDevice));
+  // end initializing random GPU array of size 162 and type Float at device (pre-rename) x39
+  NCCLCHECK(ncclAllReduce(x9, x9, (size_t)(162 * sizeof(float)), ncclFloat32, ncclSum, x4, x5));
+  // begin initializing fixed GPU array of size 162 and type Float and device (pre-rename) x39
+  CUDA_CALL(cudaSetDevice(x6));
+  float* x10 = (float*)malloc(0 * sizeof(float));
+  CUDA_CALL(cudaMalloc(&x10, (size_t)(162 * sizeof(float))));
+  x11<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x10, 0, 162);
+  // end initializing fixed GPU array of size 162 and type Float and device (pre-rename) x39
+  // begin initializing fixed GPU array of size 162 and type Float and device (pre-rename) x39
+  CUDA_CALL(cudaSetDevice(x6));
+  float* x17 = (float*)malloc(0 * sizeof(float));
+  CUDA_CALL(cudaMalloc(&x17, (size_t)(162 * sizeof(float))));
+  x11<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x17, 0, 162);
+  // end initializing fixed GPU array of size 162 and type Float and device (pre-rename) x39
+  int x18 = 0;
+  while (x18 != 10) {
+    // begin creating and setting tensor descriptor of shape List(2, 1, 9, 9)
+    cudnnTensorDescriptor_t x35;
+    CUDNNCHECK(cudnnCreateTensorDescriptor(&x35));
+    CUDNNCHECK(cudnnSetTensor4dDescriptor(x35, CUDNN_TENSOR_NCHW, CUDNN_DATA_FLOAT, 2, 1, 9, 9));
+    // end creating and setting tensor descriptor
+    // begin creating and setting tensor descriptor of shape List(2, 1, 10, 10)
+    cudnnTensorDescriptor_t x36;
+    CUDNNCHECK(cudnnCreateTensorDescriptor(&x36));
+    CUDNNCHECK(cudnnSetTensor4dDescriptor(x36, CUDNN_TENSOR_NCHW, CUDNN_DATA_FLOAT, 2, 1, 10, 10));
+    // end creating and setting tensor descriptor
+    // begin creating and setting pooling descriptor
+    cudnnPoolingDescriptor_t x37;
+    CUDNNCHECK(cudnnCreatePoolingDescriptor(&x37));
+    CUDNNCHECK(cudnnSetPooling2dDescriptor(x37, CUDNN_POOLING_MAX, CUDNN_PROPAGATE_NAN, 2, 2, 1, 1, 1, 1));
+    // end creating and setting pooling descriptor
+    // begin allocating gpu array for the output of pooling
+    CUDA_CALL(cudaSetDevice(x6));
+    float* x38 = (float*)malloc(0 * sizeof(float));
+    CUDA_CALL(cudaMalloc(&x38, (size_t)(200 * sizeof(float))));
+    // end allocating gpu array for the output of pooling
+    // begin setting up the CUDNN environment
+    cudnnHandle_t x39;
+    CUDNNCHECK(cudnnCreate(&x39));
+    // end setting up the CUDNN environment
+    float x40 = 1.0;
+    float x41 = 0.0;
+    CUDNNCHECK(cudnnPoolingForward(x39, x37, &x40, x35, x9, &x41, x36, x38));
+    // begin initializing fixed GPU array of size 100 and type Float and device (pre-rename) x39
+    CUDA_CALL(cudaSetDevice(x6));
+    float* x42 = (float*)malloc(0 * sizeof(float));
+    CUDA_CALL(cudaMalloc(&x42, (size_t)(100 * sizeof(float))));
+    x11<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x42, 1, 100);
+    // end initializing fixed GPU array of size 100 and type Float and device (pre-rename) x39
+    // begin allocating gpu array for the gradient of input of pooling
+    CUDA_CALL(cudaSetDevice(x6));
+    float* x43 = (float*)malloc(0 * sizeof(float));
+    CUDA_CALL(cudaMalloc(&x43, (size_t)(162 * sizeof(float))));
+    // end allocating gpu array for the gradient of input of pooling
+    float x44 = 1.0;
+    float x45 = 0.0;
+    CUDNNCHECK(cudnnPoolingBackward(x39, x37, &x44, x36, x38, x36, x42, x35, x9, &x45, x35, x43));
+    // begin computing ACCUM on GPU for size 162 and type Float at device (pre-rename) x39 with base_operand x88 and addition_operand x203
+    CUDA_CALL(cudaSetDevice(x6));
+    x19<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x10, x43, 162);
+    // end computing ACCUM on GPU for size 162 and type Float at device (pre-rename) x39 with base_operand x88 and addition_operand x203
+    // begin computing SGD on GPU for size 162 and type Float at device (pre-name) x39 with weight x65, grad x88, and momentum x126
+    CUDA_CALL(cudaSetDevice(x6));
+    x26<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x9, x10, x17, 162);
+    // end computing SGD on GPU for size 162 and type Float at device (pre-name) x39 with weight x65, grad x88, and momentum x126
+    x18 = x18 + 1;
+  }
+  if (x6 == 0) {
+    // begin copying GPU array x65 to CPU and print for size 162 and type Float
+    float* x46 = (float*)malloc(162 * sizeof(float));
+    CUDA_CALL(cudaMemcpy(x46, x9, (size_t)(162 * sizeof(float)), cudaMemcpyDeviceToHost));
+    int x47 = 0;
+    while (x47 != 162) {
+      printf("%f ", x46[x47]);
+      x47 = x47 + 1;
+    }
+    printf("\n");
+    // end copying GPU array x65 to CPU and print for size 162 and type Float
+  }
+  printf("compile");
+  MPICHECK(MPI_Finalize());
+  NCCLCHECK(ncclCommDestroy(x4));
+}
+/*****************************************
+End of C Generated Code
+*******************************************/
+int main(int argc, char *argv[]) {
+  if (argc != 2) {
+    printf("usage: %s <arg>\n", argv[0]);
+    return 0;
+  }
+  Snippet(atoi(argv[1]));
+  return 0;
+}

--- a/src/out/transformer/distributed_tensor/pooling.check.cu
+++ b/src/out/transformer/distributed_tensor/pooling.check.cu
@@ -114,9 +114,11 @@ void Snippet(int x0) {
     float* x39 = (float*)malloc(0 * sizeof(float));
     CUDA_CALL(cudaMalloc(&x39, (size_t)(200 * sizeof(float))));
     // end allocating gpu array for the output of pooling
+    // begin pooling forward pass
     float x40 = 1.0;
     float x41 = 0.0;
     CUDNNCHECK(cudnnPoolingForward(x7, x38, &x40, x36, x10, &x41, x37, x39));
+    // end pooling forward pass
     // begin initializing fixed GPU array of size 100 and type Float and device (pre-rename) x39
     CUDA_CALL(cudaSetDevice(x6));
     float* x42 = (float*)malloc(0 * sizeof(float));
@@ -128,13 +130,15 @@ void Snippet(int x0) {
     float* x43 = (float*)malloc(0 * sizeof(float));
     CUDA_CALL(cudaMalloc(&x43, (size_t)(162 * sizeof(float))));
     // end allocating gpu array for the gradient of input of pooling
+    // begin pooling backward pass
     float x44 = 1.0;
     float x45 = 0.0;
     CUDNNCHECK(cudnnPoolingBackward(x7, x38, &x44, x37, x39, x37, x42, x36, x10, &x45, x36, x43));
-    // begin computing ACCUM on GPU for size 162 and type Float at device (pre-rename) x39 with base_operand x93 and addition_operand x203
+    // end pooling backward pass
+    // begin computing ACCUM on GPU for size 162 and type Float at device (pre-rename) x39 with base_operand x93 and addition_operand x205
     CUDA_CALL(cudaSetDevice(x6));
     x20<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x11, x43, 162);
-    // end computing ACCUM on GPU for size 162 and type Float at device (pre-rename) x39 with base_operand x93 and addition_operand x203
+    // end computing ACCUM on GPU for size 162 and type Float at device (pre-rename) x39 with base_operand x93 and addition_operand x205
     // begin computing SGD on GPU for size 162 and type Float at device (pre-name) x39 with weight x70, grad x93, and momentum x131
     CUDA_CALL(cudaSetDevice(x6));
     x27<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x10, x11, x18, 162);

--- a/src/out/transformer/distributed_tensor/pooling.check.cu
+++ b/src/out/transformer/distributed_tensor/pooling.check.cu
@@ -12,35 +12,35 @@ Emitting C Generated Code
 #include <stdbool.h>
 #include "mpi_header.h"
 /************* Functions **************/
-__global__ void x11(float* x12, float x13, int x14) {
-  int x15 = gridDim.x * blockDim.x;
-  int x16 = threadIdx.x + blockIdx.x * blockDim.x;
-  while (x16 < x14) {
-    x12[x16] = x13;
-    x16 = x16 + x15;
+__global__ void x12(float* x13, float x14, int x15) {
+  int x16 = gridDim.x * blockDim.x;
+  int x17 = threadIdx.x + blockIdx.x * blockDim.x;
+  while (x17 < x15) {
+    x13[x17] = x14;
+    x17 = x17 + x16;
   }
 }
-__global__ void x19(float* x20, float* x21, int x22) {
+__global__ void x20(float* x21, float* x22, int x23) {
   // begin generating kernel function for ACCUM of type Float
-  int x23 = gridDim.x * blockDim.x;
-  int x24 = threadIdx.x + blockIdx.x * blockDim.x;
-  while (x24 < x22) {
-    int x25 = x24;
-    x20[x25] = x20[x25] + x21[x25];
-    x24 = x24 + x23;
+  int x24 = gridDim.x * blockDim.x;
+  int x25 = threadIdx.x + blockIdx.x * blockDim.x;
+  while (x25 < x23) {
+    int x26 = x25;
+    x21[x26] = x21[x26] + x22[x26];
+    x25 = x25 + x24;
   }
   // end generating kernel function for ACCUM of type Float
 }
-__global__ void x26(float* x27, float* x28, float* x29, int x30) {
+__global__ void x27(float* x28, float* x29, float* x30, int x31) {
   // begin generating kernel function for SGD of type Float
-  int x31 = gridDim.x * blockDim.x;
-  int x32 = threadIdx.x + blockIdx.x * blockDim.x;
-  while (x32 < x30) {
-    int x33 = x32;
-    float x34 = x29[x33] * 0.5 + x28[x33];
-    x27[x33] = x27[x33] - x34 * 1.0E-4;
-    x29[x33] = x34;
-    x32 = x32 + x31;
+  int x32 = gridDim.x * blockDim.x;
+  int x33 = threadIdx.x + blockIdx.x * blockDim.x;
+  while (x33 < x31) {
+    int x34 = x33;
+    float x35 = x30[x34] * 0.5 + x29[x34];
+    x28[x34] = x28[x34] - x35 * 1.0E-4;
+    x30[x34] = x35;
+    x33 = x33 + x32;
   }
   // end generating kernel function for SGD of type Float
 }
@@ -63,65 +63,65 @@ void Snippet(int x0) {
   CUDA_CALL(cudaStreamCreateWithFlags(&x5, cudaStreamNonBlocking));
   int x6 = x2;
   // end setting up the MPI/NCCL environment
+  // begin setting up the CUDNN environment
+  cudnnHandle_t x7;
+  CUDNNCHECK(cudnnCreate(&x7));
+  // end setting up the CUDNN environment
   // begin initializing random GPU array of size 162 and type Float at device (pre-rename) x39
-  float* x7 = (float*)malloc(162 * sizeof(float));
-  int x8 = 0;
-  while (x8 != 162) {
-    x7[x8] = (float)(rand() - RAND_MAX / 2) / (float)RAND_MAX;
-    x8 = x8 + 1;
+  float* x8 = (float*)malloc(162 * sizeof(float));
+  int x9 = 0;
+  while (x9 != 162) {
+    x8[x9] = (float)(rand() - RAND_MAX / 2) / (float)RAND_MAX;
+    x9 = x9 + 1;
   }
-  CUDA_CALL(cudaSetDevice(x6));
-  float* x9 = (float*)malloc(0 * sizeof(float));
-  CUDA_CALL(cudaMalloc(&x9, (size_t)(162 * sizeof(float))));
-  CUDA_CALL(cudaMemcpy(x9, x7, (size_t)(162 * sizeof(float)), cudaMemcpyHostToDevice));
-  // end initializing random GPU array of size 162 and type Float at device (pre-rename) x39
-  NCCLCHECK(ncclAllReduce(x9, x9, (size_t)(162 * sizeof(float)), ncclFloat32, ncclSum, x4, x5));
-  // begin initializing fixed GPU array of size 162 and type Float and device (pre-rename) x39
   CUDA_CALL(cudaSetDevice(x6));
   float* x10 = (float*)malloc(0 * sizeof(float));
   CUDA_CALL(cudaMalloc(&x10, (size_t)(162 * sizeof(float))));
-  x11<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x10, 0, 162);
+  CUDA_CALL(cudaMemcpy(x10, x8, (size_t)(162 * sizeof(float)), cudaMemcpyHostToDevice));
+  // end initializing random GPU array of size 162 and type Float at device (pre-rename) x39
+  NCCLCHECK(ncclAllReduce(x10, x10, (size_t)(162 * sizeof(float)), ncclFloat32, ncclSum, x4, x5));
+  // begin initializing fixed GPU array of size 162 and type Float and device (pre-rename) x39
+  CUDA_CALL(cudaSetDevice(x6));
+  float* x11 = (float*)malloc(0 * sizeof(float));
+  CUDA_CALL(cudaMalloc(&x11, (size_t)(162 * sizeof(float))));
+  x12<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x11, 0, 162);
   // end initializing fixed GPU array of size 162 and type Float and device (pre-rename) x39
   // begin initializing fixed GPU array of size 162 and type Float and device (pre-rename) x39
   CUDA_CALL(cudaSetDevice(x6));
-  float* x17 = (float*)malloc(0 * sizeof(float));
-  CUDA_CALL(cudaMalloc(&x17, (size_t)(162 * sizeof(float))));
-  x11<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x17, 0, 162);
+  float* x18 = (float*)malloc(0 * sizeof(float));
+  CUDA_CALL(cudaMalloc(&x18, (size_t)(162 * sizeof(float))));
+  x12<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x18, 0, 162);
   // end initializing fixed GPU array of size 162 and type Float and device (pre-rename) x39
-  int x18 = 0;
-  while (x18 != 10) {
+  int x19 = 0;
+  while (x19 != 10) {
     // begin creating and setting tensor descriptor of shape List(2, 1, 9, 9)
-    cudnnTensorDescriptor_t x35;
-    CUDNNCHECK(cudnnCreateTensorDescriptor(&x35));
-    CUDNNCHECK(cudnnSetTensor4dDescriptor(x35, CUDNN_TENSOR_NCHW, CUDNN_DATA_FLOAT, 2, 1, 9, 9));
-    // end creating and setting tensor descriptor
-    // begin creating and setting tensor descriptor of shape List(2, 1, 10, 10)
     cudnnTensorDescriptor_t x36;
     CUDNNCHECK(cudnnCreateTensorDescriptor(&x36));
-    CUDNNCHECK(cudnnSetTensor4dDescriptor(x36, CUDNN_TENSOR_NCHW, CUDNN_DATA_FLOAT, 2, 1, 10, 10));
+    CUDNNCHECK(cudnnSetTensor4dDescriptor(x36, CUDNN_TENSOR_NCHW, CUDNN_DATA_FLOAT, 2, 1, 9, 9));
+    // end creating and setting tensor descriptor
+    // begin creating and setting tensor descriptor of shape List(2, 1, 10, 10)
+    cudnnTensorDescriptor_t x37;
+    CUDNNCHECK(cudnnCreateTensorDescriptor(&x37));
+    CUDNNCHECK(cudnnSetTensor4dDescriptor(x37, CUDNN_TENSOR_NCHW, CUDNN_DATA_FLOAT, 2, 1, 10, 10));
     // end creating and setting tensor descriptor
     // begin creating and setting pooling descriptor
-    cudnnPoolingDescriptor_t x37;
-    CUDNNCHECK(cudnnCreatePoolingDescriptor(&x37));
-    CUDNNCHECK(cudnnSetPooling2dDescriptor(x37, CUDNN_POOLING_MAX, CUDNN_PROPAGATE_NAN, 2, 2, 1, 1, 1, 1));
+    cudnnPoolingDescriptor_t x38;
+    CUDNNCHECK(cudnnCreatePoolingDescriptor(&x38));
+    CUDNNCHECK(cudnnSetPooling2dDescriptor(x38, CUDNN_POOLING_MAX, CUDNN_PROPAGATE_NAN, 2, 2, 1, 1, 1, 1));
     // end creating and setting pooling descriptor
     // begin allocating gpu array for the output of pooling
     CUDA_CALL(cudaSetDevice(x6));
-    float* x38 = (float*)malloc(0 * sizeof(float));
-    CUDA_CALL(cudaMalloc(&x38, (size_t)(200 * sizeof(float))));
+    float* x39 = (float*)malloc(0 * sizeof(float));
+    CUDA_CALL(cudaMalloc(&x39, (size_t)(200 * sizeof(float))));
     // end allocating gpu array for the output of pooling
-    // begin setting up the CUDNN environment
-    cudnnHandle_t x39;
-    CUDNNCHECK(cudnnCreate(&x39));
-    // end setting up the CUDNN environment
     float x40 = 1.0;
     float x41 = 0.0;
-    CUDNNCHECK(cudnnPoolingForward(x39, x37, &x40, x35, x9, &x41, x36, x38));
+    CUDNNCHECK(cudnnPoolingForward(x7, x38, &x40, x36, x10, &x41, x37, x39));
     // begin initializing fixed GPU array of size 100 and type Float and device (pre-rename) x39
     CUDA_CALL(cudaSetDevice(x6));
     float* x42 = (float*)malloc(0 * sizeof(float));
     CUDA_CALL(cudaMalloc(&x42, (size_t)(100 * sizeof(float))));
-    x11<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x42, 1, 100);
+    x12<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x42, 1, 100);
     // end initializing fixed GPU array of size 100 and type Float and device (pre-rename) x39
     // begin allocating gpu array for the gradient of input of pooling
     CUDA_CALL(cudaSetDevice(x6));
@@ -130,30 +130,31 @@ void Snippet(int x0) {
     // end allocating gpu array for the gradient of input of pooling
     float x44 = 1.0;
     float x45 = 0.0;
-    CUDNNCHECK(cudnnPoolingBackward(x39, x37, &x44, x36, x38, x36, x42, x35, x9, &x45, x35, x43));
-    // begin computing ACCUM on GPU for size 162 and type Float at device (pre-rename) x39 with base_operand x88 and addition_operand x203
+    CUDNNCHECK(cudnnPoolingBackward(x7, x38, &x44, x37, x39, x37, x42, x36, x10, &x45, x36, x43));
+    // begin computing ACCUM on GPU for size 162 and type Float at device (pre-rename) x39 with base_operand x93 and addition_operand x203
     CUDA_CALL(cudaSetDevice(x6));
-    x19<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x10, x43, 162);
-    // end computing ACCUM on GPU for size 162 and type Float at device (pre-rename) x39 with base_operand x88 and addition_operand x203
-    // begin computing SGD on GPU for size 162 and type Float at device (pre-name) x39 with weight x65, grad x88, and momentum x126
+    x20<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x11, x43, 162);
+    // end computing ACCUM on GPU for size 162 and type Float at device (pre-rename) x39 with base_operand x93 and addition_operand x203
+    // begin computing SGD on GPU for size 162 and type Float at device (pre-name) x39 with weight x70, grad x93, and momentum x131
     CUDA_CALL(cudaSetDevice(x6));
-    x26<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x9, x10, x17, 162);
-    // end computing SGD on GPU for size 162 and type Float at device (pre-name) x39 with weight x65, grad x88, and momentum x126
-    x18 = x18 + 1;
+    x27<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x10, x11, x18, 162);
+    // end computing SGD on GPU for size 162 and type Float at device (pre-name) x39 with weight x70, grad x93, and momentum x131
+    x19 = x19 + 1;
   }
   if (x6 == 0) {
-    // begin copying GPU array x65 to CPU and print for size 162 and type Float
+    // begin copying GPU array x70 to CPU and print for size 162 and type Float
     float* x46 = (float*)malloc(162 * sizeof(float));
-    CUDA_CALL(cudaMemcpy(x46, x9, (size_t)(162 * sizeof(float)), cudaMemcpyDeviceToHost));
+    CUDA_CALL(cudaMemcpy(x46, x10, (size_t)(162 * sizeof(float)), cudaMemcpyDeviceToHost));
     int x47 = 0;
     while (x47 != 162) {
       printf("%f ", x46[x47]);
       x47 = x47 + 1;
     }
     printf("\n");
-    // end copying GPU array x65 to CPU and print for size 162 and type Float
+    // end copying GPU array x70 to CPU and print for size 162 and type Float
   }
   printf("compile");
+  CUDNNCHECK(cudnnDestroy(x7));
   MPICHECK(MPI_Finalize());
   NCCLCHECK(ncclCommDestroy(x4));
 }

--- a/src/test/scala/lms/transformation/test_distributed_tensor.scala
+++ b/src/test/scala/lms/transformation/test_distributed_tensor.scala
@@ -300,7 +300,6 @@ class FixedSizeDistributedTensorTest extends TutorialFunSuite {
           val params = DropoutParam(0.5f, 1)
           val dropouts = tensor_filter dropout (batchSplitAnno, params)
 
-          // dropouts(0) + (tensor_input, batchSplitAnno)
           dropouts(0)
         }
         model(10)

--- a/src/test/scala/lms/transformation/test_distributed_tensor.scala
+++ b/src/test/scala/lms/transformation/test_distributed_tensor.scala
@@ -323,10 +323,9 @@ class FixedSizeDistributedTensorTest extends TutorialFunSuite {
         val params = PoolingParam(1.0f, 0.0f, Seq(2, 2), Seq(1, 1), Seq(1, 1))
 
         val model = module {
-          // val tensor_input = Tensor.input[Float](inputTensorType)
           val tensor_filter = Tensor.weight[Float](Seq(2, 1, 9, 9))
           
-          tensor_filter pooling (batchSplitAnno, params)
+          tensor_filter maxpool (batchSplitAnno, params)
         }
         model(10)
         printf("compile")

--- a/src/test/scala/lms/utils.scala
+++ b/src/test/scala/lms/utils.scala
@@ -10,7 +10,7 @@ trait LibSuite extends FunSuite {
 }
 
 trait TutorialFunSuite extends LibSuite {
-  val overwriteCheckFiles = true // should be false; temporary set to true only to simplify development
+  val overwriteCheckFiles = false // should be false; temporary set to true only to simplify development
 
   val prefix = "src/out/"
   val under: String

--- a/src/test/scala/lms/utils.scala
+++ b/src/test/scala/lms/utils.scala
@@ -10,7 +10,7 @@ trait LibSuite extends FunSuite {
 }
 
 trait TutorialFunSuite extends LibSuite {
-  val overwriteCheckFiles = false // should be false; temporary set to true only to simplify development
+  val overwriteCheckFiles = true // should be false; temporary set to true only to simplify development
 
   val prefix = "src/out/"
   val under: String


### PR DESCRIPTION
- [x] change `traverse` in `DistributeTensor2MPI_NCCLAnalysis` to use a list of cudnn ops
- [x] change names of `gpu_array1_...` functions
- [ ] remove fwd-bwd hashmaps
- [x] implement more unary ops for activation. If user doesn't specify parameter, use unary. Otherwise, use cudnn activation.
- [x] implement pooling
- [x] implement pooling user API
- [x] fix unused getoutputdim in conv (current implement is not correct because var_read is not used)
- [x] fix alpha/beta pointer bug in sgemm
- [ ] more cudnn ops?
- [x] cleanup
- [x] change `overwriteCheckFiles` to false before merge