### PR TITLE
Expose sym when using reflectEffect

### DIFF
--- a/src/main/scala/lms/core/backend.scala
+++ b/src/main/scala/lms/core/backend.scala
@@ -672,8 +672,17 @@ class GraphBuilderOpt extends GraphBuilder {
     case ("-", List(Const(a:Int),Const(b:Int))) => Const(a-b)
     case ("*", List(Const(a:Int),Const(b:Int))) => Const(a*b)
     case ("/", List(Const(a:Int),Const(b:Int))) => Const(a/b)
+
+    case ("+", List(Const(a:Long),Const(b:Long))) => Const(a+b)
+    case ("-", List(Const(a:Long),Const(b:Long))) => Const(a-b)
+    case ("*", List(Const(a:Long),Const(b:Long))) => Const(a*b)
     case ("/", List(Const(a:Long),Const(b:Long))) => Const(a/b)
+
+    case ("+", List(Const(a:Double),Const(b:Double))) => Const(a+b)
+    case ("-", List(Const(a:Double),Const(b:Double))) => Const(a-b)
+    case ("*", List(Const(a:Double),Const(b:Double))) => Const(a*b)
     case ("/", List(Const(a:Double),Const(b:Double))) => Const(a/b)
+
     case ("%", List(Const(a:Int),Const(b:Int))) => Const(a%b)
     case (">>>", List(Const(a: Int),Const(b:Int))) => Const(a >>> b)
     case (">>>", List(Const(a: Long),Const(b:Int))) => Const(a >>> b)

--- a/src/main/scala/lms/core/backend.scala
+++ b/src/main/scala/lms/core/backend.scala
@@ -138,11 +138,11 @@ object Backend {
   }
 
   case class BlockEffect(var map: Map[Exp,(Sym, List[Sym])], prev: BlockEffect) {
-    var allEff: Map[Exp, Set[(Sym, List[Sym])]] = Map()
+    var allEff: Map[Exp, List[(Sym, List[Sym])]] = Map()
     def get(key: Exp): Option[(Sym, List[Sym])] = if (prev != null) map.get(key) orElse prev.get(key) else map.get(key)
     def getOrElse(key: Exp, default: (Sym, List[Sym])) = get(key).getOrElse(default)
     def +=(kv: (Exp, (Sym, List[Sym]))) = {
-      allEff = allEff + (kv._1 -> (allEff.getOrElse(kv._1, Set()) ++ Set(kv._2)))
+      allEff = allEff + (kv._1 -> (kv._2::(allEff.getOrElse(kv._1, List()))))
       map += kv
     }
   }

--- a/src/main/scala/lms/core/backend.scala
+++ b/src/main/scala/lms/core/backend.scala
@@ -173,14 +173,14 @@ class GraphBuilder {
   }
   def findDefinition(op: String, as: Seq[Def]): Option[Node] = globalDefsReverseCache.get((op,as))
 
-  var rewrites: (String => Any => Option[Exp]) = (s => x => None)
+  var __rewrites: (String => Any => Option[Exp]) = (s => x => None)
 
-  def rewrite(s: String, as: List[Def]): Option[Exp] = rewrites("")((s, as))
+  def rewrite(s: String, as: List[Def]): Option[Exp] = __rewrites("")((s, as))
 
   def addRewrite(f: PartialFunction[Any, Option[Exp]]) = {
-    val old = rewrites
+    val old = __rewrites
     val f1 = ((x: Any) => if (f.isDefinedAt(x)) f(x) else None)
-    rewrites = (s =>x => f1(x).orElse(old(s)(x)))
+    __rewrites = (s =>x => f1(x).orElse(old(s)(x)))
   }
 
   def reflect(s: String, as: Def*): Exp = {

--- a/src/main/scala/lms/core/codegen/c_codegen.scala
+++ b/src/main/scala/lms/core/codegen/c_codegen.scala
@@ -17,6 +17,9 @@ class ExtendedCCodeGen extends CompactCodeGen with ExtendedCodeGen {
     case Const(scala.Int.MinValue) => "0x" + scala.Int.MinValue.toHexString
     case Const(scala.Long.MinValue) => "0x" + scala.Long.MinValue.toHexString + "L"
     case Const(x: Double) if x.isNaN => "NAN"
+    case Const(x: Double) if x.isInfinity => "INFINITY"
+    case Const(x: Float) if x.isNaN => "NAN"
+    case Const(x: Float) if x.isInfinity => "INFINITY"
     case Const(null) => "NULL"
     case Const(c: Char) if c.toInt < 0x20 || c.toInt > 0x7F =>
       val res = super.quote(x) // if escaped

--- a/src/main/scala/lms/core/frontend.scala
+++ b/src/main/scala/lms/core/frontend.scala
@@ -111,5 +111,4 @@ class FrontEnd {
     } finally {g = null}
   }
 
-
 }

--- a/src/main/scala/lms/core/stub.scala
+++ b/src/main/scala/lms/core/stub.scala
@@ -477,8 +477,7 @@ trait Base extends EmbeddedControls with OverloadHack with lms.util.ClosureCompa
 
   // MiscOps
   def exit(res: Rep[Int]): Unit = Adapter.g.reflectWrite("exit", Unwrap(res))(Adapter.CTRL)
-  def println(x: Rep[Any]): Unit =
-    Adapter.g.reflectWrite("P",Unwrap(x))(Adapter.CTRL)
+  def println(x: Rep[Any]): Unit = Adapter.g.reflectWrite("P",Unwrap(x))(Adapter.CTRL)
   def printf(f: String, x: Rep[Any]*): Unit = {
     // for (a <- f.split('%'))
     //   System.out.println(s"a:$a")

--- a/src/main/scala/lms/core/traversal.scala
+++ b/src/main/scala/lms/core/traversal.scala
@@ -471,7 +471,6 @@ class CompactTraverser extends Traverser {
   }
 }
 
-
 abstract class Transformer extends Traverser {
   val name: String = "Transformer"
 
@@ -481,28 +480,32 @@ abstract class Transformer extends Traverser {
 
   def transform(s: Exp): Exp = s match {
     case s @ Sym(_) if subst contains s => subst(s)
-    case s @ Sym(_) => println(s"Warning: not found in subst $subst: "+s); s
-    case a => a // must be const
+    case s @ Sym(_) => throw new Exception("not found in subst: "+s)
+    case s @ Const(_) =>
+      if (Adapter.oldTypeMap.contains(s)) Adapter.typeMap(s) = Adapter.oldTypeMap(s)
+      s
   }
 
-  def transform(b: Block): Block = b match {
-    case b @ Block(Nil, res, block, eff) =>
-      g.reify {
+  def transform(b: Block): Block = {
+    val Block(args, res, block, eff) = b
+    g.reify(args.size, { es =>
+      args.filter(subst.contains(_)).foreach { a =>
+        println(s"Warning: already have a subst for $a")
+      }
+      try {
+        args.zipWithIndex.foreach { case (e, i) =>
+          if (Adapter.oldTypeMap.contains(args(i))) {
+            Adapter.typeMap(es(i)) = Adapter.oldTypeMap(args(i))
+          }
+          subst(args(i)) = es(i)
+        }
         //subst(block) = g.effectToExp(g.curBlock) //XXX
-        traverse(b); transform(res)
+        traverse(b)
+        transform(res)
+      } finally {
+        subst --= args
       }
-    case b @ Block(arg::Nil, res, block, eff) =>
-      g.reify { e =>
-        if (subst contains arg)
-          println(s"Warning: already have a subst for $arg")
-        try {
-          subst(arg) = e
-          //subst(block) = g.effectToExp(g.curBlock) //XXX
-          traverse(b)
-          transform(res)
-        } finally subst -= arg
-      }
-    case _ => ???
+    })
   }
 
   def transformRHS(rhs: List[Def]) = rhs.map {
@@ -513,10 +516,8 @@ abstract class Transformer extends Traverser {
 
   def transform(n: Node): Exp = n match {
     case Node(s, "λ", (b @ Block(in, y, ein, eff))::rest, _) =>
-      // need to deal with recursive binding!
-      val s1 = Sym(g.fresh)
-      subst(s) = s1
-      g.reflect(s1, "λ", (transform(b)+:transformRHS(rest)):_*)()
+      // need to deal with recursive binding! yes!
+      g.reflect(subst(s).asInstanceOf[Sym], "λ", (transform(b)+:transformRHS(rest)):_*)()
     case Node(s,op,rs,es) =>
       // effect dependencies in target graph are managed by
       // graph builder, so we drop all effects here
@@ -545,7 +546,13 @@ abstract class Transformer extends Traverser {
   def transform(graph: Graph): Graph = {
     // XXX unfortunate code duplication, either
     // with traverser or with transform(Block)
-
+    for (n <- graph.nodes) {
+      n match {
+        case Node(s, "λ", (b @ Block(in, y, ein, eff))::rest, _) =>
+          subst(s) = Sym(g.fresh)
+        case _ =>
+      }
+    }
     // Handling MetaData 1. save oldTypeMap/SourceMap first
     Adapter.oldDefsCache = graph.globalDefsCache
     Adapter.oldTypeMap = Adapter.typeMap
@@ -570,7 +577,7 @@ abstract class Transformer extends Traverser {
     for ((k, v) <- subst if v.isInstanceOf[Sym] && Adapter.oldSourceMap.contains(k))
       Adapter.sourceMap.getOrElseUpdate(v, Adapter.oldSourceMap(k))
 
-    Graph(g.globalDefs,block, g.globalDefsCache.toMap)
+    Graph(g.globalDefs, block, g.globalDefsCache.toMap)
   }
 
 }

--- a/src/main/scala/lms/core/traversal.scala
+++ b/src/main/scala/lms/core/traversal.scala
@@ -517,7 +517,10 @@ abstract class Transformer extends Traverser {
   def transform(n: Node): Exp = n match {
     case Node(s, "λ", (b @ Block(in, y, ein, eff))::rest, _) =>
       // need to deal with recursive binding! yes!
-      g.reflect(subst(s).asInstanceOf[Sym], "λ", (transform(b)+:transformRHS(rest)):_*)()
+      val s1 = subst(s).asInstanceOf[Sym]
+      if (!g.globalDefsCache.contains(s1))
+        g.reflect(s1, "λ", (transform(b)+:transformRHS(rest)):_*)()
+      else s1
     case Node(s,op,rs,es) =>
       // effect dependencies in target graph are managed by
       // graph builder, so we drop all effects here
@@ -553,6 +556,7 @@ abstract class Transformer extends Traverser {
         case _ =>
       }
     }
+
     // Handling MetaData 1. save oldTypeMap/SourceMap first
     Adapter.oldDefsCache = graph.globalDefsCache
     Adapter.oldTypeMap = Adapter.typeMap

--- a/src/main/scala/lms/core/traversal.scala
+++ b/src/main/scala/lms/core/traversal.scala
@@ -483,7 +483,9 @@ abstract class Transformer extends Traverser {
     case s @ Sym(_) =>
       throw new Exception("not found in subst: "+s)
     case s @ Const(_) =>
-      if (Adapter.oldTypeMap.contains(s)) Adapter.typeMap(s) = Adapter.oldTypeMap(s)
+      if (Adapter.oldTypeMap != null && Adapter.oldTypeMap.contains(s)) {
+        Adapter.typeMap(s) = Adapter.oldTypeMap(s)
+      }
       s
   }
 
@@ -540,9 +542,9 @@ abstract class Transformer extends Traverser {
     // Also pass the metadata to the new exp
     // We use `getOrElseUpdate` because the handling of each node might
     // have already filled a proper value, which we don't want to override
-    if (Adapter.oldTypeMap.contains(n.n))
+    if (Adapter.oldTypeMap != null && Adapter.oldTypeMap.contains(n.n))
       Adapter.typeMap.getOrElseUpdate(subst(n.n), Adapter.oldTypeMap(n.n))
-    if (Adapter.oldSourceMap.contains(n.n))
+    if (Adapter.oldTypeMap != null && Adapter.oldSourceMap.contains(n.n))
       Adapter.sourceMap.getOrElseUpdate(subst(n.n), Adapter.oldSourceMap(n.n))
   }
 
@@ -578,10 +580,14 @@ abstract class Transformer extends Traverser {
 
     // Handling MetaData 3. update new metadata with old metadata
     // this is not redundant because of the block arguments (function definitions)
-    for ((k, v) <- subst if v.isInstanceOf[Sym] && Adapter.oldTypeMap.contains(k))
-      Adapter.typeMap.getOrElseUpdate(v, Adapter.oldTypeMap(k))
-    for ((k, v) <- subst if v.isInstanceOf[Sym] && Adapter.oldSourceMap.contains(k))
-      Adapter.sourceMap.getOrElseUpdate(v, Adapter.oldSourceMap(k))
+    if (Adapter.oldTypeMap != null) {
+      for ((k, v) <- subst if v.isInstanceOf[Sym] && Adapter.oldTypeMap.contains(k))
+        Adapter.typeMap.getOrElseUpdate(v, Adapter.oldTypeMap(k))
+    }
+    if (Adapter.oldSourceMap != null) {
+      for ((k, v) <- subst if v.isInstanceOf[Sym] && Adapter.oldSourceMap.contains(k))
+        Adapter.sourceMap.getOrElseUpdate(v, Adapter.oldSourceMap(k))
+    }
 
     Graph(g.globalDefs, block, g.globalDefsCache.toMap)
   }

--- a/src/main/scala/lms/core/traversal.scala
+++ b/src/main/scala/lms/core/traversal.scala
@@ -480,7 +480,8 @@ abstract class Transformer extends Traverser {
 
   def transform(s: Exp): Exp = s match {
     case s @ Sym(_) if subst contains s => subst(s)
-    case s @ Sym(_) => throw new Exception("not found in subst: "+s)
+    case s @ Sym(_) =>
+      throw new Exception("not found in subst: "+s)
     case s @ Const(_) =>
       if (Adapter.oldTypeMap.contains(s)) Adapter.typeMap(s) = Adapter.oldTypeMap(s)
       s
@@ -503,7 +504,7 @@ abstract class Transformer extends Traverser {
         traverse(b)
         transform(res)
       } finally {
-        subst --= args
+        //subst --= args
       }
     })
   }
@@ -527,8 +528,9 @@ abstract class Transformer extends Traverser {
       val (effects,pure) = (es.deps,rs)
       val args = transformRHS(pure)
       // NOTE: we're not transforming 'effects' here (just the keys)
-      if (effects.nonEmpty)
+      if (effects.nonEmpty) {
         g.reflectEffect(op,args:_*)(es.rkeys.map(transform).toSeq:_*)(es.wkeys.map(transform).toSeq:_*)
+      }
       else
         g.reflect(op,args:_*)
   }

--- a/src/out/cps/dc_if.check.scala
+++ b/src/out/cps/dc_if.check.scala
@@ -1,27 +1,27 @@
 class Snippet extends (Int => Int) {
   def apply(x1: Int): Int = {
     val x3 = x1 * 2
-    val x11 = x3 > 5
-    def cIf0(x16: Int) = {
-      val x18 = {
+    val x12 = x3 > 5
+    def cIf0(x17: Int) = {
+      val x19 = {
         def x6(x10: Int) = {
-          val x17 = x10 * x16
-          x17
+          val x18 = x10 * x17
+          x18
         }
         val x7 = x6(x1)
         val x8 = x6(x7)
         val x9 = x8 + 3
         x9
       }
-      val x19 = x18 + 10
-      x19 /*exit x19*/
+      val x20 = x19 + 10
+      x20 /*exit x20*/
     }
-    if (x11) {
-      val x13 = x1 - 5
-      cIf0(x13)
+    if (x12) {
+      val x14 = x1 - 5
+      cIf0(x14)
     } else {
-      val x15 = x1 + 5
-      cIf0(x15)
+      val x16 = x1 + 5
+      cIf0(x16)
     }
   }
 }

--- a/src/out/cps/dc_lambda.check.scala
+++ b/src/out/cps/dc_lambda.check.scala
@@ -5,21 +5,21 @@ class Snippet extends (Int => Int) {
       val x9 = x8 * 2
       c(x9)
     }
-    def cApp0(x15: Int) = {
-      def cApp1(x16: Int) = {
-        val x18 = {
+    def cApp0(x16: Int) = {
+      def cApp1(x17: Int) = {
+        val x19 = {
           def x11(x14: Int) = {
-            val x17 = x14 + x16
-            x17
+            val x18 = x14 + x17
+            x18
           }
           val x12 = x11(x1)
           val x13 = x11(x12)
           x13
         }
-        val x19 = x18 + 5
-        x19 /*exit x19*/
+        val x20 = x19 + 5
+        x20 /*exit x20*/
       }
-      x6(cApp1, x15)
+      x6(cApp1, x16)
     }
     x6(cApp0, x3)
   }

--- a/src/out/cps/whileDc.check.scala
+++ b/src/out/cps/whileDc.check.scala
@@ -1,16 +1,16 @@
 class Snippet extends (Int => Int) {
   def apply(x1: Int): Int = {
-    val x26 = {
+    val x27 = {
       var x3 = 0
       var x4 = 0
       def loop0(): Int = {
         val x6 = x3
         val x7 = x6 < 5
         if (x7) {
-          def x10(x19: Int) = {
-            val x21 = x3
-            val x22 = x21 + 1
-            x3 = x22
+          def x10(x20: Int) = {
+            val x22 = x3
+            val x23 = x22 + 1
+            x3 = x23
             loop0()
           }
           val x11 = x4
@@ -23,14 +23,14 @@ class Snippet extends (Int => Int) {
           x4 = x17
           x17
         } else {
-          val x25 = x4
-          x25
+          val x26 = x4
+          x26
         }
       }
       loop0()
     }
-    val x27 = x26 + 4
-    x27 /*exit x27*/
+    val x28 = x27 + 4
+    x28 /*exit x28*/
   }
 }
 // output:

--- a/src/out/cps/whileDc2.check.scala
+++ b/src/out/cps/whileDc2.check.scala
@@ -9,10 +9,10 @@ class Snippet extends (Int => Int) {
         val x8 = x2
         val x9 = x8 + 1
         x2 = x9
-        val x24 = {
-          def x13(x22: Int) = {
-            val x23 = x22 * 2
-            x23
+        val x25 = {
+          def x13(x23: Int) = {
+            val x24 = x23 * 2
+            x24
           }
           val x14 = x3
           val x15 = x13(x14)
@@ -26,8 +26,8 @@ class Snippet extends (Int => Int) {
         }
         loop0()
       } else {
-        val x27 = x3
-        x27 /*exit x27*/
+        val x28 = x3
+        x28 /*exit x28*/
       }
     }
     loop0()

--- a/src/out/demos/tensors/tensors-01.check.scala
+++ b/src/out/demos/tensors/tensors-01.check.scala
@@ -17,6 +17,8 @@ def tensors_01(x0: Int): Int = {
   println(tensor(List(3, 4, 5), x6 => tensor_apply(x3, x6) + tensor_apply(x1, x6)))
   0
 }
+Warning: already have a subst for x3
+Warning: already have a subst for x6
 // After Tensor fusion V:
 def tensors_01(x0: Int): Int = {
   println(tensor(List(3, 4, 5), x1 => 2))

--- a/src/out/demos/tensors/tensors-02.check.scala
+++ b/src/out/demos/tensors/tensors-02.check.scala
@@ -24,6 +24,9 @@ def tensors_02(x0: Int): Int = {
   }) / 100 - x7 * x7)
   0
 }
+Warning: already have a subst for x3
+Warning: already have a subst for x6
+Warning: already have a subst for x11
 // After Tensor fusion V:
 def tensors_02(x0: Int): Int = {
   val x1 = sum(List(100), x2 => 1 + 2 * seq_apply(x2, 0)) / 100

--- a/src/out/transformer/distributed_tensor/masked_fill/masked_fill.check.cu
+++ b/src/out/transformer/distributed_tensor/masked_fill/masked_fill.check.cu
@@ -200,14 +200,14 @@ void Snippet(int x0) {
   CUDA_CALL(cudaMalloc(&x60, (size_t)(81 * sizeof(float))));
   x10<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x60, 1, 81);
   // end initializing fixed GPU array of size 81 and type Float and device (pre-rename) x39
-  // begin computing ACCUM on GPU for size 81 and type Float at device (pre-rename) x39 with base_operand x286 and addition_operand x309
+  // begin computing ACCUM on GPU for size 81 and type Float at device (pre-rename) x39 with base_operand x312 and addition_operand x335
   CUDA_CALL(cudaSetDevice(x6));
   x61<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x58, x60, 81);
-  // end computing ACCUM on GPU for size 81 and type Float at device (pre-rename) x39 with base_operand x286 and addition_operand x309
-  // begin computing ACCUM on GPU for size 81 and type Float at device (pre-rename) x39 with base_operand x273 and addition_operand x309
+  // end computing ACCUM on GPU for size 81 and type Float at device (pre-rename) x39 with base_operand x312 and addition_operand x335
+  // begin computing ACCUM on GPU for size 81 and type Float at device (pre-rename) x39 with base_operand x299 and addition_operand x335
   CUDA_CALL(cudaSetDevice(x6));
   x61<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x57, x60, 81);
-  // end computing ACCUM on GPU for size 81 and type Float at device (pre-rename) x39 with base_operand x273 and addition_operand x309
+  // end computing ACCUM on GPU for size 81 and type Float at device (pre-rename) x39 with base_operand x299 and addition_operand x335
   // begin allocating gpu array of size 81 and type Float for the gradient input of masked fill
   CUDA_CALL(cudaSetDevice(x6));
   float* x68 = (float*)malloc(0 * sizeof(float));
@@ -216,10 +216,10 @@ void Snippet(int x0) {
   // begin calling masked fill gradient kernel
   x69<<<dim3(1, 1, 1), dim3(512, 1, 1)>>>(x58, x68, x19, 9, 9, 9, 1, 81);
   // end calling masked fill gradient kernel
-  // begin computing ACCUM on GPU for size 81 and type Float at device (pre-rename) x39 with base_operand x62 and addition_operand x366
+  // begin computing ACCUM on GPU for size 81 and type Float at device (pre-rename) x39 with base_operand x62 and addition_operand x392
   CUDA_CALL(cudaSetDevice(x6));
   x61<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x9, x68, 81);
-  // end computing ACCUM on GPU for size 81 and type Float at device (pre-rename) x39 with base_operand x62 and addition_operand x366
+  // end computing ACCUM on GPU for size 81 and type Float at device (pre-rename) x39 with base_operand x62 and addition_operand x392
   // begin checking GPU array of size 81 and type Float
   float* x95 = (float*)malloc(81 * sizeof(float));
   CUDA_CALL(cudaMemcpy(x95, x9, (size_t)(81 * sizeof(float)), cudaMemcpyDeviceToHost));

--- a/src/out/transformer/distributed_tensor/permute/permute.check.cu
+++ b/src/out/transformer/distributed_tensor/permute/permute.check.cu
@@ -129,10 +129,10 @@ void Snippet(int x0) {
   // begin calling permute kernel
   x10<<<dim3(2, 2, 50), dim3(32, 8, 1)>>>(x34, x35, 50, 60, 55);
   // end calling permute kernel
-  // begin computing ACCUM on GPU for size 165000 and type Float at device (pre-rename) x39 with base_operand x196 and addition_operand x259
+  // begin computing ACCUM on GPU for size 165000 and type Float at device (pre-rename) x39 with base_operand x199 and addition_operand x262
   CUDA_CALL(cudaSetDevice(x6));
   x36<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x26, x35, 165000);
-  // end computing ACCUM on GPU for size 165000 and type Float at device (pre-rename) x39 with base_operand x196 and addition_operand x259
+  // end computing ACCUM on GPU for size 165000 and type Float at device (pre-rename) x39 with base_operand x199 and addition_operand x262
   // begin checking GPU array of size 165000 and type Float
   float* x43 = (float*)malloc(165000 * sizeof(float));
   CUDA_CALL(cudaMemcpy(x43, x26, (size_t)(165000 * sizeof(float)), cudaMemcpyDeviceToHost));

--- a/src/out/transformer/distributed_tensor/permute_120/permute_120.check.cu
+++ b/src/out/transformer/distributed_tensor/permute_120/permute_120.check.cu
@@ -129,10 +129,10 @@ void Snippet(int x0) {
   // begin calling permute kernel
   x10<<<dim3(1, 6, 1), dim3(32, 1, 8)>>>(x34, x35, 5, 6, 6);
   // end calling permute kernel
-  // begin computing ACCUM on GPU for size 180 and type Float at device (pre-rename) x39 with base_operand x196 and addition_operand x259
+  // begin computing ACCUM on GPU for size 180 and type Float at device (pre-rename) x39 with base_operand x199 and addition_operand x262
   CUDA_CALL(cudaSetDevice(x6));
   x36<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x26, x35, 180);
-  // end computing ACCUM on GPU for size 180 and type Float at device (pre-rename) x39 with base_operand x196 and addition_operand x259
+  // end computing ACCUM on GPU for size 180 and type Float at device (pre-rename) x39 with base_operand x199 and addition_operand x262
   // begin checking GPU array of size 180 and type Float
   float* x43 = (float*)malloc(180 * sizeof(float));
   CUDA_CALL(cudaMemcpy(x43, x26, (size_t)(180 * sizeof(float)), cudaMemcpyDeviceToHost));

--- a/src/out/transformer/distributed_tensor/split/split.check.cu
+++ b/src/out/transformer/distributed_tensor/split/split.check.cu
@@ -164,36 +164,36 @@ void Snippet(int x0) {
   CUDA_CALL(cudaMalloc(&x45, (size_t)(256 * sizeof(float))));
   x10<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x45, 1, 256);
   // end initializing fixed GPU array of size 256 and type Float and device (pre-rename) x39
-  // begin computing MULT on GPU for size 256 and type Float at device (pre-rename) x39 with left_operand x45 and right_operand x279
+  // begin computing MULT on GPU for size 256 and type Float at device (pre-rename) x39 with left_operand x45 and right_operand x282
   CUDA_CALL(cudaSetDevice(x6));
   float* x46 = (float*)malloc(0 * sizeof(float));
   CUDA_CALL(cudaMalloc(&x46, (size_t)(256 * sizeof(float))));
   x33<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x8, x45, x46, 256);
-  // end computing MULT on GPU for size 256 and type Float at device (pre-rename) x39 with left_operand x45 and right_operand x279
-  // begin computing ACCUM on GPU for size 256 and type Float at device (pre-rename) x39 with base_operand x243 and addition_operand x292
+  // end computing MULT on GPU for size 256 and type Float at device (pre-rename) x39 with left_operand x45 and right_operand x282
+  // begin computing ACCUM on GPU for size 256 and type Float at device (pre-rename) x39 with base_operand x246 and addition_operand x295
   CUDA_CALL(cudaSetDevice(x6));
   x47<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x42, x46, 256);
-  // end computing ACCUM on GPU for size 256 and type Float at device (pre-rename) x39 with base_operand x243 and addition_operand x292
-  // begin computing MULT on GPU for size 256 and type Float at device (pre-rename) x39 with left_operand x120 and right_operand x279
+  // end computing ACCUM on GPU for size 256 and type Float at device (pre-rename) x39 with base_operand x246 and addition_operand x295
+  // begin computing MULT on GPU for size 256 and type Float at device (pre-rename) x39 with left_operand x120 and right_operand x282
   CUDA_CALL(cudaSetDevice(x6));
   float* x54 = (float*)malloc(0 * sizeof(float));
   CUDA_CALL(cudaMalloc(&x54, (size_t)(256 * sizeof(float))));
   x33<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x18, x45, x54, 256);
-  // end computing MULT on GPU for size 256 and type Float at device (pre-rename) x39 with left_operand x120 and right_operand x279
-  // begin computing ACCUM on GPU for size 256 and type Float at device (pre-rename) x39 with base_operand x62 and addition_operand x342
+  // end computing MULT on GPU for size 256 and type Float at device (pre-rename) x39 with left_operand x120 and right_operand x282
+  // begin computing ACCUM on GPU for size 256 and type Float at device (pre-rename) x39 with base_operand x62 and addition_operand x345
   CUDA_CALL(cudaSetDevice(x6));
   x47<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x9, x54, 256);
-  // end computing ACCUM on GPU for size 256 and type Float at device (pre-rename) x39 with base_operand x62 and addition_operand x342
-  // begin computing Concat on GPU for size 16 x 32 and type Float at device (pre-rename) x39 with input0 x243 input1 x256
+  // end computing ACCUM on GPU for size 256 and type Float at device (pre-rename) x39 with base_operand x62 and addition_operand x345
+  // begin computing Concat on GPU for size 16 x 32 and type Float at device (pre-rename) x39 with input0 x246 input1 x259
   CUDA_CALL(cudaSetDevice(x6));
   float* x55 = (float*)malloc(0 * sizeof(float));
   CUDA_CALL(cudaMalloc(&x55, (size_t)(512 * sizeof(float))));
   x56<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x42, x43, x55, 16, 16);
-  // end computing Concat on GPU for size 16 x 32 and type Float at device (pre-rename) x39 with input0 x243 input1 x256
-  // begin computing ACCUM on GPU for size 512 and type Float at device (pre-rename) x39 with base_operand x230 and addition_operand x362
+  // end computing Concat on GPU for size 16 x 32 and type Float at device (pre-rename) x39 with input0 x246 input1 x259
+  // begin computing ACCUM on GPU for size 512 and type Float at device (pre-rename) x39 with base_operand x233 and addition_operand x365
   CUDA_CALL(cudaSetDevice(x6));
   x47<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x41, x55, 512);
-  // end computing ACCUM on GPU for size 512 and type Float at device (pre-rename) x39 with base_operand x230 and addition_operand x362
+  // end computing ACCUM on GPU for size 512 and type Float at device (pre-rename) x39 with base_operand x233 and addition_operand x365
   // begin checking GPU array of size 256 and type Float
   float* x68 = (float*)malloc(256 * sizeof(float));
   CUDA_CALL(cudaMemcpy(x68, x9, (size_t)(256 * sizeof(float)), cudaMemcpyDeviceToHost));

--- a/src/out/transformer/distributed_tensor/split2/split2.check.cu
+++ b/src/out/transformer/distributed_tensor/split2/split2.check.cu
@@ -164,36 +164,36 @@ void Snippet(int x0) {
   CUDA_CALL(cudaMalloc(&x45, (size_t)(256 * sizeof(float))));
   x10<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x45, 1, 256);
   // end initializing fixed GPU array of size 256 and type Float and device (pre-rename) x39
-  // begin computing MULT on GPU for size 256 and type Float at device (pre-rename) x39 with left_operand x120 and right_operand x279
+  // begin computing MULT on GPU for size 256 and type Float at device (pre-rename) x39 with left_operand x120 and right_operand x282
   CUDA_CALL(cudaSetDevice(x6));
   float* x46 = (float*)malloc(0 * sizeof(float));
   CUDA_CALL(cudaMalloc(&x46, (size_t)(256 * sizeof(float))));
   x33<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x18, x45, x46, 256);
-  // end computing MULT on GPU for size 256 and type Float at device (pre-rename) x39 with left_operand x120 and right_operand x279
-  // begin computing ACCUM on GPU for size 256 and type Float at device (pre-rename) x39 with base_operand x230 and addition_operand x292
+  // end computing MULT on GPU for size 256 and type Float at device (pre-rename) x39 with left_operand x120 and right_operand x282
+  // begin computing ACCUM on GPU for size 256 and type Float at device (pre-rename) x39 with base_operand x233 and addition_operand x295
   CUDA_CALL(cudaSetDevice(x6));
   x47<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x41, x46, 256);
-  // end computing ACCUM on GPU for size 256 and type Float at device (pre-rename) x39 with base_operand x230 and addition_operand x292
-  // begin computing MULT on GPU for size 256 and type Float at device (pre-rename) x39 with left_operand x103 and right_operand x279
+  // end computing ACCUM on GPU for size 256 and type Float at device (pre-rename) x39 with base_operand x233 and addition_operand x295
+  // begin computing MULT on GPU for size 256 and type Float at device (pre-rename) x39 with left_operand x103 and right_operand x282
   CUDA_CALL(cudaSetDevice(x6));
   float* x54 = (float*)malloc(0 * sizeof(float));
   CUDA_CALL(cudaMalloc(&x54, (size_t)(256 * sizeof(float))));
   x33<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x17, x45, x54, 256);
-  // end computing MULT on GPU for size 256 and type Float at device (pre-rename) x39 with left_operand x103 and right_operand x279
-  // begin computing ACCUM on GPU for size 256 and type Float at device (pre-rename) x39 with base_operand x243 and addition_operand x342
+  // end computing MULT on GPU for size 256 and type Float at device (pre-rename) x39 with left_operand x103 and right_operand x282
+  // begin computing ACCUM on GPU for size 256 and type Float at device (pre-rename) x39 with base_operand x246 and addition_operand x345
   CUDA_CALL(cudaSetDevice(x6));
   x47<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x42, x54, 256);
-  // end computing ACCUM on GPU for size 256 and type Float at device (pre-rename) x39 with base_operand x243 and addition_operand x342
-  // begin computing Concat on GPU for size 16 x 32 and type Float at device (pre-rename) x39 with input0 x243 input1 x256
+  // end computing ACCUM on GPU for size 256 and type Float at device (pre-rename) x39 with base_operand x246 and addition_operand x345
+  // begin computing Concat on GPU for size 16 x 32 and type Float at device (pre-rename) x39 with input0 x246 input1 x259
   CUDA_CALL(cudaSetDevice(x6));
   float* x55 = (float*)malloc(0 * sizeof(float));
   CUDA_CALL(cudaMalloc(&x55, (size_t)(512 * sizeof(float))));
   x56<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x42, x43, x55, 16, 16);
-  // end computing Concat on GPU for size 16 x 32 and type Float at device (pre-rename) x39 with input0 x243 input1 x256
-  // begin computing ACCUM on GPU for size 512 and type Float at device (pre-rename) x39 with base_operand x62 and addition_operand x362
+  // end computing Concat on GPU for size 16 x 32 and type Float at device (pre-rename) x39 with input0 x246 input1 x259
+  // begin computing ACCUM on GPU for size 512 and type Float at device (pre-rename) x39 with base_operand x62 and addition_operand x365
   CUDA_CALL(cudaSetDevice(x6));
   x47<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x9, x55, 512);
-  // end computing ACCUM on GPU for size 512 and type Float at device (pre-rename) x39 with base_operand x62 and addition_operand x362
+  // end computing ACCUM on GPU for size 512 and type Float at device (pre-rename) x39 with base_operand x62 and addition_operand x365
   // begin checking GPU array of size 512 and type Float
   float* x68 = (float*)malloc(512 * sizeof(float));
   CUDA_CALL(cudaMemcpy(x68, x9, (size_t)(512 * sizeof(float)), cudaMemcpyDeviceToHost));

--- a/src/out/transformer/distributed_tensor/split2_3D/split2_3D.check.cu
+++ b/src/out/transformer/distributed_tensor/split2_3D/split2_3D.check.cu
@@ -166,26 +166,26 @@ void Snippet(int x0) {
   CUDA_CALL(cudaMalloc(&x41, (size_t)(8192 * sizeof(float))));
   x10<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x41, 1, 8192);
   // end initializing fixed GPU array of size 8192 and type Float and device (pre-rename) x39
-  // begin computing MULT on GPU for size 8192 and type Float at device (pre-rename) x39 with left_operand x119 and right_operand x281
+  // begin computing MULT on GPU for size 8192 and type Float at device (pre-rename) x39 with left_operand x119 and right_operand x282
   CUDA_CALL(cudaSetDevice(x6));
   float* x42 = (float*)malloc(0 * sizeof(float));
   CUDA_CALL(cudaMalloc(&x42, (size_t)(8192 * sizeof(float))));
   x29<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x18, x41, x42, 8192);
-  // end computing MULT on GPU for size 8192 and type Float at device (pre-rename) x39 with left_operand x119 and right_operand x281
-  // begin computing ACCUM on GPU for size 8192 and type Float at device (pre-rename) x39 with base_operand x232 and addition_operand x294
+  // end computing MULT on GPU for size 8192 and type Float at device (pre-rename) x39 with left_operand x119 and right_operand x282
+  // begin computing ACCUM on GPU for size 8192 and type Float at device (pre-rename) x39 with base_operand x233 and addition_operand x295
   CUDA_CALL(cudaSetDevice(x6));
   x43<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x37, x42, 8192);
-  // end computing ACCUM on GPU for size 8192 and type Float at device (pre-rename) x39 with base_operand x232 and addition_operand x294
-  // begin computing MULT on GPU for size 8192 and type Float at device (pre-rename) x39 with left_operand x103 and right_operand x281
+  // end computing ACCUM on GPU for size 8192 and type Float at device (pre-rename) x39 with base_operand x233 and addition_operand x295
+  // begin computing MULT on GPU for size 8192 and type Float at device (pre-rename) x39 with left_operand x103 and right_operand x282
   CUDA_CALL(cudaSetDevice(x6));
   float* x50 = (float*)malloc(0 * sizeof(float));
   CUDA_CALL(cudaMalloc(&x50, (size_t)(8192 * sizeof(float))));
   x29<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x17, x41, x50, 8192);
-  // end computing MULT on GPU for size 8192 and type Float at device (pre-rename) x39 with left_operand x103 and right_operand x281
-  // begin computing ACCUM on GPU for size 8192 and type Float at device (pre-rename) x39 with base_operand x245 and addition_operand x344
+  // end computing MULT on GPU for size 8192 and type Float at device (pre-rename) x39 with left_operand x103 and right_operand x282
+  // begin computing ACCUM on GPU for size 8192 and type Float at device (pre-rename) x39 with base_operand x246 and addition_operand x345
   CUDA_CALL(cudaSetDevice(x6));
   x43<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x38, x50, 8192);
-  // end computing ACCUM on GPU for size 8192 and type Float at device (pre-rename) x39 with base_operand x245 and addition_operand x344
+  // end computing ACCUM on GPU for size 8192 and type Float at device (pre-rename) x39 with base_operand x246 and addition_operand x345
   CUDA_CALL(cudaSetDevice(x6));
   float* x51 = (float*)malloc(0 * sizeof(float));
   CUDA_CALL(cudaMalloc(&x51, (size_t)(16384 * sizeof(float))));
@@ -196,10 +196,10 @@ void Snippet(int x0) {
   CUDA_CALL(cudaMalloc(&x53, (size_t)(2 * sizeof(float*))));
   CUDA_CALL(cudaMemcpy(x53, x52, (size_t)(2 * sizeof(float*)), cudaMemcpyHostToDevice));
   x54<<<dim3(32, 1, 1), dim3(512, 1, 1)>>>(x53, x51);
-  // begin computing ACCUM on GPU for size 16384 and type Float at device (pre-rename) x39 with base_operand x62 and addition_operand x363
+  // begin computing ACCUM on GPU for size 16384 and type Float at device (pre-rename) x39 with base_operand x62 and addition_operand x364
   CUDA_CALL(cudaSetDevice(x6));
   x43<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x9, x51, 16384);
-  // end computing ACCUM on GPU for size 16384 and type Float at device (pre-rename) x39 with base_operand x62 and addition_operand x363
+  // end computing ACCUM on GPU for size 16384 and type Float at device (pre-rename) x39 with base_operand x62 and addition_operand x364
   // begin checking GPU array of size 16384 and type Float
   float* x59 = (float*)malloc(16384 * sizeof(float));
   CUDA_CALL(cudaMemcpy(x59, x9, (size_t)(16384 * sizeof(float)), cudaMemcpyDeviceToHost));

--- a/src/out/transformer/distributed_tensor/split3D/split3D.check.cu
+++ b/src/out/transformer/distributed_tensor/split3D/split3D.check.cu
@@ -166,26 +166,26 @@ void Snippet(int x0) {
   CUDA_CALL(cudaMalloc(&x41, (size_t)(8192 * sizeof(float))));
   x10<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x41, 1, 8192);
   // end initializing fixed GPU array of size 8192 and type Float and device (pre-rename) x39
-  // begin computing MULT on GPU for size 8192 and type Float at device (pre-rename) x39 with left_operand x45 and right_operand x281
+  // begin computing MULT on GPU for size 8192 and type Float at device (pre-rename) x39 with left_operand x45 and right_operand x282
   CUDA_CALL(cudaSetDevice(x6));
   float* x42 = (float*)malloc(0 * sizeof(float));
   CUDA_CALL(cudaMalloc(&x42, (size_t)(8192 * sizeof(float))));
   x29<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x8, x41, x42, 8192);
-  // end computing MULT on GPU for size 8192 and type Float at device (pre-rename) x39 with left_operand x45 and right_operand x281
-  // begin computing ACCUM on GPU for size 8192 and type Float at device (pre-rename) x39 with base_operand x245 and addition_operand x294
+  // end computing MULT on GPU for size 8192 and type Float at device (pre-rename) x39 with left_operand x45 and right_operand x282
+  // begin computing ACCUM on GPU for size 8192 and type Float at device (pre-rename) x39 with base_operand x246 and addition_operand x295
   CUDA_CALL(cudaSetDevice(x6));
   x43<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x38, x42, 8192);
-  // end computing ACCUM on GPU for size 8192 and type Float at device (pre-rename) x39 with base_operand x245 and addition_operand x294
-  // begin computing MULT on GPU for size 8192 and type Float at device (pre-rename) x39 with left_operand x119 and right_operand x281
+  // end computing ACCUM on GPU for size 8192 and type Float at device (pre-rename) x39 with base_operand x246 and addition_operand x295
+  // begin computing MULT on GPU for size 8192 and type Float at device (pre-rename) x39 with left_operand x119 and right_operand x282
   CUDA_CALL(cudaSetDevice(x6));
   float* x50 = (float*)malloc(0 * sizeof(float));
   CUDA_CALL(cudaMalloc(&x50, (size_t)(8192 * sizeof(float))));
   x29<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x18, x41, x50, 8192);
-  // end computing MULT on GPU for size 8192 and type Float at device (pre-rename) x39 with left_operand x119 and right_operand x281
-  // begin computing ACCUM on GPU for size 8192 and type Float at device (pre-rename) x39 with base_operand x62 and addition_operand x344
+  // end computing MULT on GPU for size 8192 and type Float at device (pre-rename) x39 with left_operand x119 and right_operand x282
+  // begin computing ACCUM on GPU for size 8192 and type Float at device (pre-rename) x39 with base_operand x62 and addition_operand x345
   CUDA_CALL(cudaSetDevice(x6));
   x43<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x9, x50, 8192);
-  // end computing ACCUM on GPU for size 8192 and type Float at device (pre-rename) x39 with base_operand x62 and addition_operand x344
+  // end computing ACCUM on GPU for size 8192 and type Float at device (pre-rename) x39 with base_operand x62 and addition_operand x345
   CUDA_CALL(cudaSetDevice(x6));
   float* x51 = (float*)malloc(0 * sizeof(float));
   CUDA_CALL(cudaMalloc(&x51, (size_t)(16384 * sizeof(float))));
@@ -196,10 +196,10 @@ void Snippet(int x0) {
   CUDA_CALL(cudaMalloc(&x53, (size_t)(2 * sizeof(float*))));
   CUDA_CALL(cudaMemcpy(x53, x52, (size_t)(2 * sizeof(float*)), cudaMemcpyHostToDevice));
   x54<<<dim3(32, 1, 1), dim3(512, 1, 1)>>>(x53, x51);
-  // begin computing ACCUM on GPU for size 16384 and type Float at device (pre-rename) x39 with base_operand x232 and addition_operand x363
+  // begin computing ACCUM on GPU for size 16384 and type Float at device (pre-rename) x39 with base_operand x233 and addition_operand x364
   CUDA_CALL(cudaSetDevice(x6));
   x43<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x37, x51, 16384);
-  // end computing ACCUM on GPU for size 16384 and type Float at device (pre-rename) x39 with base_operand x232 and addition_operand x363
+  // end computing ACCUM on GPU for size 16384 and type Float at device (pre-rename) x39 with base_operand x233 and addition_operand x364
   // begin checking GPU array of size 8192 and type Float
   float* x59 = (float*)malloc(8192 * sizeof(float));
   CUDA_CALL(cudaMemcpy(x59, x9, (size_t)(8192 * sizeof(float)), cudaMemcpyDeviceToHost));

--- a/src/out/transformer/distributed_tensor/split4_3D/split4_3D.check.cu
+++ b/src/out/transformer/distributed_tensor/split4_3D/split4_3D.check.cu
@@ -190,26 +190,26 @@ void Snippet(int x0) {
   CUDA_CALL(cudaMalloc(&x45, (size_t)(4096 * sizeof(float))));
   x10<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x45, 1, 4096);
   // end initializing fixed GPU array of size 4096 and type Float and device (pre-rename) x39
-  // begin computing MULT on GPU for size 4096 and type Float at device (pre-rename) x39 with left_operand x119 and right_operand x341
+  // begin computing MULT on GPU for size 4096 and type Float at device (pre-rename) x39 with left_operand x119 and right_operand x344
   CUDA_CALL(cudaSetDevice(x6));
   float* x46 = (float*)malloc(0 * sizeof(float));
   CUDA_CALL(cudaMalloc(&x46, (size_t)(4096 * sizeof(float))));
   x31<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x18, x45, x46, 4096);
-  // end computing MULT on GPU for size 4096 and type Float at device (pre-rename) x39 with left_operand x119 and right_operand x341
-  // begin computing ACCUM on GPU for size 4096 and type Float at device (pre-rename) x39 with base_operand x266 and addition_operand x354
+  // end computing MULT on GPU for size 4096 and type Float at device (pre-rename) x39 with left_operand x119 and right_operand x344
+  // begin computing ACCUM on GPU for size 4096 and type Float at device (pre-rename) x39 with base_operand x269 and addition_operand x357
   CUDA_CALL(cudaSetDevice(x6));
   x47<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x39, x46, 4096);
-  // end computing ACCUM on GPU for size 4096 and type Float at device (pre-rename) x39 with base_operand x266 and addition_operand x354
-  // begin computing MULT on GPU for size 4096 and type Float at device (pre-rename) x39 with left_operand x103 and right_operand x341
+  // end computing ACCUM on GPU for size 4096 and type Float at device (pre-rename) x39 with base_operand x269 and addition_operand x357
+  // begin computing MULT on GPU for size 4096 and type Float at device (pre-rename) x39 with left_operand x103 and right_operand x344
   CUDA_CALL(cudaSetDevice(x6));
   float* x54 = (float*)malloc(0 * sizeof(float));
   CUDA_CALL(cudaMalloc(&x54, (size_t)(4096 * sizeof(float))));
   x31<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x17, x45, x54, 4096);
-  // end computing MULT on GPU for size 4096 and type Float at device (pre-rename) x39 with left_operand x103 and right_operand x341
-  // begin computing ACCUM on GPU for size 4096 and type Float at device (pre-rename) x39 with base_operand x279 and addition_operand x404
+  // end computing MULT on GPU for size 4096 and type Float at device (pre-rename) x39 with left_operand x103 and right_operand x344
+  // begin computing ACCUM on GPU for size 4096 and type Float at device (pre-rename) x39 with base_operand x282 and addition_operand x407
   CUDA_CALL(cudaSetDevice(x6));
   x47<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x40, x54, 4096);
-  // end computing ACCUM on GPU for size 4096 and type Float at device (pre-rename) x39 with base_operand x279 and addition_operand x404
+  // end computing ACCUM on GPU for size 4096 and type Float at device (pre-rename) x39 with base_operand x282 and addition_operand x407
   CUDA_CALL(cudaSetDevice(x6));
   float* x55 = (float*)malloc(0 * sizeof(float));
   CUDA_CALL(cudaMalloc(&x55, (size_t)(16384 * sizeof(float))));
@@ -222,10 +222,10 @@ void Snippet(int x0) {
   CUDA_CALL(cudaMalloc(&x57, (size_t)(4 * sizeof(float*))));
   CUDA_CALL(cudaMemcpy(x57, x56, (size_t)(4 * sizeof(float*)), cudaMemcpyHostToDevice));
   x58<<<dim3(32, 1, 1), dim3(512, 1, 1)>>>(x57, x55);
-  // begin computing ACCUM on GPU for size 16384 and type Float at device (pre-rename) x39 with base_operand x62 and addition_operand x423
+  // begin computing ACCUM on GPU for size 16384 and type Float at device (pre-rename) x39 with base_operand x62 and addition_operand x426
   CUDA_CALL(cudaSetDevice(x6));
   x47<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x9, x55, 16384);
-  // end computing ACCUM on GPU for size 16384 and type Float at device (pre-rename) x39 with base_operand x62 and addition_operand x423
+  // end computing ACCUM on GPU for size 16384 and type Float at device (pre-rename) x39 with base_operand x62 and addition_operand x426
   // begin checking GPU array of size 16384 and type Float
   float* x63 = (float*)malloc(16384 * sizeof(float));
   CUDA_CALL(cudaMemcpy(x63, x9, (size_t)(16384 * sizeof(float)), cudaMemcpyDeviceToHost));

--- a/src/out/transformer/distributed_tensor/split_small/split_small.check.cu
+++ b/src/out/transformer/distributed_tensor/split_small/split_small.check.cu
@@ -127,16 +127,16 @@ void Snippet(int x0) {
   CUDA_CALL(cudaMalloc(&x32, (size_t)(256 * sizeof(float))));
   x24<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x32, 1, 256);
   // end initializing fixed GPU array of size 256 and type Float and device (pre-rename) x39
-  // begin computing Concat on GPU for size 16 x 32 and type Float at device (pre-rename) x39 with input0 x191 input1 x168
+  // begin computing Concat on GPU for size 16 x 32 and type Float at device (pre-rename) x39 with input0 x194 input1 x171
   CUDA_CALL(cudaSetDevice(x6));
   float* x33 = (float*)malloc(0 * sizeof(float));
   CUDA_CALL(cudaMalloc(&x33, (size_t)(512 * sizeof(float))));
   x34<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x32, x30, x33, 16, 16);
-  // end computing Concat on GPU for size 16 x 32 and type Float at device (pre-rename) x39 with input0 x191 input1 x168
-  // begin computing ACCUM on GPU for size 512 and type Float at device (pre-rename) x39 with base_operand x128 and addition_operand x204
+  // end computing Concat on GPU for size 16 x 32 and type Float at device (pre-rename) x39 with input0 x194 input1 x171
+  // begin computing ACCUM on GPU for size 512 and type Float at device (pre-rename) x39 with base_operand x131 and addition_operand x207
   CUDA_CALL(cudaSetDevice(x6));
   x46<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x23, x33, 512);
-  // end computing ACCUM on GPU for size 512 and type Float at device (pre-rename) x39 with base_operand x128 and addition_operand x204
+  // end computing ACCUM on GPU for size 512 and type Float at device (pre-rename) x39 with base_operand x131 and addition_operand x207
   // begin checking GPU array of size 512 and type Float
   float* x53 = (float*)malloc(512 * sizeof(float));
   CUDA_CALL(cudaMemcpy(x53, x23, (size_t)(512 * sizeof(float)), cudaMemcpyDeviceToHost));

--- a/src/out/transformer/distributed_tensor/split_small3D/split_small3D.check.cu
+++ b/src/out/transformer/distributed_tensor/split_small3D/split_small3D.check.cu
@@ -139,10 +139,10 @@ void Snippet(int x0) {
   CUDA_CALL(cudaMalloc(&x31, (size_t)(2 * sizeof(float*))));
   CUDA_CALL(cudaMemcpy(x31, x30, (size_t)(2 * sizeof(float*)), cudaMemcpyHostToDevice));
   x32<<<dim3(32, 1, 1), dim3(512, 1, 1)>>>(x31, x29);
-  // begin computing ACCUM on GPU for size 16384 and type Float at device (pre-rename) x39 with base_operand x130 and addition_operand x205
+  // begin computing ACCUM on GPU for size 16384 and type Float at device (pre-rename) x39 with base_operand x131 and addition_operand x206
   CUDA_CALL(cudaSetDevice(x6));
   x37<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x19, x29, 16384);
-  // end computing ACCUM on GPU for size 16384 and type Float at device (pre-rename) x39 with base_operand x130 and addition_operand x205
+  // end computing ACCUM on GPU for size 16384 and type Float at device (pre-rename) x39 with base_operand x131 and addition_operand x206
   // begin checking GPU array of size 16384 and type Float
   float* x44 = (float*)malloc(16384 * sizeof(float));
   CUDA_CALL(cudaMemcpy(x44, x19, (size_t)(16384 * sizeof(float)), cudaMemcpyDeviceToHost));

--- a/src/out/transformer/distributed_tensor/transpose/transpose.check.cu
+++ b/src/out/transformer/distributed_tensor/transpose/transpose.check.cu
@@ -127,10 +127,10 @@ void Snippet(int x0) {
   // begin calling transpose kernel
   x10<<<dim3(4, 2, 1), dim3(32, 8, 1)>>>(x30, x31, 56, 107);
   // end calling transpose kernel
-  // begin computing ACCUM on GPU for size 5992 and type Float at device (pre-rename) x39 with base_operand x181 and addition_operand x244
+  // begin computing ACCUM on GPU for size 5992 and type Float at device (pre-rename) x39 with base_operand x182 and addition_operand x245
   CUDA_CALL(cudaSetDevice(x6));
   x32<<<dim3(28, 1, 1), dim3(512, 1, 1)>>>(x22, x31, 5992);
-  // end computing ACCUM on GPU for size 5992 and type Float at device (pre-rename) x39 with base_operand x181 and addition_operand x244
+  // end computing ACCUM on GPU for size 5992 and type Float at device (pre-rename) x39 with base_operand x182 and addition_operand x245
   // begin checking GPU array of size 5992 and type Float
   float* x39 = (float*)malloc(5992 * sizeof(float));
   CUDA_CALL(cudaMemcpy(x39, x22, (size_t)(5992 * sizeof(float)), cudaMemcpyDeviceToHost));

--- a/src/test/scala/lms/demos/tensors/test7_tensors2.scala
+++ b/src/test/scala/lms/demos/tensors/test7_tensors2.scala
@@ -89,7 +89,6 @@ class TensorFrontEnd2 extends FrontEnd {
     }
   }
 
-
   var name: String = ""
 
   var rewrites: (String => Any => Option[Exp]) = (s => x => None)
@@ -309,7 +308,6 @@ class TensorFrontEnd2 extends FrontEnd {
       rewrites(name)((s,as))
     }
 
-
     override def reflect(s: String, as: Def*): Exp = (s,as.toList) match {
       case ("+", List(Const(a:Int),Const(b:Int))) => Const(a+b)
       case ("-", List(Const(a:Int),Const(b:Int))) => Const(a-b)
@@ -326,11 +324,7 @@ class TensorFrontEnd2 extends FrontEnd {
         super.reflect(s, as:_*)
     }
   }
-
-
 }
-
-
 
 class TensorTransformer(name: String) extends Transformer {
   val frontEnd: TensorFrontEnd2 = new TensorFrontEnd2
@@ -338,8 +332,6 @@ class TensorTransformer(name: String) extends Transformer {
   frontEnd.name = name
   g = frontEnd.g
 }
-
-
 
 class TensorFusionH2 extends TensorTransformer("TensorFusionH2") {
   import frontEnd._
@@ -413,17 +405,11 @@ class TensorFusionH2 extends TensorTransformer("TensorFusionH2") {
           val summary = this.g.getEffKeys(newBody)
           val fusedLoopSym = this.g.reflectEffectSummary("forloops", shape, this.g.reflect("λ",newBody))(summary)
       }
-
     } else {
       super.traverse(ns,y)
     }
   }
-
-
 }
-
-
-
 
 class TensorTest2 extends TutorialFunSuite {
   val under = "demos/tensors/tensors-"
@@ -577,7 +563,6 @@ class TensorTest2 extends TutorialFunSuite {
   }
 */
   testBE("03") { x =>
-
     val m = foobar(7)
     val n = foobar(m)
 
@@ -587,7 +572,6 @@ class TensorTest2 extends TutorialFunSuite {
 
 
   testBE("04") { x =>
-
     val m = Tensor1(SEQ(3,4,5), x => x(0) + x(1) + x(2))
     val n = tensor_add1(m,m)
     PRINT(n)
@@ -595,7 +579,6 @@ class TensorTest2 extends TutorialFunSuite {
   }
 
   testBE("05", eff=true) { x =>
-
     val m = Tensor1(SEQ(3,4,5), x => x(0) + x(1) + x(2))
     val a = tensor_add1(m,m)
     PRINT(a)
@@ -628,6 +611,5 @@ class TensorTest2 extends TutorialFunSuite {
     PRINT(v)
     0
   }
-
 
 }


### PR DESCRIPTION
For a downstream customization, I need to expose the symbol name when calling `reflectEffect`. 

An overloaded function `reflectEffect` with the same old interface is also added to keep compatibility. 