### PR TITLE
Add provenance tracking for array cells

### DIFF
--- a/src/main/scala/lms/collection/ArrayOps.scala
+++ b/src/main/scala/lms/collection/ArrayOps.scala
@@ -52,7 +52,6 @@ object ArrayTypeLess {
 }
 
 trait ArrayOps extends PrimitiveOps {
-
   def NewArray[T:Manifest](x: Rep[Int]): Rep[Array[T]] = {
     Wrap[Array[T]](Adapter.g.reflectMutable("NewArray", Unwrap(x)))
   }
@@ -65,11 +64,11 @@ trait ArrayOps extends PrimitiveOps {
 
   class ArrayOps[A:Manifest](x: Rep[Array[A]]) {
     def apply(i: Rep[Int]): Rep[A] = x match {
-      case Wrap(_) => Wrap[A](Adapter.g.reflectRead("array_get", Unwrap(x), Unwrap(i))(Unwrap(x)))
+      case Wrap(_, provenance) => Wrap[A](Adapter.g.reflectRead("array_get", Unwrap(x), Unwrap(i))(Unwrap(x)), Unwrap(x)::provenance)
       case EffectView(x, base) => Wrap[A](Adapter.g.reflectRead("array_get", Unwrap(x), Unwrap(i))(Unwrap(base)))
     }
     def update(i: Rep[Int], y: Rep[A]): Unit = x match {
-      case Wrap(_) => Adapter.g.reflectWrite("array_set", Unwrap(x), Unwrap(i), Unwrap(y))(Unwrap(x))
+      case Wrap(_, provenance) => Adapter.g.reflectWrite("array_set", Unwrap(x), Unwrap(i), Unwrap(y))((Unwrap(x)::provenance):_*)
       case EffectView(x, base) => Adapter.g.reflectWrite("array_set", Unwrap(x), Unwrap(i), Unwrap(y))(Unwrap(base))
     }
     def length: Rep[Int] = Wrap[Int](Adapter.g.reflect("array_length", Unwrap(x)))
@@ -96,11 +95,11 @@ trait ArrayOps extends PrimitiveOps {
   }
   implicit class LongArrayOps[A:Manifest](x: Rep[LongArray[A]]) {
     def apply(i: Rep[Long]): Rep[A] = x match {
-      case Wrap(_) => Wrap[A](Adapter.g.reflectRead("array_get", Unwrap(x), Unwrap(i))(Unwrap(x)))
+      case Wrap(_, provenance) => Wrap[A](Adapter.g.reflectRead("array_get", Unwrap(x), Unwrap(i))(Unwrap(x)), Unwrap(x)::provenance)
       case EffectView(x, base) => Wrap[A](Adapter.g.reflectRead("array_get", Unwrap(x), Unwrap(i))(Unwrap(base)))
     }
     def update(i: Rep[Long], y: Rep[A]): Unit = x match {
-      case Wrap(_) => Adapter.g.reflectWrite("array_set", Unwrap(x), Unwrap(i), Unwrap(y))(Unwrap(x))
+      case Wrap(_, provenance) => Adapter.g.reflectWrite("array_set", Unwrap(x), Unwrap(i), Unwrap(y))((Unwrap(x)::provenance):_*)
       case EffectView(x, base) => Adapter.g.reflectWrite("array_set", Unwrap(x), Unwrap(i), Unwrap(y))(Unwrap(base))
     }
     def length: Rep[Long] = Wrap[Long](Adapter.g.reflect("array_length", Unwrap(x)))

--- a/src/main/scala/lms/collection/ArrayOps.scala
+++ b/src/main/scala/lms/collection/ArrayOps.scala
@@ -65,14 +65,15 @@ trait ArrayOps extends PrimitiveOps {
   class ArrayOps[A:Manifest](x: Rep[Array[A]]) {
     def apply(i: Rep[Int]): Rep[A] = x match {
       case Wrap(_, provenance) => Wrap[A](Adapter.g.reflectRead("array_get", Unwrap(x), Unwrap(i))(Unwrap(x)), Unwrap(x)::provenance)
-      case EffectView(x, base) => Wrap[A](Adapter.g.reflectRead("array_get", Unwrap(x), Unwrap(i))(Unwrap(base)))
     }
     def update(i: Rep[Int], y: Rep[A]): Unit = x match {
       case Wrap(_, provenance) => Adapter.g.reflectWrite("array_set", Unwrap(x), Unwrap(i), Unwrap(y))((Unwrap(x)::provenance):_*)
-      case EffectView(x, base) => Adapter.g.reflectWrite("array_set", Unwrap(x), Unwrap(i), Unwrap(y))(Unwrap(base))
     }
     def length: Rep[Int] = Wrap[Int](Adapter.g.reflect("array_length", Unwrap(x)))
-    def slice(s: Rep[Int], e: Rep[Int]): Rep[Array[A]] = EffectView[Array[A]](Wrap[Array[A]](Adapter.g.reflect("array_slice", Unwrap(x), Unwrap(s), Unwrap(e))), x) // (Unwrap(x), Adapter.STORE)())
+    def slice(s: Rep[Int], e: Rep[Int]): Rep[Array[A]] = x match {
+      case Wrap(_, provenance) =>
+        Wrap[Array[A]](Adapter.g.reflect("array_slice", Unwrap(x), Unwrap(s), Unwrap(e)), Unwrap(x)::provenance) // (Unwrap(x), Adapter.STORE)())
+    }
     def free: Unit = Adapter.g.reflectFree("array_free", Unwrap(x))(Unwrap(x))
     def copyToArray(arr: Rep[Array[A]], start: Rep[Int], len: Rep[Int]) = Adapter.g.reflectEffect("array_copyTo", Unwrap(x), Unwrap(arr), Unwrap(start), Unwrap(len))(Unwrap(x))(Unwrap(arr))
     def copyToLongArray(arr: Rep[LongArray[A]], start: Rep[Long], len: Rep[Int]) = Adapter.g.reflectEffect("array_copyTo", Unwrap(x), Unwrap(arr), Unwrap(start), Unwrap(len))(Unwrap(x))(Unwrap(arr))
@@ -96,14 +97,14 @@ trait ArrayOps extends PrimitiveOps {
   implicit class LongArrayOps[A:Manifest](x: Rep[LongArray[A]]) {
     def apply(i: Rep[Long]): Rep[A] = x match {
       case Wrap(_, provenance) => Wrap[A](Adapter.g.reflectRead("array_get", Unwrap(x), Unwrap(i))(Unwrap(x)), Unwrap(x)::provenance)
-      case EffectView(x, base) => Wrap[A](Adapter.g.reflectRead("array_get", Unwrap(x), Unwrap(i))(Unwrap(base)))
     }
     def update(i: Rep[Long], y: Rep[A]): Unit = x match {
       case Wrap(_, provenance) => Adapter.g.reflectWrite("array_set", Unwrap(x), Unwrap(i), Unwrap(y))((Unwrap(x)::provenance):_*)
-      case EffectView(x, base) => Adapter.g.reflectWrite("array_set", Unwrap(x), Unwrap(i), Unwrap(y))(Unwrap(base))
     }
     def length: Rep[Long] = Wrap[Long](Adapter.g.reflect("array_length", Unwrap(x)))
-    def slice(s: Rep[Long], e: Rep[Long] = unit(-1L)): Rep[LongArray[A]] = EffectView[LongArray[A]](Wrap[LongArray[A]](Adapter.g.reflect("array_slice", Unwrap(x), Unwrap(s), Unwrap(e))), x) // FIXME: borrowing effect?
+    def slice(s: Rep[Long], e: Rep[Long] = unit(-1L)): Rep[LongArray[A]] = x match {
+      case Wrap(_, provenance) => Wrap[LongArray[A]](Adapter.g.reflect("array_slice", Unwrap(x), Unwrap(s), Unwrap(e)), Unwrap(x)::provenance)
+    }
     def resize(s: Rep[Long]): Rep[LongArray[A]] = Wrap[LongArray[A]](Adapter.g.reflectRealloc("array_resize", Unwrap(x), Unwrap(s))(Unwrap(x)))
     def free: Unit = Adapter.g.reflectFree("array_free", Unwrap(x))(Unwrap(x))
   }

--- a/src/main/scala/lms/collection/StructOps.scala
+++ b/src/main/scala/lms/collection/StructOps.scala
@@ -30,7 +30,8 @@ trait StructOps extends Base with ArrayOps {
   object Pointer {
     def apply[T <: Struct:RefinedManifest](v: Rep[T]): Pointer[T] = Pointer(LongArray[T](v))
     def apply[T <: Struct:RefinedManifest](arr: Rep[LongArray[T]], idx: Rep[Long] = 0L) = arr match {
-      case Wrap(_) => new Pointer(arr.slice(idx), arr)
+      // TODO(cwong): How to handle provenance?
+      case Wrap(_, _) => new Pointer(arr.slice(idx), arr)
       case EffectView(_, base) => new Pointer(arr.slice(idx), base)
     }
     def local[T <: Struct:RefinedManifest] = {

--- a/src/main/scala/lms/collection/StructOps.scala
+++ b/src/main/scala/lms/collection/StructOps.scala
@@ -32,7 +32,6 @@ trait StructOps extends Base with ArrayOps {
     def apply[T <: Struct:RefinedManifest](arr: Rep[LongArray[T]], idx: Rep[Long] = 0L) = arr match {
       // TODO(cwong): How to handle provenance?
       case Wrap(_, _) => new Pointer(arr.slice(idx), arr)
-      case EffectView(_, base) => new Pointer(arr.slice(idx), base)
     }
     def local[T <: Struct:RefinedManifest] = {
       val struct = Wrap[T](Adapter.g.reflectMutable("local_struct"))

--- a/src/main/scala/lms/core/stub.scala
+++ b/src/main/scala/lms/core/stub.scala
@@ -199,6 +199,8 @@ trait Base extends EmbeddedControls with OverloadHack with lms.util.ClosureCompa
 
   case class Const[T](x: T) extends Exp[T]
   case class Sym[T](x: Int) extends Exp[T]
+
+  // TODO(cwong): This should track provenance as well
   case class EffectView[A:Manifest](x: Rep[A], base: Rep[A]) extends Exp[A]
 
   case class Wrap[+A:Manifest](x: lms.core.Backend.Exp, provenance: List[lms.core.Backend.Exp] = List()) extends Exp[A] {

--- a/src/main/scala/lms/core/stub.scala
+++ b/src/main/scala/lms/core/stub.scala
@@ -201,17 +201,17 @@ trait Base extends EmbeddedControls with OverloadHack with lms.util.ClosureCompa
   case class Sym[T](x: Int) extends Exp[T]
   case class EffectView[A:Manifest](x: Rep[A], base: Rep[A]) extends Exp[A]
 
-  case class Wrap[+A:Manifest](x: lms.core.Backend.Exp) extends Exp[A] {
+  case class Wrap[+A:Manifest](x: lms.core.Backend.Exp, provenance: List[lms.core.Backend.Exp] = List()) extends Exp[A] {
     Adapter.typeMap.getOrElseUpdate(x, manifest[A])
   }
-  def Wrap[A:Manifest](x: lms.core.Backend.Exp): Exp[A] = {
+  def Wrap[A:Manifest](x: lms.core.Backend.Exp, provenance: List[lms.core.Backend.Exp] = List()): Exp[A] = {
     if (manifest[A] == manifest[Unit]) Const(()).asInstanceOf[Exp[A]]
-    else new Wrap[A](x)
+    else new Wrap[A](x, provenance)
   }
   def Unwrap(x: Exp[Any]) = x match {
-    case Wrap(x) => x
+    case Wrap(x, _) => x
     case Const(x) => Backend.Const(x)
-    case EffectView(Wrap(x), _) => x // TODO: fix!
+    case EffectView(Wrap(x, _), _) => x // TODO: fix!
   }
 
   case class WrapV[A:Manifest](x: lms.core.Backend.Exp) extends Var[A] {
@@ -410,8 +410,8 @@ trait Base extends EmbeddedControls with OverloadHack with lms.util.ClosureCompa
 
   // IfThenElse
   def __ifThenElse[T:Manifest](c: Rep[Boolean], a: => Rep[T], b: => Rep[T])(implicit pos: SourceContext): Rep[T] = c match {
-    case Wrap(Backend.Const(true))  => a
-    case Wrap(Backend.Const(false)) => b
+    case Wrap(Backend.Const(true), _)  => a
+    case Wrap(Backend.Const(false), _) => b
     case _ =>
       Wrap[T](Adapter.IF(Adapter.BOOL(Unwrap(c)))
                      (Adapter.INT(Unwrap(a)))
@@ -1072,7 +1072,7 @@ trait PrimitiveOps extends Base with OverloadHack {
   implicit def intToChar(x: Int) = x.toChar
 
   def cast_helper[X,Y](x: Rep[X])(implicit c: X => Y, mX: Manifest[X], mY: Manifest[Y], pos: SourceContext) : Rep[Y] = x match {
-    case Wrap(Backend.Const(x: X)) => Wrap[Y](Backend.Const(c(x)))
+    case Wrap(Backend.Const(x: X), _) => Wrap[Y](Backend.Const(c(x)))
     case _ => Wrap[Y](Adapter.g.reflect("cast", Unwrap(x), Backend.Const(manifest[Y])))
   }
 

--- a/src/main/scala/lms/core/stub.scala
+++ b/src/main/scala/lms/core/stub.scala
@@ -186,7 +186,7 @@ object BaseTypeLess {
  * 3. handing of recursive function definition via Adapter.funTable
  * 4. control flows such as conditional, loop (with @virtualize macro)
  * 5. other basics: misc, print, unchecked, timer, et al.
- * 6. other extentions are at later part of this file or can be extended by DSL writer
+ * 6. other extensions are at later part of this file or can be extended by DSL writer
  *    including UtilOps, RangeOps, Equal, OrderingOps, PrimitiveOps, LiftPrimitiveOps, et al.
  */
 trait Base extends EmbeddedControls with OverloadHack with lms.util.ClosureCompare {

--- a/src/main/scala/lms/core/stub.scala
+++ b/src/main/scala/lms/core/stub.scala
@@ -200,9 +200,6 @@ trait Base extends EmbeddedControls with OverloadHack with lms.util.ClosureCompa
   case class Const[T](x: T) extends Exp[T]
   case class Sym[T](x: Int) extends Exp[T]
 
-  // TODO(cwong): This should track provenance as well
-  case class EffectView[A:Manifest](x: Rep[A], base: Rep[A]) extends Exp[A]
-
   case class Wrap[+A:Manifest](x: lms.core.Backend.Exp, provenance: List[lms.core.Backend.Exp] = List()) extends Exp[A] {
     Adapter.typeMap.getOrElseUpdate(x, manifest[A])
   }
@@ -213,7 +210,6 @@ trait Base extends EmbeddedControls with OverloadHack with lms.util.ClosureCompa
   def Unwrap(x: Exp[Any]) = x match {
     case Wrap(x, _) => x
     case Const(x) => Backend.Const(x)
-    case EffectView(Wrap(x, _), _) => x // TODO: fix!
   }
 
   case class WrapV[A:Manifest](x: lms.core.Backend.Exp) extends Var[A] {

--- a/src/out/backend/nested_array.check.c
+++ b/src/out/backend/nested_array.check.c
@@ -1,0 +1,23 @@
+/*****************************************
+Emitting C Generated Code
+*******************************************/
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+/**************** Snippet ****************/
+int** Snippet(int** x0) {
+  x0[0][0] = 3;
+  return x0;
+}
+/*****************************************
+End of C Generated Code
+*******************************************/
+int main(int argc, char *argv[]) {
+  if (argc != 2) {
+    printf("usage: %s <arg>\n", argv[0]);
+    return 0;
+  }
+  Snippet();
+  return 0;
+}

--- a/src/test/scala/lms/collection/test_nested_array.scala
+++ b/src/test/scala/lms/collection/test_nested_array.scala
@@ -1,0 +1,28 @@
+package lms
+package core
+
+import core._
+import core.stub._
+import macros.SourceContext
+import macros.RefinedManifest
+
+import lms.collection.mutable._
+
+class NestedArrayTest extends TutorialFunSuite {
+  val under = "backend/"
+
+  test("nested_array_is_ok") {
+    val driver = new DslDriverC[Array[Array[Int]], Array[Array[Int]]] with StructOps { q =>
+      override val codegen = new DslGenC with CCodeGenStruct {
+        val IR: q.type = q
+      }
+
+      @virtualize
+      def snippet(arg: Rep[Array[Array[Int]]]) = {
+        arg(0)(0) = 3
+        arg
+      }
+    }
+    check("nested_array", driver.code, "c")
+  }
+}


### PR DESCRIPTION
This PR improves tracking of alias information for nested mutable arrays.

Currently, writes to nested mutable structures are extremely likely to be incorrectly marked as dead code. This is because the current means of effect tracking only tracks one "parent" at a time. That is, in the following snippet:

```
// a : Rep[Array[Array[Int]]]
val a0 = a(0)
a0(0) = 2
return a
```

the write to `a0(0)` is correctly associated with the cell `a0`, but that write is not propagated to the parent array `a`, leaving LMS to conclude that the writes are unobservable and can be optimized out.

This PR seeks to fix this by adding a new parameter to the `Wrap` class, `provenance`, holding the set of all cells from which the wrapped node originated. For example, the value `a0` has provenance `[a]`. Now, when writing to `a0(0)`, we can properly mark the write as also affecting `a`.

Presumably, in the future, this change can be subsumed by a more general mechanism like reachability types, but for now this is a simple mechanism that fixes a bug right now.