### PR TITLE
Alternative scheduler with proper graph traversal

### DIFF
--- a/src/main/scala/lms/core/codegen.scala
+++ b/src/main/scala/lms/core/codegen.scala
@@ -14,7 +14,7 @@ class Unknown // HACK: Sentinel for typeMap
  * This `GenericCodeGen` class demonstrates a minimal code generator from Traverser.
  * It is not used in production.
  */
-class GenericCodeGen extends Traverser {
+class GenericCodeGen extends Traverser with GraphTraversal {
 
   def emit(s: String) = println(s)
 

--- a/src/main/scala/lms/core/codegen/cps_codegen.scala
+++ b/src/main/scala/lms/core/codegen/cps_codegen.scala
@@ -156,8 +156,9 @@ class CPSScalaCodeGen extends CPSTraverser {
 
   override def apply(g: Graph): Unit = {
     bound(g)
-    path = Nil; inner = g.nodes
-    traverse(g.block){ e => emit(s"${quote(e)} /*exit ${quote(e)}*/") }
+    withScope(Nil, g.nodes) {
+      traverse(g.block){ e => emit(s"${quote(e)} /*exit ${quote(e)}*/") }
+    }
   }
 
   def emitAll(g: Graph)(m1:Manifest[_],m2:Manifest[_]): Unit = {

--- a/src/main/scala/lms/core/codegen/scala_codegen.scala
+++ b/src/main/scala/lms/core/codegen/scala_codegen.scala
@@ -12,7 +12,7 @@ import Backend._
  * The `ScalaCodeGen` is a simple code generation class built on Traverser.
  * It is not used in production.
  */
-class ScalaCodeGen extends Traverser {
+class ScalaCodeGen extends Traverser with GraphTraversal {
 
   def emit(s: String) = println(s)
 

--- a/src/main/scala/lms/core/traversal.scala
+++ b/src/main/scala/lms/core/traversal.scala
@@ -337,7 +337,7 @@ trait GraphTraversal extends Traverser {
     val reachCold = add(_, false, true)
     val reachSoft = add(_, true, false)
 
-    def toSchedule = {
+    def toSchedule =
       new Iterator[RepNode] {
         override def hasNext = !queue.isEmpty
         override def next() = {
@@ -347,7 +347,6 @@ trait GraphTraversal extends Traverser {
           ret
         }
       }
-    }
   }
 
   override def scheduleBlock_[T](y: Block, extra: Sym*)(f: (List[Sym], Seq[Node], Seq[Node], Block) => T): T = {

--- a/src/main/scala/lms/core/traversal.scala
+++ b/src/main/scala/lms/core/traversal.scala
@@ -109,9 +109,9 @@ abstract class Traverser {
   // we have to pass the "old" environment to the `b`.
   // Checkout the `CPSTraverser` and `CPSTransformer` below for more details.
   def withScopeCPS[T](p: List[Sym], ns: Seq[Node])(b: (List[Sym], Seq[Node]) => T): T = {
-    val (path0, inner0) = (path, inner)
-    path = p; inner = ns;
-    try b(path0, inner0) finally { path = path0; inner = inner0 }
+    val (path0, inner0, lookup0) = (path, inner, lookupInner)
+    path = p; inner = ns; lookupInner = RepNode.buildLookup(inner)
+    try b(path0, inner0) finally { path = path0; inner = inner0; lookupInner = lookup0 }
   }
 
   // This `withResetScope` function maintains the old `inner` when entering a new block
@@ -120,8 +120,10 @@ abstract class Traverser {
   def withResetScope[T](p: List[Sym], ns: Seq[Node])(b: => T): T = {
     assert(path.takeRight(p.length) == p, s"$path -- $p")
     val inner0 = inner
+    val lookup0 = lookupInner
     inner = ns
-    try b finally { inner = inner0 }
+    lookupInner = RepNode.buildLookup(inner)
+    try b finally { inner = inner0; lookupInner = lookup0 }
   }
 
   // This `scheduleBlock` function wraps on the `scheduleBlock_` function, while

--- a/src/main/scala/lms/core/traversal.scala
+++ b/src/main/scala/lms/core/traversal.scala
@@ -322,8 +322,7 @@ trait GraphTraversal extends Traverser {
           if (rp.inQueue) {
             rp.reachableHot |= reachHot
             rp.reachableHard |= reachHard
-          }
-          else {
+          } else {
             rp.inQueue = true
             rp.reachableHot = reachHot
             rp.reachableHard = reachHard
@@ -370,15 +369,13 @@ trait GraphTraversal extends Traverser {
             if (f > 0.5) g.reach(e) else g.reachCold(e)
           n.node.eff.sdeps foreach g.reachSoft
           outer1 = n.node +: outer1
-        }
-        else {
+        } else {
           // QUESTION(feiw): why we don't split via frequency here?
           if (n.reachableHard)
             hardSyms(n.node) foreach g.reach
           inner1 = n.node +: inner1
         }
-      }
-      else {
+      } else {
         hardSyms(n.node) foreach g.reachCold
         inner1 = n.node +: inner1
       }
@@ -640,8 +637,7 @@ abstract class Transformer extends Traverser {
       // NOTE: we're not transforming 'effects' here (just the keys)
       if (effects.nonEmpty) {
         g.reflectEffect(op,args:_*)(es.rkeys.map(transform).toSeq:_*)(es.wkeys.map(transform).toSeq:_*)
-      }
-      else
+      } else
         g.reflect(op,args:_*)
   }
 

--- a/src/main/scala/lms/core/traversal.scala
+++ b/src/main/scala/lms/core/traversal.scala
@@ -393,7 +393,7 @@ trait GraphTraversal extends Traverser {
  * what needs to happen after are captured in the `continuation`, such that when
  * a `traverse` function returns, the traverse of all the nodes are done already.
  */
-abstract class CPSTraverser extends Traverser {
+abstract class CPSTraverser extends Traverser with GraphTraversal {
 
   // Note that the continuation of `traverse(block)` need to use the original
   // `path0` and `inner0`, as shown in the `(v => withScope(path0, inner0)(k(v)))`
@@ -428,7 +428,7 @@ abstract class CPSTraverser extends Traverser {
 }
 
 
-class CompactTraverser extends Traverser {
+class CompactTraverser extends Traverser with GraphTraversal {
 
   def mayInline(n: Node): Boolean = n match {
     case Node(s, "var_new", _, _) => false
@@ -576,7 +576,7 @@ class CompactTraverser extends Traverser {
   }
 }
 
-abstract class Transformer extends Traverser {
+abstract class Transformer extends Traverser with GraphTraversal {
   val name: String = "Transformer"
 
   var g: GraphBuilder = null

--- a/src/main/scala/lms/transformation/distributed_tensor/dim_name/TensorDimName.scala
+++ b/src/main/scala/lms/transformation/distributed_tensor/dim_name/TensorDimName.scala
@@ -13,7 +13,7 @@ import lms.transformation.util.DataStructure
 import Backend._
 
 
-class DimNameAnalysis extends Traverser {
+class DimNameAnalysis extends Traverser with GraphTraversal {
   import FixedSizeDistributedTensorTypeLess._
   import DataStructure._
 

--- a/src/main/scala/lms/transformation/mpi_nccl_transformation/distributedTensor2MPINCCL.scala
+++ b/src/main/scala/lms/transformation/mpi_nccl_transformation/distributedTensor2MPINCCL.scala
@@ -25,7 +25,7 @@ abstract class DistributeTensor2MPI_NCCL extends DistributeTensor2MPI_NCCLBase
     with DistributeTensor2MPI_NCCLMiscs
     with DistributedTensor2MPI_NCCLComm
 
-class DistributeTensor2MPI_NCCLAnalysis extends Traverser {
+class DistributeTensor2MPI_NCCLAnalysis extends Traverser with GraphTraversal {
     var hasCublas = false
     var hasCudnn = false
     var modulecount = 0


### PR DESCRIPTION
- LMS graph scheduling  
	- `lookupInner`: a mapping from `Sym` to `Node` with metadata, wrapped as `RepNode`  
		- priority value  
		- ~~`scheHere`~~`reachableHot`: required in the outer scope, at least once  
			- will be scheduled there only if available  
			- verb: `reach` vs `reachInner`  
		- ~~`reachHard`~~`reachableHard`: required by a hard dependency path, at least once  
			- unnecessary, will prune further reachability if unavailable  
			- we only care about the soft deps of a node actually scheduled in the outer scope  
			- verb: `reach` vs `reachSoft`  
	- `ScheduleQueue`  
		- maintain a descending priority queue  
		- no repeated enqueue for performance -- metadata update is in-place  
		- `lookup` has the same scope as `inner`, also serving as scheduling boundary  
		- optimization: share the same `lookup` for blocks sharing the same `inner`  
	- testing  
		- pipeline passed  
		- `echo` whole program: ~170s => ~35s  
		- `echo` application only: ~15s => ~5s  
		- `libc_kl_posix` library only: 8947s => ~71s  

To use, mixin `GraphTraversal` in your choice of transformer or codegen.