### PR TITLE
Adapter.oldTypeMap and oldSourceMap could be null

### DIFF
--- a/src/main/scala/lms/core/traversal.scala
+++ b/src/main/scala/lms/core/traversal.scala
@@ -534,9 +534,9 @@ abstract class Transformer extends Traverser {
     // Also pass the metadata to the new exp
     // We use `getOrElseUpdate` because the handling of each node might
     // have already filled a proper value, which we don't want to override
-    if (Adapter.oldTypeMap.contains(n.n))
+    if (Adapter.oldTypeMap != null && Adapter.oldTypeMap.contains(n.n))
       Adapter.typeMap.getOrElseUpdate(subst(n.n), Adapter.oldTypeMap(n.n))
-    if (Adapter.oldSourceMap.contains(n.n))
+    if (Adapter.oldSourceMap != null && Adapter.oldSourceMap.contains(n.n))
       Adapter.sourceMap.getOrElseUpdate(subst(n.n), Adapter.oldSourceMap(n.n))
   }
 
@@ -565,9 +565,9 @@ abstract class Transformer extends Traverser {
 
     // Handling MetaData 3. update new metadata with old metadata
     // this is not redundant because of the block arguments (function definitions)
-    for ((k, v) <- subst if v.isInstanceOf[Sym] && Adapter.oldTypeMap.contains(k))
+    for ((k, v) <- subst if v.isInstanceOf[Sym] && Adapter.oldTypeMap != null && Adapter.oldTypeMap.contains(k))
       Adapter.typeMap.getOrElseUpdate(v, Adapter.oldTypeMap(k))
-    for ((k, v) <- subst if v.isInstanceOf[Sym] && Adapter.oldSourceMap.contains(k))
+    for ((k, v) <- subst if v.isInstanceOf[Sym] && Adapter.oldSourceMap != null && Adapter.oldSourceMap.contains(k))
       Adapter.sourceMap.getOrElseUpdate(v, Adapter.oldSourceMap(k))
 
     Graph(g.globalDefs,block, g.globalDefsCache.toMap)


### PR DESCRIPTION
When working on the last submission, I played a bit with the loop fusion example `lms.tensors.TensorTest2` and `lms.tensors.TensorTest`. The two test cases are good when running with all other test cases via `sbt test`.

But if running them separately (eg `testOnly lms.tensors.TensorTest`), I got null pointer exceptions for `Adapter.oldSourceMap` and `Adapter.oldSourceMap`. This is also an issue if `Adapter.oldTypeMap` and `Adapter.oldSourceMap` indeed should be properly reset between independent runs. 

The current commit simply checks if they are null and skips if they are.

@feiwang3311 Any thought to properly fix it? Maybe we should not use the null pointer to represent the initial state, instead, use an empty map for that?