### PR TITLE
update scala/sbt version to support jdk17

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -18,5 +18,7 @@ jobs:
       with:
         distribution: 'adopt'
         java-version: '17'
+    - name: Setup sbt launcher
+      uses: sbt/setup-sbt@v1
     - name: Run tests
       run: sbt test

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -12,10 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
       with:
-        java-version: 1.8
+        distribution: 'adopt'
+        java-version: '17'
     - name: Run tests
       run: sbt test

--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ organization := "org.scala-lang.virtualized"
 
 version := "0.0.1-SNAPSHOT"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.12.15"
 
-val paradiseVersion = "2.1.0"
+val paradiseVersion = "2.1.1"
 
 //crossScalaVersions := Seq("2.12.1")
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
 #Project properties
-sbt.version=1.2.8
+sbt.version=1.10.0

--- a/src/main/scala/lms/util/ScalaCompile.scala
+++ b/src/main/scala/lms/util/ScalaCompile.scala
@@ -15,7 +15,7 @@ trait ScalaCompile {
 
   var compiler: Global = _
   var reporter: ConsoleReporter = _
-  //var output: ByteArrayOutputStream = _ 
+  //var output: ByteArrayOutputStream = _
 
   def setupCompiler() = {
     /*
@@ -44,7 +44,7 @@ trait ScalaCompile {
   }
 
   var compileCount = 0
-  
+
   var dumpGeneratedCode = false
 
   def nextClassName = "staged$" + compileCount
@@ -55,9 +55,9 @@ trait ScalaCompile {
   def compile[A,B](className: String, source: String, staticData: List[(Class[_],Any)]): A=>B = {
     if (this.compiler eq null)
       setupCompiler()
-    
+
     compileCount += 1
-    
+
     // val source = new StringWriter()
     // val writer = new PrintWriter(source)
     // val staticData = codegen.emitSource(f, className, writer)
@@ -76,7 +76,7 @@ trait ScalaCompile {
     //compiler.genJVM.outputDir = fileSystem
 
     run.compileSources(List(new util.BatchSourceFile("<stdin>", source.toString)))
-    reporter.printSummary()
+    reporter.finish()
 
     if (!reporter.hasErrors)
       println("compilation: ok")
@@ -91,7 +91,7 @@ trait ScalaCompile {
 
     val cls: Class[_] = loader.loadClass(className)
     val cons = cls.getConstructor(staticData.map(_._1):_*)
-    
+
     val obj: A=>B = cons.newInstance(staticData.map(_._2.asInstanceOf[AnyRef]):_*).asInstanceOf[A=>B]
     obj
   }


### PR DESCRIPTION
Many other packages (eg z3 on Java) have compatibility issues on JDK 8/11, this PR upgrades the dependency to Scala 2.12.15, which is the minimum version to run JDK 17 (https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html).